### PR TITLE
docs: Astro Starlight documentation site 🧠

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,40 @@
+name: Deploy Docs to GitHub Pages
+on:
+  push:
+    branches: [main]
+    paths: ["website/**"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - run: cd website && npm install --no-audit --no-fund
+      - run: cd website && npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: website/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/deploy-pages@v4
+        id: deployment
+

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.astro/
+.DS_Store

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -1,0 +1,49 @@
+import { defineConfig } from "astro/config";
+import mdx from "@astrojs/mdx";
+import starlight from "@astrojs/starlight";
+
+const repo = process.env.GITHUB_REPOSITORY?.split("/")?.[1] ?? "gigabrain";
+const owner = process.env.GITHUB_REPOSITORY_OWNER ?? "macro88";
+const isGitHubActions = process.env.GITHUB_ACTIONS === "true";
+
+export default defineConfig({
+  site: isGitHubActions ? `https://${owner}.github.io` : undefined,
+  base: isGitHubActions ? `/${repo}` : "/",
+  trailingSlash: "always",
+  integrations: [
+    starlight({
+      title: "GigaBrain",
+      description:
+        "The personal knowledge brain. SQLite + FTS5 + vector embeddings in one file.",
+      customCss: ["./src/styles/custom.css"],
+      social: [
+        { icon: "github", label: "GitHub", href: "https://github.com/macro88/gigabrain" },
+      ],
+      sidebar: [
+        {
+          label: "Overview",
+          items: [
+            "index",
+            "guides/why-gigabrain",
+            "guides/how-it-works",
+          ],
+        },
+        {
+          label: "Getting Started",
+          items: ["guides/getting-started", "guides/quick-start"],
+        },
+        { label: "CLI Reference", items: ["reference/cli"] },
+        { label: "MCP Server", items: ["guides/mcp-server"] },
+        {
+          label: "Architecture",
+          items: ["reference/architecture", "reference/spec"],
+        },
+        {
+          label: "Contributing",
+          items: ["contributing/contributing", "contributing/roadmap"],
+        },
+      ],
+    }),
+    mdx(),
+  ],
+});

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,0 +1,6692 @@
+{
+  "name": "gigabrain-docs",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "gigabrain-docs",
+      "version": "0.1.0",
+      "dependencies": {
+        "@astrojs/mdx": "^5.0.3",
+        "@astrojs/starlight": "^0.38.3",
+        "astro": "^6.1.6",
+        "sharp": "0.33.5"
+      }
+    },
+    "node_modules/@astrojs/compiler": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-3.0.1.tgz",
+      "integrity": "sha512-z97oYbdebO5aoWzuJ/8q5hLK232+17KcLZ7cJ8BCWk6+qNzVxn/gftC0KzMBUTD8WAaBkPpNSQK6PXLnNrZ0CA==",
+      "license": "MIT"
+    },
+    "node_modules/@astrojs/internal-helpers": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.8.0.tgz",
+      "integrity": "sha512-J56GrhEiV+4dmrGLPNOl2pZjpHXAndWVyiVDYGDuw6MWKpBSEMLdFxHzeM/6sqaknw9M+HFfHZAcvi3OfT3D/w==",
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^4.0.3"
+      }
+    },
+    "node_modules/@astrojs/markdown-remark": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.1.0.tgz",
+      "integrity": "sha512-P+HnCsu2js3BoTc8kFmu+E9gOcFeMdPris75g+Zl4sY8+bBRbSQV6xzcBDbZ27eE7yBGEGQoqjpChx+KJYIPYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.8.0",
+        "@astrojs/prism": "4.0.1",
+        "github-slugger": "^2.0.0",
+        "hast-util-from-html": "^2.0.3",
+        "hast-util-to-text": "^4.0.2",
+        "js-yaml": "^4.1.1",
+        "mdast-util-definitions": "^6.0.0",
+        "rehype-raw": "^7.0.0",
+        "rehype-stringify": "^10.0.1",
+        "remark-gfm": "^4.0.1",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.1.2",
+        "remark-smartypants": "^3.0.2",
+        "retext-smartypants": "^6.2.0",
+        "shiki": "^4.0.0",
+        "smol-toml": "^1.6.0",
+        "unified": "^11.0.5",
+        "unist-util-remove-position": "^5.0.0",
+        "unist-util-visit": "^5.1.0",
+        "unist-util-visit-parents": "^6.0.2",
+        "vfile": "^6.0.3"
+      }
+    },
+    "node_modules/@astrojs/mdx": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-5.0.3.tgz",
+      "integrity": "sha512-zv/OlM5sZZvyjHqJjR3FjJvoCgbxdqj3t4jO/gSEUNcck3BjdtMgNQw8UgPfAGe4yySdG4vjZ3OC5wUxhu7ckg==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/markdown-remark": "7.1.0",
+        "@mdx-js/mdx": "^3.1.1",
+        "acorn": "^8.16.0",
+        "es-module-lexer": "^2.0.0",
+        "estree-util-visit": "^2.0.0",
+        "hast-util-to-html": "^9.0.5",
+        "piccolore": "^0.1.3",
+        "rehype-raw": "^7.0.0",
+        "remark-gfm": "^4.0.1",
+        "remark-smartypants": "^3.0.2",
+        "source-map": "^0.7.6",
+        "unist-util-visit": "^5.1.0",
+        "vfile": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "peerDependencies": {
+        "astro": "^6.0.0"
+      }
+    },
+    "node_modules/@astrojs/prism": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-4.0.1.tgz",
+      "integrity": "sha512-nksZQVjlferuWzhPsBpQ1JE5XuKAf1id1/9Hj4a9KG4+ofrlzxUUwX4YGQF/SuDiuiGKEnzopGOt38F3AnVWsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prismjs": "^1.30.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/sitemap": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.2.tgz",
+      "integrity": "sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA==",
+      "license": "MIT",
+      "dependencies": {
+        "sitemap": "^9.0.0",
+        "stream-replace-string": "^2.0.0",
+        "zod": "^4.3.6"
+      }
+    },
+    "node_modules/@astrojs/starlight": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/starlight/-/starlight-0.38.3.tgz",
+      "integrity": "sha512-kDlJPlUDdQFWYmyFM2yUPo66yws7v067AEK+/rQjjoVyqehL3DabuOJuy6UJFFTFyGbHxYcBms/ITEgdW7tphw==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/markdown-remark": "^7.0.0",
+        "@astrojs/mdx": "^5.0.0",
+        "@astrojs/sitemap": "^3.7.1",
+        "@pagefind/default-ui": "^1.3.0",
+        "@types/hast": "^3.0.4",
+        "@types/js-yaml": "^4.0.9",
+        "@types/mdast": "^4.0.4",
+        "astro-expressive-code": "^0.41.6",
+        "bcp-47": "^2.1.0",
+        "hast-util-from-html": "^2.0.1",
+        "hast-util-select": "^6.0.2",
+        "hast-util-to-string": "^3.0.0",
+        "hastscript": "^9.0.0",
+        "i18next": "^23.11.5",
+        "js-yaml": "^4.1.0",
+        "klona": "^2.0.6",
+        "magic-string": "^0.30.17",
+        "mdast-util-directive": "^3.0.0",
+        "mdast-util-to-markdown": "^2.1.0",
+        "mdast-util-to-string": "^4.0.0",
+        "pagefind": "^1.3.0",
+        "rehype": "^13.0.1",
+        "rehype-format": "^5.0.0",
+        "remark-directive": "^3.0.0",
+        "ultrahtml": "^1.6.0",
+        "unified": "^11.0.5",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.2"
+      },
+      "peerDependencies": {
+        "astro": "^6.0.0"
+      }
+    },
+    "node_modules/@astrojs/telemetry": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.0.tgz",
+      "integrity": "sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ci-info": "^4.2.0",
+        "debug": "^4.4.0",
+        "dlv": "^1.1.3",
+        "dset": "^3.1.4",
+        "is-docker": "^3.0.0",
+        "is-wsl": "^3.1.0",
+        "which-pm-runs": "^1.1.0"
+      },
+      "engines": {
+        "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@capsizecss/unpack": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-4.0.0.tgz",
+      "integrity": "sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA==",
+      "license": "MIT",
+      "dependencies": {
+        "fontkitten": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@clack/core": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.2.0.tgz",
+      "integrity": "sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-wrap-ansi": "^0.1.3",
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.2.0.tgz",
+      "integrity": "sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "1.2.0",
+        "fast-string-width": "^1.1.0",
+        "fast-wrap-ansi": "^0.1.3",
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@ctrl/tinycolor": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-4.2.0.tgz",
+      "integrity": "sha512-kzyuwOAQnXJNLS9PSyrk0CWk35nWJW/zl/6KvnTBMFK65gm7U1/Z5BqjxeapjZCIhQcM/DsrEmcbRwDyXyXK4A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@expressive-code/core": {
+      "version": "0.41.7",
+      "resolved": "https://registry.npmjs.org/@expressive-code/core/-/core-0.41.7.tgz",
+      "integrity": "sha512-ck92uZYZ9Wba2zxkiZLsZGi9N54pMSAVdrI9uW3Oo9AtLglD5RmrdTwbYPCT2S/jC36JGB2i+pnQtBm/Ib2+dg==",
+      "license": "MIT",
+      "dependencies": {
+        "@ctrl/tinycolor": "^4.0.4",
+        "hast-util-select": "^6.0.2",
+        "hast-util-to-html": "^9.0.1",
+        "hast-util-to-text": "^4.0.1",
+        "hastscript": "^9.0.0",
+        "postcss": "^8.4.38",
+        "postcss-nested": "^6.0.1",
+        "unist-util-visit": "^5.0.0",
+        "unist-util-visit-parents": "^6.0.1"
+      }
+    },
+    "node_modules/@expressive-code/plugin-frames": {
+      "version": "0.41.7",
+      "resolved": "https://registry.npmjs.org/@expressive-code/plugin-frames/-/plugin-frames-0.41.7.tgz",
+      "integrity": "sha512-diKtxjQw/979cTglRFaMCY/sR6hWF0kSMg8jsKLXaZBSfGS0I/Hoe7Qds3vVEgeoW+GHHQzMcwvgx/MOIXhrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@expressive-code/core": "^0.41.7"
+      }
+    },
+    "node_modules/@expressive-code/plugin-shiki": {
+      "version": "0.41.7",
+      "resolved": "https://registry.npmjs.org/@expressive-code/plugin-shiki/-/plugin-shiki-0.41.7.tgz",
+      "integrity": "sha512-DL605bLrUOgqTdZ0Ot5MlTaWzppRkzzqzeGEu7ODnHF39IkEBbFdsC7pbl3LbUQ1DFtnfx6rD54k/cdofbW6KQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@expressive-code/core": "^0.41.7",
+        "shiki": "^3.2.2"
+      }
+    },
+    "node_modules/@expressive-code/plugin-shiki/node_modules/@shikijs/core": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.23.0.tgz",
+      "integrity": "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      }
+    },
+    "node_modules/@expressive-code/plugin-shiki/node_modules/@shikijs/engine-javascript": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.23.0.tgz",
+      "integrity": "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.4"
+      }
+    },
+    "node_modules/@expressive-code/plugin-shiki/node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+      "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@expressive-code/plugin-shiki/node_modules/@shikijs/langs": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+      "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@expressive-code/plugin-shiki/node_modules/@shikijs/themes": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+      "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@expressive-code/plugin-shiki/node_modules/@shikijs/types": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@expressive-code/plugin-shiki/node_modules/shiki": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.23.0.tgz",
+      "integrity": "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "3.23.0",
+        "@shikijs/engine-javascript": "3.23.0",
+        "@shikijs/engine-oniguruma": "3.23.0",
+        "@shikijs/langs": "3.23.0",
+        "@shikijs/themes": "3.23.0",
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@expressive-code/plugin-text-markers": {
+      "version": "0.41.7",
+      "resolved": "https://registry.npmjs.org/@expressive-code/plugin-text-markers/-/plugin-text-markers-0.41.7.tgz",
+      "integrity": "sha512-Ewpwuc5t6eFdZmWlFyeuy3e1PTQC0jFvw2Q+2bpcWXbOZhPLsT7+h8lsSIJxb5mS7wZko7cKyQ2RLYDyK6Fpmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@expressive-code/core": "^0.41.7"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@mdx-js/mdx": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-3.1.1.tgz",
+      "integrity": "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdx": "^2.0.0",
+        "acorn": "^8.0.0",
+        "collapse-white-space": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "estree-util-scope": "^1.0.0",
+        "estree-walker": "^3.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "markdown-extensions": "^2.0.0",
+        "recma-build-jsx": "^1.0.0",
+        "recma-jsx": "^1.0.0",
+        "recma-stringify": "^1.0.0",
+        "rehype-recma": "^1.0.0",
+        "remark-mdx": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "source-map": "^0.7.0",
+        "unified": "^11.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@oslojs/encoding": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
+      "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
+      "license": "MIT"
+    },
+    "node_modules/@pagefind/darwin-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.5.2.tgz",
+      "integrity": "sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/darwin-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.5.2.tgz",
+      "integrity": "sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/default-ui": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/default-ui/-/default-ui-1.5.2.tgz",
+      "integrity": "sha512-pm1LMnQg8N2B3n2TnjKlhaFihpz6zTiA4HiGQ6/slKO/+8K9CAU5kcjdSSPgpuk1PMuuN4hxLipUIifnrkl3Sg==",
+      "license": "MIT"
+    },
+    "node_modules/@pagefind/freebsd-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.5.2.tgz",
+      "integrity": "sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@pagefind/linux-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.5.2.tgz",
+      "integrity": "sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/linux-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.5.2.tgz",
+      "integrity": "sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/windows-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-arm64/-/windows-arm64-1.5.2.tgz",
+      "integrity": "sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@pagefind/windows-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.5.2.tgz",
+      "integrity": "sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@shikijs/core": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.0.2.tgz",
+      "integrity": "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/primitive": "4.0.2",
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.0.2.tgz",
+      "integrity": "sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.0.2.tgz",
+      "integrity": "sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.0.2.tgz",
+      "integrity": "sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.0.2.tgz",
+      "integrity": "sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.0.2.tgz",
+      "integrity": "sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.2.tgz",
+      "integrity": "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdx": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.13.tgz",
+      "integrity": "sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/nlcst": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/nlcst/-/nlcst-2.0.3.tgz",
+      "integrity": "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "license": "ISC"
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/array-iterate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-2.0.1.tgz",
+      "integrity": "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/astring": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+      "license": "MIT",
+      "bin": {
+        "astring": "bin/astring"
+      }
+    },
+    "node_modules/astro": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.1.6.tgz",
+      "integrity": "sha512-pRsz+kYriwCV/AUcY/I9OVKtVHuYFs2DtCszAxprXded/kTE53nMwxfnK0Nf6FPfaX9vcUiLnigcSIhuFoKntA==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/compiler": "^3.0.1",
+        "@astrojs/internal-helpers": "0.8.0",
+        "@astrojs/markdown-remark": "7.1.0",
+        "@astrojs/telemetry": "3.3.0",
+        "@capsizecss/unpack": "^4.0.0",
+        "@clack/prompts": "^1.1.0",
+        "@oslojs/encoding": "^1.1.0",
+        "@rollup/pluginutils": "^5.3.0",
+        "aria-query": "^5.3.2",
+        "axobject-query": "^4.1.0",
+        "ci-info": "^4.4.0",
+        "clsx": "^2.1.1",
+        "common-ancestor-path": "^2.0.0",
+        "cookie": "^1.1.1",
+        "devalue": "^5.6.3",
+        "diff": "^8.0.3",
+        "dset": "^3.1.4",
+        "es-module-lexer": "^2.0.0",
+        "esbuild": "^0.27.3",
+        "flattie": "^1.1.1",
+        "fontace": "~0.4.1",
+        "github-slugger": "^2.0.0",
+        "html-escaper": "3.0.3",
+        "http-cache-semantics": "^4.2.0",
+        "js-yaml": "^4.1.1",
+        "magic-string": "^0.30.21",
+        "magicast": "^0.5.2",
+        "mrmime": "^2.0.1",
+        "neotraverse": "^0.6.18",
+        "obug": "^2.1.1",
+        "p-limit": "^7.3.0",
+        "p-queue": "^9.1.0",
+        "package-manager-detector": "^1.6.0",
+        "piccolore": "^0.1.3",
+        "picomatch": "^4.0.3",
+        "rehype": "^13.0.2",
+        "semver": "^7.7.4",
+        "shiki": "^4.0.2",
+        "smol-toml": "^1.6.0",
+        "svgo": "^4.0.1",
+        "tinyclip": "^0.1.12",
+        "tinyexec": "^1.0.4",
+        "tinyglobby": "^0.2.15",
+        "tsconfck": "^3.1.6",
+        "ultrahtml": "^1.6.0",
+        "unifont": "~0.7.4",
+        "unist-util-visit": "^5.1.0",
+        "unstorage": "^1.17.4",
+        "vfile": "^6.0.3",
+        "vite": "^7.3.1",
+        "vitefu": "^1.1.2",
+        "xxhash-wasm": "^1.1.0",
+        "yargs-parser": "^22.0.0",
+        "zod": "^4.3.6"
+      },
+      "bin": {
+        "astro": "bin/astro.mjs"
+      },
+      "engines": {
+        "node": ">=22.12.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/astrodotbuild"
+      },
+      "optionalDependencies": {
+        "sharp": "^0.34.0"
+      }
+    },
+    "node_modules/astro-expressive-code": {
+      "version": "0.41.7",
+      "resolved": "https://registry.npmjs.org/astro-expressive-code/-/astro-expressive-code-0.41.7.tgz",
+      "integrity": "sha512-hUpogGc6DdAd+I7pPXsctyYPRBJDK7Q7d06s4cyP0Vz3OcbziP3FNzN0jZci1BpCvLn9675DvS7B9ctKKX64JQ==",
+      "license": "MIT",
+      "dependencies": {
+        "rehype-expressive-code": "^0.41.7"
+      },
+      "peerDependencies": {
+        "astro": "^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta"
+      }
+    },
+    "node_modules/astro/node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/astro/node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/astro/node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/astro/node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/astro/node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/astro/node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/astro/node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/astro/node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/astro/node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/astro/node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/astro/node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/astro/node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/astro/node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/astro/node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/astro/node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/astro/node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/astro/node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/astro/node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/astro/node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/astro/node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/bcp-47": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bcp-47/-/bcp-47-2.1.0.tgz",
+      "integrity": "sha512-9IIS3UPrvIa1Ej+lVDdDwO7zLehjqsaByECw0bu2RRGP73jALm6FYbzI5gWbgHLvNdkvfXB5YrSbocZdOS0c0w==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/bcp-47-match": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/bcp-47-match/-/bcp-47-match-2.0.3.tgz",
+      "integrity": "sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/collapse-white-space": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-2.1.0.tgz",
+      "integrity": "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/common-ancestor-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-2.0.0.tgz",
+      "integrity": "sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cookie-es": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.3.tgz",
+      "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
+      "license": "MIT"
+    },
+    "node_modules/crossws": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
+      "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-selector-parser": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-3.3.0.tgz",
+      "integrity": "sha512-Y2asgMGFqJKF4fq4xHDSlFYIkeVfRsm69lQC1q9kbEsH5XtnINTMrweLkjYMeaUgiXBy/uvKeO/a1JHTNnmB2g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/csso": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "~2.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/css-tree": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.28",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/mdn-data": {
+      "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/destr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/devalue": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.7.1.tgz",
+      "integrity": "sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==",
+      "license": "MIT"
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/direction": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/direction/-/direction-2.0.1.tgz",
+      "integrity": "sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA==",
+      "license": "MIT",
+      "bin": {
+        "direction": "cli.js"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "license": "MIT"
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dset": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
+      "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "license": "MIT"
+    },
+    "node_modules/esast-util-from-estree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/esast-util-from-estree/-/esast-util-from-estree-2.0.0.tgz",
+      "integrity": "sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-visit": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/esast-util-from-js": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esast-util-from-js/-/esast-util-from-js-2.0.1.tgz",
+      "integrity": "sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "acorn": "^8.0.0",
+        "esast-util-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-util-attach-comments": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-attach-comments/-/estree-util-attach-comments-3.0.0.tgz",
+      "integrity": "sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-build-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/estree-util-build-jsx/-/estree-util-build-jsx-3.0.1.tgz",
+      "integrity": "sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "estree-walker": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-scope": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-scope/-/estree-util-scope-1.0.0.tgz",
+      "integrity": "sha512-2CAASclonf+JFWBNJPndcOpA8EMJwa0Q8LUFJEKqXLW6+qBvbFZuF5gItbQOs/umBUkjviCSDCbBwU2cXbmrhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-to-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-to-js/-/estree-util-to-js-2.0.0.tgz",
+      "integrity": "sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "astring": "^1.8.0",
+        "source-map": "^0.7.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-visit": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-visit/-/estree-util-visit-2.0.0.tgz",
+      "integrity": "sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/expressive-code": {
+      "version": "0.41.7",
+      "resolved": "https://registry.npmjs.org/expressive-code/-/expressive-code-0.41.7.tgz",
+      "integrity": "sha512-2wZjC8OQ3TaVEMcBtYY4Va3lo6J+Ai9jf3d4dbhURMJcU4Pbqe6EcHe424MIZI0VHUA1bR6xdpoHYi3yxokWqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@expressive-code/core": "^0.41.7",
+        "@expressive-code/plugin-frames": "^0.41.7",
+        "@expressive-code/plugin-shiki": "^0.41.7",
+        "@expressive-code/plugin-text-markers": "^0.41.7"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-string-truncated-width": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-1.2.1.tgz",
+      "integrity": "sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow==",
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-1.1.0.tgz",
+      "integrity": "sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^1.2.0"
+      }
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.1.6.tgz",
+      "integrity": "sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^1.1.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/flattie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/flattie/-/flattie-1.1.1.tgz",
+      "integrity": "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fontace": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/fontace/-/fontace-0.4.1.tgz",
+      "integrity": "sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw==",
+      "license": "MIT",
+      "dependencies": {
+        "fontkitten": "^1.0.2"
+      }
+    },
+    "node_modules/fontkitten": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fontkitten/-/fontkitten-1.0.3.tgz",
+      "integrity": "sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==",
+      "license": "MIT",
+      "dependencies": {
+        "tiny-inflate": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/github-slugger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+      "license": "ISC"
+    },
+    "node_modules/h3": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.11.tgz",
+      "integrity": "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie-es": "^1.2.3",
+        "crossws": "^0.3.5",
+        "defu": "^6.1.6",
+        "destr": "^2.0.5",
+        "iron-webcrypto": "^1.2.1",
+        "node-mock-http": "^1.0.4",
+        "radix3": "^1.1.2",
+        "ufo": "^1.6.3",
+        "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/hast-util-embedded": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-embedded/-/hast-util-embedded-3.0.0.tgz",
+      "integrity": "sha512-naH8sld4Pe2ep03qqULEtvYr7EjrLK2QHY8KJR6RJkTUjPGObe1vnx585uzem2hGra+s1q08DZZpfgDVYRbaXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-is-element": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-format": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-format/-/hast-util-format-1.1.0.tgz",
+      "integrity": "sha512-yY1UDz6bC9rDvCWHpx12aIBGRG7krurX0p0Fm6pT547LwDIZZiNr8a+IHDogorAdreULSEzP82Nlv5SZkHZcjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-embedded": "^3.0.0",
+        "hast-util-minify-whitespace": "^1.0.0",
+        "hast-util-phrasing": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-whitespace-sensitive-tag-names": "^3.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.1.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "parse5": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-has-property": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-3.0.0.tgz",
+      "integrity": "sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-body-ok-link": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-is-body-ok-link/-/hast-util-is-body-ok-link-3.0.1.tgz",
+      "integrity": "sha512-0qpnzOBLztXHbHQenVB8uNuxTnm/QBFUOmdOSsEn7GnBtyY07+ENTWVFBAnXd/zEgd9/SUG3lRY7hSIBWRgGpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-minify-whitespace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-minify-whitespace/-/hast-util-minify-whitespace-1.0.1.tgz",
+      "integrity": "sha512-L96fPOVpnclQE0xzdWb/D12VT5FabA7SnZOUMtL1DbXmYiHJMXZvFkIZfiMmTCNJHUeO2K9UYNXoVyfz+QHuOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-embedded": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-phrasing": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-phrasing/-/hast-util-phrasing-3.0.1.tgz",
+      "integrity": "sha512-6h60VfI3uBQUxHqTyMymMZnEbNl1XmEGtOxxKYL7stY2o601COo62AWAYBQR9lZbYXYSBoxag8UpPRXK+9fqSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-embedded": "^3.0.0",
+        "hast-util-has-property": "^3.0.0",
+        "hast-util-is-body-ok-link": "^3.0.0",
+        "hast-util-is-element": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-raw": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+      "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "hast-util-to-parse5": "^8.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "parse5": "^7.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-select": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/hast-util-select/-/hast-util-select-6.0.4.tgz",
+      "integrity": "sha512-RqGS1ZgI0MwxLaKLDxjprynNzINEkRHY2i8ln4DDjgv9ZhcYVIHN9rlpiYsqtFwrgpYU361SyWDQcGNIBVu3lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "bcp-47-match": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "css-selector-parser": "^3.0.0",
+        "devlop": "^1.0.0",
+        "direction": "^2.0.0",
+        "hast-util-has-property": "^3.0.0",
+        "hast-util-to-string": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "nth-check": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-estree": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-3.1.3.tgz",
+      "integrity": "sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-attach-comments": "^3.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+      "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-string": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
+      "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+      "license": "MIT"
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/html-whitespace-sensitive-tag-names": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-whitespace-sensitive-tag-names/-/html-whitespace-sensitive-tag-names-3.0.1.tgz",
+      "integrity": "sha512-q+310vW8zmymYHALr1da4HyXUQ0zgiIwIicEfotYPWGN0OJVEN/58IJ3A4GBYcEq3LGAZqKb+ugvP0GNB9CEAA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/i18next": {
+      "version": "23.16.8",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.16.8.tgz",
+      "integrity": "sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
+    "node_modules/iron-webcrypto": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
+      "integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/brc-dd"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT"
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/klona": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
+      "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/markdown-extensions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-extensions/-/markdown-extensions-2.0.0.tgz",
+      "integrity": "sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-definitions": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-6.0.0.tgz",
+      "integrity": "sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-directive": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-directive/-/mdast-util-directive-3.1.0.tgz",
+      "integrity": "sha512-I3fNFt+DHmpWCYAT7quoM6lHf9wuqtI+oCOfvILnoicNIqjh5E3dEJWiXuYME2gNe8vl1iMQwyUHa7bgFmak6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx/-/mdast-util-mdx-3.0.0.tgz",
+      "integrity": "sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-directive": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-3.0.2.tgz",
+      "integrity": "sha512-wjcXHgk+PPdmvR58Le9d7zQYWy+vKEU9Se44p2CrCDPiLr2FMyiT4Fyb5UFKFC66wGB3kPlgD7q3TnoqPS7SZA==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "parse-entities": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdx-expression": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-3.0.1.tgz",
+      "integrity": "sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-mdx-expression": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-mdx-jsx": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-3.0.2.tgz",
+      "integrity": "sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "micromark-factory-mdx-expression": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdx-md": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-md/-/micromark-extension-mdx-md-2.0.0.tgz",
+      "integrity": "sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdxjs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs/-/micromark-extension-mdxjs-3.0.0.tgz",
+      "integrity": "sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.0.0",
+        "acorn-jsx": "^5.0.0",
+        "micromark-extension-mdx-expression": "^3.0.0",
+        "micromark-extension-mdx-jsx": "^3.0.0",
+        "micromark-extension-mdx-md": "^2.0.0",
+        "micromark-extension-mdxjs-esm": "^3.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdxjs-esm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs-esm/-/micromark-extension-mdxjs-esm-3.0.0.tgz",
+      "integrity": "sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-mdx-expression": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-2.0.3.tgz",
+      "integrity": "sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-events-to-acorn": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-2.0.3.tgz",
+      "integrity": "sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-visit": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      }
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/neotraverse": {
+      "version": "0.6.18",
+      "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
+      "integrity": "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/nlcst-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-4.0.0.tgz",
+      "integrity": "sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/nlcst": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/node-fetch-native": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+      "license": "MIT"
+    },
+    "node_modules/node-mock-http": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.4.tgz",
+      "integrity": "sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==",
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/ofetch": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
+      "integrity": "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==",
+      "license": "MIT",
+      "dependencies": {
+        "destr": "^2.0.5",
+        "node-fetch-native": "^1.6.7",
+        "ufo": "^1.6.1"
+      }
+    },
+    "node_modules/ohash": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.1.tgz",
+      "integrity": "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.5.tgz",
+      "integrity": "sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.1",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.0.tgz",
+      "integrity": "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.1.2.tgz",
+      "integrity": "sha512-ktsDOALzTYTWWF1PbkNVg2rOt+HaOaMWJMUnt7T3qf5tvZ1L8dBW3tObzprBcXNMKkwj+yFSLqHso0x+UFcJXw==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-manager-detector": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+      "license": "MIT"
+    },
+    "node_modules/pagefind": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.5.2.tgz",
+      "integrity": "sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==",
+      "license": "MIT",
+      "bin": {
+        "pagefind": "lib/runner/bin.cjs"
+      },
+      "optionalDependencies": {
+        "@pagefind/darwin-arm64": "1.5.2",
+        "@pagefind/darwin-x64": "1.5.2",
+        "@pagefind/freebsd-x64": "1.5.2",
+        "@pagefind/linux-arm64": "1.5.2",
+        "@pagefind/linux-x64": "1.5.2",
+        "@pagefind/windows-arm64": "1.5.2",
+        "@pagefind/windows-x64": "1.5.2"
+      }
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/parse-latin": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
+      "integrity": "sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/nlcst": "^2.0.0",
+        "@types/unist": "^3.0.0",
+        "nlcst-to-string": "^4.0.0",
+        "unist-util-modify-children": "^4.0.0",
+        "unist-util-visit-children": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/piccolore": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
+      "integrity": "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==",
+      "license": "ISC"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/radix3": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
+      "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
+      "license": "MIT"
+    },
+    "node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/recma-build-jsx": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/recma-build-jsx/-/recma-build-jsx-1.0.0.tgz",
+      "integrity": "sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-util-build-jsx": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/recma-jsx": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/recma-jsx/-/recma-jsx-1.0.1.tgz",
+      "integrity": "sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn-jsx": "^5.0.0",
+        "estree-util-to-js": "^2.0.0",
+        "recma-parse": "^1.0.0",
+        "recma-stringify": "^1.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/recma-parse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/recma-parse/-/recma-parse-1.0.0.tgz",
+      "integrity": "sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "esast-util-from-js": "^2.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/recma-stringify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/recma-stringify/-/recma-stringify-1.0.0.tgz",
+      "integrity": "sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-util-to-js": "^2.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "license": "MIT"
+    },
+    "node_modules/rehype": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/rehype/-/rehype-13.0.2.tgz",
+      "integrity": "sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "rehype-parse": "^9.0.0",
+        "rehype-stringify": "^10.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-expressive-code": {
+      "version": "0.41.7",
+      "resolved": "https://registry.npmjs.org/rehype-expressive-code/-/rehype-expressive-code-0.41.7.tgz",
+      "integrity": "sha512-25f8ZMSF1d9CMscX7Cft0TSQIqdwjce2gDOvQ+d/w0FovsMwrSt3ODP4P3Z7wO1jsIJ4eYyaDRnIR/27bd/EMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "expressive-code": "^0.41.7"
+      }
+    },
+    "node_modules/rehype-format": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-format/-/rehype-format-5.0.1.tgz",
+      "integrity": "sha512-zvmVru9uB0josBVpr946OR8ui7nJEdzZobwLOOqHb/OOD88W0Vk2SqLwoVOj0fM6IPCCO6TaV9CvQvJMWwukFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-format": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-parse": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
+      "integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-from-html": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-raw": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+      "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-raw": "^9.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-recma": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-recma/-/rehype-recma-1.0.0.tgz",
+      "integrity": "sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "hast-util-to-estree": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-stringify": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
+      "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-to-html": "^9.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-directive": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/remark-directive/-/remark-directive-3.0.1.tgz",
+      "integrity": "sha512-gwglrEQEZcZYgVyG1tQuA+h58EZfq5CSULw7J90AFuCTyib1thgHPoqQ+h9iFvU6R+vnZ5oNFQR5QKgGpk741A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-directive": "^3.0.0",
+        "micromark-extension-directive": "^3.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-mdx": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-3.1.1.tgz",
+      "integrity": "sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-mdx": "^3.0.0",
+        "micromark-extension-mdxjs": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-smartypants": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/remark-smartypants/-/remark-smartypants-3.0.2.tgz",
+      "integrity": "sha512-ILTWeOriIluwEvPjv67v7Blgrcx+LZOkAUVtKI3putuhlZm84FnqDORNXPPm+HY3NdZOMhyDwZ1E+eZB/Df5dA==",
+      "license": "MIT",
+      "dependencies": {
+        "retext": "^9.0.0",
+        "retext-smartypants": "^6.0.0",
+        "unified": "^11.0.4",
+        "unist-util-visit": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/retext": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/retext/-/retext-9.0.0.tgz",
+      "integrity": "sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/nlcst": "^2.0.0",
+        "retext-latin": "^4.0.0",
+        "retext-stringify": "^4.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/retext-latin": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/retext-latin/-/retext-latin-4.0.0.tgz",
+      "integrity": "sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/nlcst": "^2.0.0",
+        "parse-latin": "^7.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/retext-smartypants": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/retext-smartypants/-/retext-smartypants-6.2.0.tgz",
+      "integrity": "sha512-kk0jOU7+zGv//kfjXEBjdIryL1Acl4i9XNkHxtM7Tm5lFiCog576fjNC9hjoR7LTKQ0DsPWy09JummSsH1uqfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/nlcst": "^2.0.0",
+        "nlcst-to-string": "^4.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/retext-stringify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/retext-stringify/-/retext-stringify-4.0.0.tgz",
+      "integrity": "sha512-rtfN/0o8kL1e+78+uxPTqu1Klt0yPzKuQ2BfWwwfgIUSayyzxpM1PJzkKt4V8803uB9qSy32MvI7Xep9khTpiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/nlcst": "^2.0.0",
+        "nlcst-to-string": "^4.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
+      }
+    },
+    "node_modules/shiki": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.0.2.tgz",
+      "integrity": "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.0.2",
+        "@shikijs/engine-javascript": "4.0.2",
+        "@shikijs/engine-oniguruma": "4.0.2",
+        "@shikijs/langs": "4.0.2",
+        "@shikijs/themes": "4.0.2",
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
+    },
+    "node_modules/sitemap": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-9.0.1.tgz",
+      "integrity": "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^24.9.2",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.4.1"
+      },
+      "bin": {
+        "sitemap": "dist/esm/cli.js"
+      },
+      "engines": {
+        "node": ">=20.19.5",
+        "npm": ">=10.8.2"
+      }
+    },
+    "node_modules/smol-toml": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/stream-replace-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
+      "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
+      "license": "MIT"
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
+      }
+    },
+    "node_modules/svgo": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
+      "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^11.1.0",
+        "css-select": "^5.1.0",
+        "css-tree": "^3.0.1",
+        "css-what": "^6.1.0",
+        "csso": "^5.0.5",
+        "picocolors": "^1.1.1",
+        "sax": "^1.5.0"
+      },
+      "bin": {
+        "svgo": "bin/svgo.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/svgo"
+      }
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
+    "node_modules/tinyclip": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/tinyclip/-/tinyclip-0.1.12.tgz",
+      "integrity": "sha512-Ae3OVUqifDw0wBriIBS7yVaW44Dp6eSHQcyq4Igc7eN2TJH/2YsicswaW+J/OuMvhpDPOKEgpAZCjkb4hpoyeA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^16.14.0 || >= 17.3.0"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/tsconfck": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+      "license": "MIT",
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/ufo": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "license": "MIT"
+    },
+    "node_modules/ultrahtml": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ultrahtml/-/ultrahtml-1.6.0.tgz",
+      "integrity": "sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw==",
+      "license": "MIT"
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT"
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unifont": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.7.4.tgz",
+      "integrity": "sha512-oHeis4/xl42HUIeHuNZRGEvxj5AaIKR+bHPNegRq5LV1gdc3jundpONbjglKpihmJf+dswygdMJn3eftGIMemg==",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.1.0",
+        "ofetch": "^1.5.1",
+        "ohash": "^2.0.11"
+      }
+    },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-modify-children": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-4.0.0.tgz",
+      "integrity": "sha512-+tdN5fGNddvsQdIzUF3Xx82CU9sMM+fA0dLgR9vOmT0oPT2jH+P1nd5lSqfCfXAw+93NhcXNY2qqvTUtE4cQkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "array-iterate": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position-from-estree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position-from-estree/-/unist-util-position-from-estree-2.0.0.tgz",
+      "integrity": "sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+      "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-children": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-children/-/unist-util-visit-children-3.0.0.tgz",
+      "integrity": "sha512-RgmdTfSBOg04sdPcpTSD1jzoNBjt9a80/ZCzp5cI9n1qPzLZWF9YdvWGN2zmTumP1HWhXKdUWexjy/Wy/lJ7tA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unstorage": {
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.5.tgz",
+      "integrity": "sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==",
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "^3.1.3",
+        "chokidar": "^5.0.0",
+        "destr": "^2.0.5",
+        "h3": "^1.15.10",
+        "lru-cache": "^11.2.7",
+        "node-fetch-native": "^1.6.7",
+        "ofetch": "^1.5.1",
+        "ufo": "^1.6.3"
+      },
+      "peerDependencies": {
+        "@azure/app-configuration": "^1.8.0",
+        "@azure/cosmos": "^4.2.0",
+        "@azure/data-tables": "^13.3.0",
+        "@azure/identity": "^4.6.0",
+        "@azure/keyvault-secrets": "^4.9.0",
+        "@azure/storage-blob": "^12.26.0",
+        "@capacitor/preferences": "^6 || ^7 || ^8",
+        "@deno/kv": ">=0.9.0",
+        "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0",
+        "@planetscale/database": "^1.19.0",
+        "@upstash/redis": "^1.34.3",
+        "@vercel/blob": ">=0.27.1",
+        "@vercel/functions": "^2.2.12 || ^3.0.0",
+        "@vercel/kv": "^1 || ^2 || ^3",
+        "aws4fetch": "^1.0.20",
+        "db0": ">=0.2.1",
+        "idb-keyval": "^6.2.1",
+        "ioredis": "^5.4.2",
+        "uploadthing": "^7.4.4"
+      },
+      "peerDependenciesMeta": {
+        "@azure/app-configuration": {
+          "optional": true
+        },
+        "@azure/cosmos": {
+          "optional": true
+        },
+        "@azure/data-tables": {
+          "optional": true
+        },
+        "@azure/identity": {
+          "optional": true
+        },
+        "@azure/keyvault-secrets": {
+          "optional": true
+        },
+        "@azure/storage-blob": {
+          "optional": true
+        },
+        "@capacitor/preferences": {
+          "optional": true
+        },
+        "@deno/kv": {
+          "optional": true
+        },
+        "@netlify/blobs": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@upstash/redis": {
+          "optional": true
+        },
+        "@vercel/blob": {
+          "optional": true
+        },
+        "@vercel/functions": {
+          "optional": true
+        },
+        "@vercel/kv": {
+          "optional": true
+        },
+        "aws4fetch": {
+          "optional": true
+        },
+        "db0": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "ioredis": {
+          "optional": true
+        },
+        "uploadthing": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitefu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+      "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
+      "license": "MIT",
+      "workspaces": [
+        "tests/deps/*",
+        "tests/projects/*",
+        "tests/projects/workspace/packages/*"
+      ],
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/which-pm-runs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
+      "integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/xxhash-wasm": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
+      "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
+      "license": "MIT"
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/website/package.json
+++ b/website/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "gigabrain-docs",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "astro dev",
+    "start": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview",
+    "astro": "astro"
+  },
+  "dependencies": {
+    "@astrojs/mdx": "^4.0.8",
+    "@astrojs/starlight": "^0.38.3",
+    "astro": "^6.1.6",
+    "sharp": "0.33.5"
+  }
+}

--- a/website/public/favicon.svg
+++ b/website/public/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <defs>
+    <linearGradient id="g" x1="10" y1="10" x2="54" y2="54" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#7c3aed"/>
+      <stop offset="1" stop-color="#06b6d4"/>
+    </linearGradient>
+  </defs>
+  <path d="M32 6c10 0 18 7.5 18 17v18c0 9.5-8 17-18 17S14 50.5 14 41V23C14 13.5 22 6 32 6Z" stroke="url(#g)" stroke-width="3"/>
+  <path d="M22 24c5-4 15-4 20 0M22 34c5-4 15-4 20 0M22 44c5-4 15-4 20 0" stroke="url(#g)" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/website/src/content.config.ts
+++ b/website/src/content.config.ts
@@ -1,0 +1,7 @@
+import { defineCollection } from "astro:content";
+import { docsLoader } from "@astrojs/starlight/loaders";
+import { docsSchema } from "@astrojs/starlight/schema";
+
+export const collections = {
+  docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
+};

--- a/website/src/content/docs/contributing/contributing.md
+++ b/website/src/content/docs/contributing/contributing.md
@@ -1,0 +1,276 @@
+---
+title: Contributing
+description: How we propose changes, work in phases, and keep the spec as source of truth.
+---
+
+Welcome. This guide covers everything a new contributor needs to navigate the codebase, understand how work is organised, and make a meaningful first contribution.
+
+---
+
+## What GigaBrain is
+
+GigaBrain is a local-first personal knowledge brain: a single Rust binary (~90MB including embedded model weights) that wraps SQLite + FTS5 + local vector embeddings. It stores structured knowledge pages, searches them with hybrid keyword + semantic queries, and exposes an MCP server for any AI agent client.
+
+Read [Getting Started](/guides/getting-started/) first if you haven't. Read the [Spec](/reference/spec/) for the full technical specification.
+
+---
+
+## Repository layout
+
+```
+gigabrain/
+├── src/
+│   ├── main.rs               # CLI entrypoint (clap dispatch)
+│   ├── schema.sql            # Full v4 DDL (embedded via include_str!)
+│   ├── core/                 # Library modules
+│   │   ├── db.rs             # SQLite connection, schema init, WAL, sqlite-vec
+│   │   ├── types.rs          # All structs
+│   │   ├── markdown.rs       # Frontmatter parse, compiled-truth/timeline split
+│   │   ├── fts.rs            # FTS5 search, BM25 scoring
+│   │   ├── inference.rs      # Candle init, BGE-small embeddings, vector search
+│   │   ├── search.rs         # Hybrid: SMS + FTS5 + vector + set-union merge
+│   │   ├── progressive.rs    # Token-budget-gated content expansion
+│   │   ├── palace.rs         # Wing/room derivation for palace filtering
+│   │   ├── novelty.rs        # Jaccard + cosine dedup
+│   │   ├── migrate.rs        # import_dir / export_dir / validate_roundtrip
+│   │   ├── chunking.rs       # Temporal sub-chunking
+│   │   └── graph.rs          # Graph neighbourhood traversal (Phase 2)
+│   ├── commands/             # One file per CLI command
+│   │   ├── init.rs, get.rs, put.rs, list.rs, stats.rs
+│   │   ├── search.rs, query.rs, embed.rs
+│   │   ├── import.rs, export.rs, ingest.rs
+│   │   ├── link.rs, graph.rs, timeline.rs
+│   │   ├── gaps.rs, check.rs
+│   │   ├── serve.rs, compact.rs, config.rs, version.rs
+│   │   └── tags.rs
+│   └── mcp/
+│       └── server.rs         # MCP stdio server (JSON-RPC 2.0 via rmcp)
+├── skills/                   # Fat markdown skill files
+│   ├── ingest/SKILL.md
+│   ├── query/SKILL.md
+│   ├── maintain/SKILL.md
+│   ├── briefing/SKILL.md
+│   ├── research/SKILL.md
+│   ├── enrich/SKILL.md
+│   ├── alerts/SKILL.md
+│   └── upgrade/SKILL.md
+├── tests/
+│   └── fixtures/             # Sample markdown pages for integration tests
+├── benchmarks/               # Benchmark harness and results
+├── docs/                     # User-facing documentation (you are here)
+│   ├── spec.md               # Full technical specification
+│   ├── getting-started.md    # New user / new contributor onboarding
+│   ├── roadmap.md            # Phased delivery plan and status
+│   └── contributing.md       # This file
+├── openspec/                 # Structured change proposals
+│   └── changes/              # One directory per proposal
+├── Cargo.toml
+├── AGENTS.md                 # Agent instructions (read by any AI spawned here)
+└── CLAUDE.md                 # Extended context for Claude-family agents
+```
+
+---
+
+## Build and test
+
+```bash
+# Check that everything compiles (fast; no linking)
+cargo check
+
+# Debug build
+cargo build
+
+# Release build (~90MB with embedded model weights)
+cargo build --release
+
+# Run tests
+cargo test
+
+# Cross-compile for fully static Linux binary
+cargo install cross
+cross build --release --target x86_64-unknown-linux-musl
+```
+
+CI runs `cargo check` and `cargo test` on every pull request. Both must pass before a PR can merge.
+
+---
+
+## Tech stack
+
+| Component | Crate | Notes |
+| --------- | ----- | ----- |
+| CLI | `clap` (derive) | One `mod` per command in `src/commands/` |
+| Database | `rusqlite` (bundled) | SQLite compiled into the binary |
+| Full-text search | FTS5 | Built into SQLite |
+| Vector search | `sqlite-vec` | Statically linked extension |
+| Embeddings | `candle` + BGE-small-en-v1.5 | Pure Rust, no ONNX runtime |
+| MCP server | `rmcp` | stdio transport, JSON-RPC 2.0 |
+| Serialisation | `serde` + `serde_json` + `serde_yaml` | |
+| Markdown | `pulldown-cmark` | |
+| Error handling | `anyhow` + `thiserror` | |
+| Async | `tokio` | Required by `rmcp` |
+
+---
+
+## How changes are proposed
+
+GigaBrain uses **OpenSpec** for structured change proposals. The rule is simple:
+
+> Every meaningful code, docs, or architecture change requires an OpenSpec proposal in `openspec/changes/` _before_ implementation begins.
+
+**To propose a change:**
+
+1. Create a new directory under `openspec/changes/` named for your change (e.g., `openspec/changes/my-feature/`).
+2. Write a `proposal.md` following the local instructions in `openspec/` — include `id`, `title`, `status: proposed`, scope, non-goals, and success criteria.
+3. Share it with the team for review before writing any implementation code.
+
+This keeps design intent visible and reviewable before any work starts.
+
+---
+
+## Workflow overview
+
+1. **Spec first.** Check `docs/spec.md` for the canonical design. If your change is not in the spec, propose it via OpenSpec.
+2. **OpenSpec proposal.** Write a proposal and get it reviewed.
+3. **Branch.** Branch off `main` — name it `phase-N/short-description` or `fix/short-description`.
+4. **Implement.** Follow the module structure above. One command per file in `src/commands/`. Core logic in `src/core/`.
+5. **Test.** Unit tests live next to the code they test (Rust convention). Integration tests go in `tests/`.
+6. **CI.** Push — CI runs `cargo check` and `cargo test` automatically.
+7. **PR.** Open a pull request. Link the OpenSpec proposal. Get reviewer sign-off per the phase gates.
+
+---
+
+## Sprint 0 operational setup
+
+Before Phase 1 implementation can begin, three one-time repository setup tasks must be completed. These steps require write access to the GitHub repository and a working `gh` CLI authenticated to the repo.
+
+**Recommended order:** create labels and issues first, then push the Sprint 0 branch, then open the PR linking the new issue and the relevant OpenSpec proposals.
+
+### 1. Create GitHub labels and issues
+
+Use the helper script from the repo root:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\create-labels-and-issues.ps1
+```
+
+If you need to run the steps manually instead, create labels first:
+
+```powershell
+gh label create "phase-1"  --color "0075ca" --description "Phase 1: Core Storage, CLI, Search, MCP"
+gh label create "phase-2"  --color "e4e669" --description "Phase 2: Intelligence Layer"
+gh label create "phase-3"  --color "d93f0b" --description "Phase 3: Polish, Benchmarks, Release"
+gh label create "squad:fry"       --color "bfd4f2" --description "Assigned to Fry (main engineer)"
+gh label create "squad:bender"    --color "bfd4f2" --description "Assigned to Bender (tester)"
+gh label create "squad:professor" --color "bfd4f2" --description "Assigned to Professor (code reviewer)"
+gh label create "squad:nibbler"   --color "bfd4f2" --description "Assigned to Nibbler (adversarial reviewer)"
+gh label create "squad:kif"       --color "bfd4f2" --description "Assigned to Kif (benchmarks)"
+gh label create "squad:zapp"      --color "bfd4f2" --description "Assigned to Zapp (DevRel/release)"
+```
+
+Then create the issues:
+
+```powershell
+gh issue create --title "[Sprint 0] Repository scaffold + CI/CD" --body "Tracks the Sprint 0 scaffold work. OpenSpec: openspec/changes/sprint-0-repo-scaffold/proposal.md" --label "squad:fry"
+gh issue create --title "[Phase 1] Core storage, CLI, search, MCP" --body "Fry implements Phase 1. OpenSpec: openspec/changes/p1-core-storage-cli/proposal.md. Gate: round-trip tests pass; MCP connects; static binary verified." --label "squad:fry,phase-1"
+gh issue create --title "[Phase 1] Round-trip test + ship gate sign-off" --body "Bender validates the Phase 1 ship gate before Phase 2 can begin." --label "squad:bender,phase-1"
+gh issue create --title "[Phase 1] Code review: db.rs, search.rs, inference.rs" --body "Professor reviews the three critical Phase 1 modules." --label "squad:professor,phase-1"
+gh issue create --title "[Phase 1] Adversarial review: MCP server" --body "Nibbler adversarially reviews the MCP server for OCC enforcement and injection risks." --label "squad:nibbler,phase-1"
+gh issue create --title "[Phase 2] Intelligence layer" --body "Fry implements Phase 2. OpenSpec: openspec/changes/p2-intelligence-layer/proposal.md. Blocked until Phase 1 gate passes." --label "squad:fry,phase-2"
+gh issue create --title "[Phase 3] Benchmarks + release gates" --body "Kif establishes BEIR baseline and all release gates. OpenSpec: openspec/changes/p3-polish-benchmarks/proposal.md" --label "squad:kif,phase-3"
+gh issue create --title "[Phase 3] v0.1.0 release" --body "Zapp coordinates the v0.1.0 GitHub Release after Phase 3 gates pass." --label "squad:zapp,phase-3"
+```
+
+> **Note:** Labels must exist before issue creation — `gh issue create --label` silently ignores labels that do not exist yet.
+
+### 2. Create the Sprint 0 branch and push the scaffold
+
+Use the helper script from the repo root:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\push-sprint0-branch.ps1
+```
+
+If you need to run the steps manually instead:
+
+```powershell
+Set-Location C:\path\to\gigabrain
+
+git checkout -b sprint-0/scaffold
+git add .
+git commit -m "Sprint 0: repository scaffold, CI/CD, OpenSpec proposals
+
+- Cargo.toml with full dependency declarations
+- src/ module stubs (commands, core, mcp)
+- src/schema.sql — full v4 DDL
+- skills/ stubs for all 8 skills
+- tests/fixtures, benchmarks/README.md
+- CLAUDE.md, AGENTS.md
+- .github/workflows/ci.yml and release.yml
+- openspec/changes/ proposals for all 4 phases
+- .squad/ team configuration and decisions
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+
+git push origin sprint-0/scaffold
+```
+
+### 3. Open the scaffold PR
+
+Open a PR on GitHub targeting `main`. Use this PR body:
+
+```
+## Sprint 0: Repository Scaffold
+
+### What
+Full repository scaffold for GigaBrain v0.1.0 as specified in
+`openspec/changes/sprint-0-repo-scaffold/proposal.md`.
+
+### OpenSpec Reference
+- openspec/changes/sprint-0-repo-scaffold/proposal.md
+- openspec/changes/p1-core-storage-cli/proposal.md
+
+### Gate
+`cargo check` must pass before merge. Phase 1 implementation begins
+after this PR merges.
+```
+
+---
+
+## Phase reviewer gates
+
+Each phase has designated reviewers before it can ship:
+
+| Reviewer | Responsibilities |
+| -------- | ---------------- |
+| Professor | Code review on `db.rs`, `search.rs`, `inference.rs` |
+| Nibbler | Adversarial review on MCP server (OCC enforcement, injection safety) |
+| Bender | End-to-end round-trip validation sign-off |
+| Scruffy | Unit test coverage on markdown parser and search merge logic |
+
+---
+
+## Constraints to keep in mind
+
+- **Single writer.** No auth, no RBAC, no multi-tenant. Do not add locking abstractions that assume multi-writer access.
+- **Optimistic concurrency on MCP writes.** `brain_put` requires `expected_version`. Always re-fetch before writing.
+- **Ingest idempotency.** SHA-256 of source content is the idempotency key. Re-ingesting the same content must be a no-op.
+- **Static binary.** Every dependency must be statically linkable. No dynamic `.so` / `.dylib` dependencies at runtime.
+- **No internet at runtime.** Embeddings run locally via candle. Do not add network calls to the hot path.
+
+---
+
+## Skills are not code
+
+Skills live in `skills/*/SKILL.md` — plain markdown. They tell agents _how_ to use GigaBrain, not what it does. If you are changing workflow behaviour, update the relevant SKILL.md. If you are changing what the binary can do, update `src/` and `docs/spec.md`.
+
+To override a default skill locally, drop a `SKILL.md` in your working directory. The binary will prefer it over the embedded default.
+
+---
+
+## Getting help
+
+- Full technical spec: [Spec](/reference/spec/)
+- Phased delivery plan: [Roadmap](/contributing/roadmap/)
+- Agent instructions: [AGENTS.md](../AGENTS.md) and [CLAUDE.md](../CLAUDE.md)
+- Open an issue on GitHub for bugs or feature requests.

--- a/website/src/content/docs/contributing/roadmap.md
+++ b/website/src/content/docs/contributing/roadmap.md
@@ -1,0 +1,139 @@
+---
+title: Roadmap
+description: Phased delivery plan with explicit ship gates.
+---
+
+GigaBrain is built in phases. Each phase has a hard ship gate — no phase begins until the previous one passes.
+
+---
+
+## Sprint 0 — Repository Scaffold ✅
+
+**Status: Complete**
+
+Sprint 0 establishes the full repository structure before any core implementation begins. It produces no runnable binary, but everything that follows depends on what it puts in place.
+
+**Deliverables:**
+- `Cargo.toml` with all declared dependencies (Rust + rusqlite + sqlite-vec + candle + clap + rmcp)
+- Module stubs in `src/` — `src/core/`, `src/commands/`, `src/mcp/`
+- `src/schema.sql` — full v4 DDL (pages, FTS5, vectors, links, assertions, knowledge gaps)
+- `skills/*/SKILL.md` stubs for all 8 skill categories
+- `tests/fixtures/` — sample page fixtures
+- `benchmarks/README.md`
+- `CLAUDE.md` and `AGENTS.md` — context files for any agent spawned in this repo
+- `.github/workflows/ci.yml` — `cargo check` + `cargo test` on every PR
+- `.github/workflows/release.yml` — cross-compile matrix → GitHub Releases on tag push
+
+**Gate:** `cargo check` passes; CI triggers on PR; all spec directories exist.
+
+---
+
+## Phase 1 — Core Storage, CLI, Search, and MCP 🔨
+
+**Status: In progress**  
+**Owner:** Fry  
+**Depends on:** Sprint 0
+
+The smallest complete slice that proves GigaBrain's value proposition. When Phase 1 ships, a real user can import their markdown brain, search it semantically and by keyword, export without data loss, and connect any MCP-compatible agent via `gbrain serve`.
+
+**Workstream 1 — Foundation (Week 1):**
+- All core types (`src/core/types.rs`)
+- Database init, WAL, sqlite-vec load (`src/core/db.rs`)
+- Markdown frontmatter parsing, compiled-truth/timeline split (`src/core/markdown.rs`)
+- Palace wing/room derivation (`src/core/palace.rs`)
+- CLI commands: `init`, `get`, `put`, `list`, `stats`, `tags`, `link`
+
+**Workstream 2 — Search (Week 2):**
+- FTS5 search with BM25 scoring (`src/core/fts.rs`)
+- Candle embeddings + vector search (`src/core/inference.rs`)
+- Hybrid search: SMS exact-match short-circuit + set-union merge of FTS5 + vector (`src/core/search.rs`)
+- Progressive retrieval with token-budget gating (`src/core/progressive.rs`)
+- CLI commands: `search`, `embed`, `query`
+
+**Workstream 3 — Ingest and MCP (Week 3):**
+- Novelty checking — Jaccard + cosine dedup (`src/core/novelty.rs`)
+- `import` / `export` with normalized markdown round-trip (`src/core/migrate.rs`)
+- MCP stdio server with 5 core tools: `brain_get`, `brain_put`, `brain_query`, `brain_search`, `brain_list`
+- CLI command: `serve`
+
+**Workstream 4 — Polish (Week 4):**
+- `config`, `version`, `compact` commands
+- `--json` output on all commands
+- Full unit test suite
+- Embedded skills finalized
+
+**Ship gate (all must pass before Phase 2):**
+1. `cargo test` passes
+2. `gbrain import <corpus>` → `gbrain export` → semantic diff = 0
+3. `gbrain serve` connects to Claude Code with all 5 MCP tools responding correctly
+4. Static binary: `ldd` confirms no dynamic dependencies on Linux musl build
+5. BEIR nDCG@10 baseline established
+
+---
+
+## Phase 2 — Intelligence Layer ⏳
+
+**Status: Not started**  
+**Depends on:** Phase 1 ship gate
+
+**Planned scope:**
+- Temporal links: `brain_link`, `brain_link_close`, backlinks with `--temporal`
+- Graph neighbourhood traversal: `brain_graph`, `gbrain graph`
+- Assertions with provenance
+- Contradiction detection: `gbrain check`
+- Progressive retrieval with token budgets (full implementation)
+- Novelty checking tiers 2–4
+- Work-context page types: `decision`, `commitment`, `action_item`
+- Palace wing filtering (validated against benchmarks before committing to room-level)
+- Full MCP write surface with version checks (optimistic concurrency enforcement)
+- Optional person template enrichment sections for tier-1 contacts
+
+**Gate:** All Phase 1 gates remain green; Phase 2 feature tests pass; no regression on BEIR baseline.
+
+---
+
+## Phase 3 — Polish, Skills, and Benchmarks ⏳
+
+**Status: Not started**  
+**Depends on:** Phase 2 ship gate
+
+**Planned scope:**
+- Briefing skill with "what shifted" report
+- Alerts skill (interrupt-driven notifications vs. scheduled briefings)
+- Research skill (knowledge gap resolution)
+- Knowledge gap detection: `brain_gap`, `brain_gaps` MCP tools, `gbrain gaps` CLI
+- Upgrade skill (agent-guided binary and skill updates)
+- Enrichment skill (external API: Crustdata, Exa, etc.)
+- LongMemEval, LoCoMo, BEIR, Ragas benchmark suite
+- `gbrain skills doctor` 
+- `gbrain validate --all` integrity checker
+- `--json` output on all commands
+- `pipe` mode
+- Full CI/CD release pipeline with all gates
+
+**Gate:** All benchmark targets met; `v0.1.0` release artifacts built and verified static.
+
+---
+
+## Deliberate Deferrals
+
+These are known design choices that are _not_ oversights:
+
+| Deferral | Reasoning |
+| -------- | --------- |
+| First-class `chunks` table | `page_embeddings` columns are sufficient for v1. Promote if progressive retrieval lifecycle becomes painful. |
+| Room-level palace filtering | Deferred until benchmarks on a real corpus prove it helps. Wing-only in v1. |
+| LLM-assisted contradiction detection | The binary stays dumb. Cross-page reasoning lives in the maintain skill. |
+| WASM compilation | Viable in principle (Rust has strong WASM support). Not a v1 priority. |
+| Overnight consolidation cycle | Powerful agent workflow (Karpathy-style DREAMS pattern). Better as a post-v1 skill than a binary feature. |
+| Collaborative / multi-user | Single-writer by design. No auth, no RBAC, no CRDTs. |
+
+---
+
+## Version targets
+
+| Tag | What ships |
+| --- | ---------- |
+| `v0.1.0` | Phase 1 — core storage, CLI, search, MCP |
+| `v0.2.0` | Phase 2 — intelligence layer |
+| `v1.0.0` | Phase 3 — full skill suite + benchmarks + release pipeline |

--- a/website/src/content/docs/guides/getting-started.md
+++ b/website/src/content/docs/guides/getting-started.md
@@ -1,0 +1,186 @@
+---
+title: Getting Started
+description: Build GigaBrain and create your first brain.db.
+---
+
+> GigaBrain is a local-first personal knowledge brain: SQLite + FTS5 + local vector embeddings in one file. One static binary, zero runtime dependencies, no internet required.
+
+## What it does
+
+GigaBrain stores your knowledge as structured pages in a single `brain.db` file. Each page follows the **compiled-truth / timeline** model:
+
+- **Above the line — compiled truth.** Always current. Rewritten when new information arrives. What you know now.
+- **Below the line — timeline.** Append-only. Never rewritten. What happened and when.
+
+You search it with full-text keywords and semantic queries. Any MCP-compatible AI agent (Claude Code, etc.) can connect to it over stdio. Everything runs locally — no API keys, no cloud, no Docker.
+
+---
+
+## Status
+
+> **GigaBrain is not yet released.** Sprint 0 (repository scaffold + CI) is complete. Phase 1 (core storage, CLI, search, MCP) is in active development.
+>
+> See the [Roadmap](/contributing/roadmap/) for the full delivery plan.
+
+---
+
+## Build from source
+
+```bash
+git clone https://github.com/macro88/gigabrain
+cd gigabrain
+cargo build --release
+# Binary at: target/release/gbrain (~90MB with embedded model weights)
+```
+
+Requirements: Rust toolchain (stable). No other system dependencies — SQLite, sqlite-vec, and the embedding model are all bundled.
+
+### Cross-compile for static Linux binary
+
+```bash
+cargo install cross
+cross build --release --target x86_64-unknown-linux-musl      # Linux x86_64 (fully static)
+cross build --release --target aarch64-unknown-linux-musl     # Linux ARM64 (fully static)
+```
+
+---
+
+## Your first brain
+
+### 1. Initialize
+
+```bash
+gbrain init ~/brain.db
+```
+
+This creates a new `brain.db` file with the full v4 schema — pages, embeddings, links, assertions, and the knowledge-gaps table.
+
+### 2. Import an existing markdown directory
+
+```bash
+gbrain import /path/to/notes/ --db ~/brain.db
+```
+
+GigaBrain ingests each markdown file, parses frontmatter, splits compiled-truth from timeline, generates embeddings, and writes to the database. Ingest is idempotent — re-running the same file is safe.
+
+### 3. Search
+
+```bash
+# Full-text keyword search (FTS5)
+gbrain search "machine learning"
+
+# Semantic / hybrid query (FTS5 + vector with set-union merge)
+gbrain query "who has worked with Jensen Huang?"
+```
+
+### 4. Read and write pages
+
+```bash
+# Read a page
+gbrain get people/pedro-franceschi
+
+# Write or update a page
+cat updated.md | gbrain put people/pedro-franceschi
+```
+
+### 5. Work with the knowledge graph
+
+```bash
+# Create a typed, temporal link
+gbrain link people/pedro-franceschi companies/brex \
+  --relationship founded \
+  --valid-from 2017-01-01
+
+# Explore graph neighbourhood (2-hop)
+gbrain graph people/pedro-franceschi --depth 2
+
+# Close a link that is no longer current
+gbrain link people/pedro-franceschi companies/brex \
+  --relationship founded \
+  --valid-until 2022-12-31
+```
+
+### 6. Brain health
+
+```bash
+gbrain stats           # page counts, index sizes
+gbrain check --all     # contradiction detection
+gbrain gaps            # unresolved knowledge gaps
+```
+
+### 7. Compact for backup or transport
+
+```bash
+gbrain compact         # WAL checkpoint → true single-file brain.db
+```
+
+---
+
+## Connect an AI agent via MCP
+
+Add GigaBrain to your MCP client config (e.g., Claude Code's `~/.claude/mcp_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "gbrain": {
+      "command": "gbrain",
+      "args": ["serve"],
+      "env": { "GBRAIN_DB": "/path/to/brain.db" }
+    }
+  }
+}
+```
+
+Then start the server:
+
+```bash
+gbrain serve
+```
+
+The MCP server exposes tools over stdio JSON-RPC 2.0. Phase 1 ships five core tools: `brain_get`, `brain_put`, `brain_query`, `brain_search`, `brain_list`. Later phases add the full surface — see [spec.md](spec.md#mcp-server).
+
+---
+
+## Skills
+
+Skills are markdown files that tell agents _how_ to use GigaBrain. The binary embeds default skills and extracts them to `~/.gbrain/skills/` on first run. Drop a custom `SKILL.md` in your working directory to override any default.
+
+```bash
+gbrain skills doctor   # show active skills and resolution order
+```
+
+| Skill | Purpose |
+| ----- | ------- |
+| `skills/ingest/` | Meeting transcripts, articles, documents |
+| `skills/query/` | Search and synthesis workflows |
+| `skills/maintain/` | Lint, contradiction detection, orphan pages |
+| `skills/briefing/` | Daily briefing compilation |
+| `skills/research/` | Knowledge gap resolution |
+| `skills/enrich/` | External API enrichment |
+| `skills/alerts/` | Interrupt-driven notifications |
+| `skills/upgrade/` | Agent-guided binary and skill updates |
+
+---
+
+## Page types
+
+`person`, `company`, `deal`, `project`, `concept`, `original`, `source`, `media`, `decision`, `commitment`, `action_item`
+
+The `original` type is for your own thinking — distinct from compiled external intelligence.
+
+---
+
+## Environment variable
+
+| Variable | Default | Purpose |
+| -------- | ------- | ------- |
+| `GBRAIN_DB` | `./brain.db` | Path to the active brain database |
+
+---
+
+## Next steps
+
+- Read the [Roadmap](/contributing/roadmap/) to understand what is built vs. what is coming.
+- Read [Contributing](/contributing/) to start contributing.
+- Read the [Spec](/reference/spec/) for the full technical specification.

--- a/website/src/content/docs/guides/how-it-works.md
+++ b/website/src/content/docs/guides/how-it-works.md
@@ -1,0 +1,28 @@
+---
+title: How It Works
+description: Compiled truth + append-only timelines, stored in SQLite.
+---
+
+GigaBrain adapts Andrej Karpathy’s compiled knowledge model:
+
+## Above the line: compiled truth
+
+Always current. Rewritten when new information arrives. This is the “what we
+believe now” view — optimized for answering questions.
+
+## Below the line: timeline
+
+Append-only. Never rewritten. This is the evidence base — what happened, when,
+and where it came from.
+
+## One file, one database
+
+Pages are stored in a single SQLite database (`brain.db`) with:
+
+- **FTS5** for fast keyword search
+- **`sqlite-vec`** for vector similarity search
+- A **typed, temporal link graph** for “works_at”, “founded”, etc.
+
+The CLI is deliberately thin: the workflows live in markdown `SKILL.md` files
+that agents read and follow.
+

--- a/website/src/content/docs/guides/mcp-server.md
+++ b/website/src/content/docs/guides/mcp-server.md
@@ -1,0 +1,68 @@
+---
+title: MCP Server
+description: Run `gbrain serve` and connect any MCP client over stdio JSON-RPC.
+---
+
+## What `gbrain serve` does
+
+`gbrain serve` starts an MCP server over **stdio**. Your MCP client spawns the
+process and talks JSON-RPC 2.0 over stdin/stdout.
+
+## Claude Code config
+
+Add to your MCP client config (example for Claude Code):
+
+```json
+{
+  "mcpServers": {
+    "gbrain": {
+      "command": "gbrain",
+      "args": ["serve"],
+      "env": { "GBRAIN_DB": "/path/to/brain.db" }
+    }
+  }
+}
+```
+
+## Common tool calls (examples)
+
+### Search (FTS5)
+
+```json
+{ "query": "river ai", "limit": 10 }
+```
+
+### Hybrid query (semantic + keyword)
+
+```json
+{ "question": "who has worked with Jensen Huang?", "depth": "auto", "limit": 10 }
+```
+
+### Read a page
+
+```json
+{ "slug": "people/pedro-franceschi" }
+```
+
+### Write a page (optimistic concurrency)
+
+1. `brain_get` to fetch the current `version`
+2. `brain_put` with `expected_version`
+
+```json
+{
+  "slug": "people/pedro-franceschi",
+  "content": "# Pedro Franceschi\\n\\nUpdated compiled truth...\\n",
+  "expected_version": 3
+}
+```
+
+## Available tools
+
+From the planned surface area:
+
+`brain_query`, `brain_search`, `brain_get`, `brain_put`, `brain_ingest`,
+`brain_link`, `brain_link_close`, `brain_backlinks`, `brain_graph`,
+`brain_timeline`, `brain_tags`, `brain_list`, `brain_check`, `brain_gap`,
+`brain_gaps`, `brain_stats`, `brain_raw`.
+

--- a/website/src/content/docs/guides/quick-start.md
+++ b/website/src/content/docs/guides/quick-start.md
@@ -1,0 +1,57 @@
+---
+title: Quick Start
+description: "Get a brain running in minutes: init, put, search, serve."
+---
+
+> **Planned API.** These commands are the target surface for Phase 1 and Phase 2. They reflect the spec but may not be implemented yet.
+
+## 1) Install
+
+Build from source (for now):
+
+```bash
+git clone https://github.com/macro88/gigabrain
+cd gigabrain
+cargo build --release
+```
+
+## 2) Initialize a brain
+
+```bash
+./target/release/gbrain init ~/brain.db
+```
+
+## 3) Write a page
+
+```bash
+cat <<'MD' | ./target/release/gbrain put people/alice
+---
+title: Alice Example
+type: person
+---
+
+# Alice Example
+
+Above the line: compiled truth.
+
+---
+
+## Timeline
+
+- 2026-04-14 — Met at a demo day; interested in offline-first knowledge systems.
+MD
+```
+
+## 4) Search it
+
+```bash
+./target/release/gbrain search "offline-first"
+./target/release/gbrain query "who is interested in offline knowledge systems?"
+```
+
+## 5) Start the MCP server
+
+```bash
+GBRAIN_DB=~/brain.db ./target/release/gbrain serve
+```
+

--- a/website/src/content/docs/guides/why-gigabrain.md
+++ b/website/src/content/docs/guides/why-gigabrain.md
@@ -1,0 +1,22 @@
+---
+title: Why GigaBrain
+description: A local-first brain that scales past thousands of markdown files.
+---
+
+Git doesn’t scale past ~5,000 markdown files. At that size, a wiki-brain becomes:
+
+- Slow to clone
+- Painful to search
+- Difficult to query structurally (links, timelines, “who knows X?”)
+
+Most existing knowledge tools either require a GUI, lock your data in a SaaS
+platform, or rely on internet + API keys for anything semantic.
+
+GigaBrain is designed for an agent-first world where your knowledge layer needs
+to:
+
+- Live in a single file you own completely
+- Do full-text **and** semantic search natively
+- Expose an MCP server for any AI client
+- Work offline (plane / air-gapped) with zero ongoing costs
+

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -1,0 +1,56 @@
+---
+title: GigaBrain
+description: The personal knowledge brain. SQLite + FTS5 + vector embeddings in one file. No API keys. No internet. One static binary.
+template: splash
+hero:
+  tagline: Your knowledge, compiled. One binary, zero dependencies, runs anywhere.
+  actions:
+    - text: Get Started
+      link: /guides/getting-started/
+      icon: right-arrow
+      variant: primary
+    - text: View on GitHub
+      link: https://github.com/macro88/gigabrain
+      icon: github
+      variant: minimal
+---
+
+import { CardGrid, Card } from "@astrojs/starlight/components";
+
+## Why GigaBrain?
+
+<CardGrid stagger>
+  <Card title="Single Binary" icon="seti:binary">
+    ~90MB static binary. Drop it anywhere. Zero runtime dependencies — no Docker,
+    no Node, no Python.
+  </Card>
+  <Card title="SQLite Everything" icon="seti:db">
+    FTS5 full-text search + `sqlite-vec` vector similarity + typed link graph.
+    All in one `brain.db` file you own completely.
+  </Card>
+  <Card title="Local Embeddings" icon="star">
+    BGE-small-en-v1.5 runs fully offline via pure-Rust candle. No OpenAI API key.
+    No internet required.
+  </Card>
+  <Card title="MCP-Ready" icon="puzzle">
+    `gbrain serve` exposes all tools over stdio JSON-RPC 2.0. Plug into Claude
+    Code, any MCP-compatible agent, instantly.
+  </Card>
+  <Card title="Hybrid Search" icon="magnifier">
+    FTS5 keyword + vector semantic search with set-union merge. Exact-match
+    short-circuit. Finds what you mean, not just what you typed.
+  </Card>
+  <Card title="Fat Skills" icon="document">
+    Agent workflows live in plain markdown SKILL.md files. Swap or extend
+    without rebuilding. The intelligence is yours.
+  </Card>
+</CardGrid>
+
+---
+
+## Status
+
+GigaBrain is currently in **Sprint 0 (scaffold complete)**. Phase 1 (Core) is
+next — the docs describe the *planned* surface area and design, even where
+implementation is still pending.
+

--- a/website/src/content/docs/reference/architecture.md
+++ b/website/src/content/docs/reference/architecture.md
@@ -1,0 +1,35 @@
+---
+title: Architecture
+description: Rust + SQLite brain with FTS5, vectors, and a typed temporal graph.
+---
+
+## Tech stack
+
+| Component | Choice |
+| --- | --- |
+| Language | Rust |
+| Database | SQLite via `rusqlite` (bundled) |
+| Full-text search | FTS5 (built into SQLite) |
+| Vector search | `sqlite-vec` (statically linked) |
+| Embeddings | `candle` + BGE-small-en-v1.5 (pure Rust, local) |
+| CLI | `clap` |
+| MCP server | `rmcp` (stdio JSON-RPC 2.0) |
+
+## Storage model
+
+Everything lives in one SQLite database file:
+
+- `pages`: canonical markdown for each slug
+- Side tables for **links**, **timeline entries**, **tags**, **raw data**, and **embeddings**
+- WAL mode for durability; `gbrain compact` checkpoints to a single-file artifact for backup/transport
+
+## Hybrid search (keyword + semantic)
+
+GigaBrain is designed for “find what I mean” without sacrificing “exact match”.
+
+- **FTS5**: fast sparse retrieval, great for names, exact phrases, and rare terms
+- **Vector search**: dense retrieval for semantic similarity
+- **Merge strategy**: planned default is set-union with exact-match short-circuit, so strong lexical hits don’t get buried by semantic noise
+
+For the full design, see the Spec.
+

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -1,0 +1,336 @@
+---
+title: CLI Reference
+description: Planned `gbrain` commands, options, and examples.
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
+> **Planned API.** This is the target CLI surface defined in `docs/spec.md`. Some commands may not be implemented yet.
+
+## Global options
+
+| Option | Description |
+| --- | --- |
+| `--db <PATH>` | Path to `brain.db` (env: `GBRAIN_DB`, default: `./brain.db`) |
+| `--json` | JSON output instead of human-readable text |
+| `--version` | Print version |
+| `--tools-json` | Print MCP tool discovery JSON |
+
+## Commands
+
+| Command | What it does |
+| --- | --- |
+| `init [PATH]` | Create a new `brain.db` |
+| `get <SLUG>` | Read a page by slug |
+| `put <SLUG> [FILE]` | Write/update a page (stdin or file) |
+| `search <QUERY>` | Full-text keyword search (FTS5) |
+| `query <QUESTION>` | Hybrid search (FTS5 + vectors) |
+| `ingest <FILE>` | Ingest a source document |
+| `import <DIR>` | Import a markdown directory |
+| `export [--dir <PATH>]` | Export a brain to a markdown directory |
+| `embed [<SLUG>]` | Generate/regenerate embeddings |
+| `link <FROM> <TO>` | Create a typed, temporal cross-reference |
+| `link-close <LINK_ID>` | Close a link interval by ID |
+| `links <SLUG>` | List outbound links (with IDs) |
+| `unlink <FROM> <TO>` | Remove a cross-reference |
+| `backlinks <SLUG>` | Show pages linking to a slug |
+| `graph <SLUG>` | N-hop neighborhood graph as JSON |
+| `timeline <SLUG>` | Show timeline entries |
+| `timeline-add <SLUG>` | Add a structured timeline entry |
+| `tags <SLUG>` | List tags for a page |
+| `tag <SLUG> <TAG>` | Add a tag |
+| `untag <SLUG> <TAG>` | Remove a tag |
+| `list` | List pages with filters |
+| `stats` | Brain statistics |
+| `check [SLUG]` | Run contradiction checks |
+| `gaps` | List unresolved knowledge gaps |
+| `validate` | Run integrity checks |
+| `compact` | Checkpoint WAL → single file |
+| `config get|set|list` | Read/write/list config |
+| `skills` | List active skills (embedded + external) |
+| `skills doctor` | Show skill resolution order + hashes |
+| `serve` | Start MCP server (stdio) |
+| `version` | Version info (and migration state) |
+| `call <TOOL> <JSON>` | Raw MCP tool call |
+| `pipe` | JSONL streaming mode |
+
+---
+
+## Command details
+
+### `init`
+
+Create a new brain database.
+
+```bash
+gbrain init ~/brain.db
+```
+
+### `get`
+
+Read a page by slug.
+
+```bash
+gbrain get people/pedro-franceschi
+```
+
+### `put`
+
+Write/update a page from stdin (or a file).
+
+```bash
+cat updated.md | gbrain put people/pedro-franceschi
+```
+
+### `search`
+
+FTS5 keyword search.
+
+```bash
+gbrain search "river ai"
+```
+
+### `query`
+
+Hybrid search (FTS5 + vectors) with progressive depth.
+
+```bash
+gbrain query "who knows Jensen Huang?" --depth auto
+```
+
+### `ingest`
+
+Ingest a source document (meeting/article/doc/conversation).
+
+```bash
+gbrain ingest ./notes/meeting.md --type meeting
+```
+
+### `import`
+
+Import a markdown directory into the brain.
+
+```bash
+gbrain import /path/to/notes/ --db ~/brain.db
+```
+
+### `export`
+
+Export a brain to a markdown directory.
+
+```bash
+gbrain export --dir ./export/
+```
+
+### `embed`
+
+Generate embeddings for one page or in batches.
+
+```bash
+gbrain embed people/pedro-franceschi
+gbrain embed --stale
+gbrain embed --all
+```
+
+### `link`
+
+Create a typed, temporal cross-reference.
+
+```bash
+gbrain link people/pedro-franceschi companies/brex --relationship founded --valid-from 2017-01-01
+```
+
+### `link-close`
+
+Close a link interval by link ID.
+
+```bash
+gbrain link-close 123 --valid-until 2021-01-01
+```
+
+### `links`
+
+List outbound links (optionally include IDs + temporal metadata).
+
+```bash
+gbrain links people/pedro-franceschi --temporal all --json
+```
+
+### `unlink`
+
+Remove a cross-reference entirely.
+
+```bash
+gbrain unlink people/pedro-franceschi companies/brex --relationship founded
+```
+
+### `backlinks`
+
+Find pages that link **to** a slug.
+
+```bash
+gbrain backlinks companies/brex
+```
+
+### `graph`
+
+Fetch an N-hop neighborhood (pages + links) as JSON.
+
+```bash
+gbrain graph people/pedro-franceschi --depth 2
+```
+
+### `timeline`
+
+Show timeline entries for a page.
+
+```bash
+gbrain timeline people/pedro-franceschi
+```
+
+### `timeline-add`
+
+Add a structured timeline entry.
+
+```bash
+gbrain timeline-add people/pedro-franceschi --date 2026-04-14 --summary "Met at demo day" --source meeting/42
+```
+
+### `tags`, `tag`, `untag`
+
+Work with tags.
+
+```bash
+gbrain tags people/pedro-franceschi
+gbrain tag people/pedro-franceschi yc-alum
+gbrain untag people/pedro-franceschi yc-alum
+```
+
+### `list`
+
+List pages with filters.
+
+```bash
+gbrain list --type person --tag yc-alum --limit 50 --sort updated
+```
+
+### `stats`
+
+Show brain statistics.
+
+```bash
+gbrain stats
+```
+
+### `check`
+
+Run contradiction checks (single page or whole brain).
+
+```bash
+gbrain check --all
+```
+
+### `gaps`
+
+List unresolved knowledge gaps.
+
+```bash
+gbrain gaps --limit 20
+```
+
+### `validate`
+
+Integrity checks (links/assertions/embeddings/etc.).
+
+```bash
+gbrain validate --all
+```
+
+### `compact`
+
+Checkpoint WAL so the brain is transportable as one file.
+
+```bash
+gbrain compact
+```
+
+### `config`
+
+Read/write/list config.
+
+```bash
+gbrain config list
+gbrain config get search_merge_strategy
+gbrain config set search_merge_strategy set-union
+```
+
+### `skills`
+
+Inspect skill resolution order and hashes.
+
+```bash
+gbrain skills
+gbrain skills doctor
+```
+
+### `serve`
+
+Start the MCP server (stdio).
+
+```bash
+gbrain serve
+```
+
+### `version`
+
+Print version info (and migration state).
+
+```bash
+gbrain version
+```
+
+### `call`
+
+Raw tool call helper (good for debugging).
+
+```bash
+gbrain call brain_search '{\"query\":\"river ai\",\"limit\":10}'
+```
+
+### `pipe`
+
+JSONL streaming mode (one JSON object per line).
+
+```bash
+cat requests.jsonl | gbrain pipe
+```
+
+## Examples
+
+<Tabs>
+  <TabItem label="Create + search">
+    ```bash
+    gbrain init ~/brain.db
+    gbrain import /path/to/notes/ --db ~/brain.db
+    gbrain search "river ai"
+    gbrain query "who has worked with Jensen Huang?"
+    ```
+  </TabItem>
+  <TabItem label="Read + write">
+    ```bash
+    gbrain get people/pedro-franceschi
+    cat updated.md | gbrain put people/pedro-franceschi
+    ```
+  </TabItem>
+  <TabItem label="Links + graph">
+    ```bash
+    gbrain link people/pedro-franceschi companies/brex --relationship founded --valid-from 2017-01-01
+    gbrain graph people/pedro-franceschi --depth 2
+    ```
+  </TabItem>
+  <TabItem label="MCP">
+    ```bash
+    GBRAIN_DB=~/brain.db gbrain serve
+    ```
+  </TabItem>
+</Tabs>

--- a/website/src/content/docs/reference/spec.md
+++ b/website/src/content/docs/reference/spec.md
@@ -1,0 +1,2920 @@
+---
+title: Spec
+description: The authoritative design document for schema, CLI, algorithms, and MCP.
+---
+
+## Spec metadata
+
+- **Created:** 2026-04-06
+- **Updated:** 2026-04-13
+- **Status:** spec-complete-v4
+- **Tags:** open-source, knowledge-base, sqlite, rag, rust, mcp, thin-harness, fat-skills, candle
+- **Sources:** Garry Tan’s GBrain spec + internal architecture notes and reviews
+
+# GigaBrain - Personal Knowledge Brain
+
+> Open-source personal knowledge brain. SQLite + FTS5 + vector embeddings in one file. Thin CLI harness, fat skill files. MCP-ready from day one. Runs anywhere. No API keys, no internet, no Docker. Truly static single binary.
+
+Inspired by Garry Tan's GBrain work, with this spec adapting similar goals to a local-first Rust + SQLite architecture intended for portable, offline use.
+
+- **Status:** Spec complete v4 — ready to build core (see [Phased Delivery](#phased-delivery))
+- **Repo (planned):** GitHub.com/[owner]/gbrain
+- **License (planned):** MIT
+- **Origin:** Inspired by Garry Tan's GBrain spec (2026-04-05), then extended with architecture improvements (2026-04-06) and memory research integration (2026-04-08)
+- **v1 differentiator over Garry's spec:** Local embeddings, Rust binary instead of TypeScript/Bun, true zero-dependency single binary
+- **v2 additions (Apr 2026 research):** Set-union hybrid search, palace-style hierarchical filtering, progressive retrieval, selective ingestion, temporal knowledge graph, contradiction detection, four-tier memory consolidation. Techniques sourced from MemPalace (96.6% R@5 LongMemEval), OMNIMEM (+411% F1), agentmemory (92% token reduction).
+- **v3 additions (Architecture Review):** Exact-Match Short-Circuit (SMS) search, Temporal Sub-chunking for timelines, Assertions table for heuristic contradiction detection, strict Optimistic Concurrency on MCP writes, true zero-dependency static linking via `candle` (replacing `fastembed`/ONNX).
+- **v4 additions (Community Research + Garry v0.8.0):** Knowledge gap detection (`knowledge_gaps` table + `brain_gap` MCP tool), graph neighborhood traversal (`brain_graph`), `original` page type for user's own thinking, standardised source attribution format with authority hierarchy, filing disambiguation rules, richer person templates, new skills (upgrade, alerts, research), and PGLite convergence validation. Informed by community prototypes, public discussion, and Garry Tan's v0.8.0 GBrain skillpack analysis.
+
+---
+
+## Table of Contents
+
+1. [The Problem](#the-problem) *(includes Non-Goals)*
+2. [The Solution](#the-solution)
+3. [Architecture Overview](#architecture-overview)
+4. [Technology Stack](#technology-stack) *(v3: candle replaces fastembed)*
+5. [Database Schema](#database-schema) *(v4: + knowledge_gaps table, original page type)*
+6. [CLI Reference](#cli-reference) *(v4: + graph, gaps commands)*
+7. [MCP Server](#mcp-server) *(v4: + brain_graph, brain_gap, brain_gaps)*
+8. [Hybrid Search](#hybrid-search) *(v3: SMS short-circuit + set-union + palace filtering)*
+9. [Progressive Retrieval](#progressive-retrieval) *(v2: token-budget-gated expansion)*
+10. [Ingest Pipeline](#ingest-pipeline) *(v3: assertions + sub-chunking + idempotency)*
+11. [Migration Plan](#migration-plan) *(v4: + original type mapping)*
+12. [Export and Round-trip](#export-and-round-trip)
+13. [Skills (Fat Markdown)](#skills-fat-markdown) *(v4: + alerts, research, upgrade skills; source attribution; filing disambiguation)*
+14. [Repository Structure](#repository-structure) *(v4: + graph.rs, gaps.rs, 3 new skills)*
+15. [Build and Release](#build-and-release)
+16. [Phased Delivery](#phased-delivery) *(v4: knowledge_gaps in P1, graph in P2, gaps/alerts/research/upgrade in P3)*
+17. [Implementation Roadmap](#implementation-roadmap) *(v4: + graph, gaps, new skills)*
+18. [Benchmarks and Release Gates](#benchmarks-and-release-gates) *(corpus-reality + LongMemEval, LoCoMo, BEIR, Ragas)*
+19. [Design Decisions](#design-decisions) *(v4: + SQLite vs PGLite, links-as-graph-layer)*
+20. [Schema Versioning and DB Migration](#schema-versioning-and-db-migration)
+21. [Security and Data Sensitivity](#security-and-data-sensitivity)
+22. [Error Handling and Graceful Degradation](#error-handling-and-graceful-degradation)
+23. [Comparison Table](#comparison-table) *(v4: updated for Garry v0.8.0 + PGLite, + graph/gap rows)*
+24. [Open Questions](#open-questions) *(v2: new questions added)*
+25. [Spec History](#spec-history)
+
+---
+
+## The Problem
+
+Git doesn't scale past ~5,000 markdown files. At 7,471 files and 2.3GB, a wiki-brain directory becomes slow to clone, painful to search, and unusable for structured queries. Full-text search requires grep. Semantic search requires an external vector database. Cross-references are just markdown links with no queryable graph.
+
+The compiled-truth + timeline architecture (Karpathy-style: always-current intelligence above the line, append-only evidence below the line) is the right knowledge model - it just needs a real database underneath.
+
+Additionally: every existing knowledge-base tool (Obsidian, Notion, RAG frameworks) either requires a GUI, locks data in a SaaS platform, or needs an internet connection and API keys to do anything useful. An agent-first world needs a knowledge layer that:
+
+- Lives in a single logical database (one `.db` file; WAL sidecars during operation, compactable to single file for transport)
+- Does full-text + semantic search natively
+- Exposes an MCP server for any AI client
+- Works on a plane, in an air-gapped environment, with no ongoing API costs
+- Is fast, small, and has zero runtime dependencies
+
+### Non-Goals (v1)
+
+- **Not a collaborative platform** — single-user, single-writer. No auth, no RBAC, no multi-tenant.
+- **Not a sync product** — no real-time replication, no CRDTs, no cloud sync. `rsync`/`scp` is the transport.
+- **Not a full graph database** — typed links with temporal validity, not arbitrary traversals or Cypher queries.
+- **Not a general note-taking app** — structured knowledge pages, not freeform notes. Use Obsidian for that.
+- **Not a document warehouse** — pages are compiled intelligence, not raw file storage. Raw data goes in `raw_data` table.
+- **Not a semantic contradiction oracle** — heuristic detection via assertions, not LLM-powered reasoning. The binary is dumb.
+- **Not multimodal** — text only. Images, audio, video are not indexed or embedded.
+
+---
+
+## The Solution
+
+A single Rust binary (~90MB including embedded model weights) wrapping:
+
+- **SQLite** with WAL mode - single logical database (`brain.db` + WAL sidecars while live; `gbrain compact` checkpoints to true single file for transport/backup)
+- **FTS5** - full-text search, built into SQLite
+- **sqlite-vec** - vector similarity search as a SQLite extension, statically linked
+- **candle + BGE-small-en-v1.5** - pure-Rust ML framework running a local embedding model, no ONNX runtime dependencies
+- **MCP stdio server** - any MCP-compliant client can search, read, write, and ingest
+- **Fat skills** - intelligence lives in markdown SKILL.md files, not in code
+
+One `cargo build --release --target x86_64-unknown-linux-musl`. One truly static binary. Drop it anywhere and run it.
+
+---
+
+## Architecture Overview
+
+```
+╔══════════════════════════════════════════════════════════════╗
+║                        CONSUMERS                             ║
+╠══════════════════════════════════════════════════════════════╣
+║                                                              ║
+║   Claude Code       OpenClaw / Doug     Any MCP Client      ║
+║   (via MCP)         (via MCP/CLI)       (via MCP)           ║
+║        │                  │                   │              ║
+║        └──────────┬────────────────────┘       │             ║
+║                   │                            │             ║
+║   ┌───────────────▼──────────┐  ┌─────────────▼──────────┐ ║
+║   │      MCP Server          │  │         CLI             │ ║
+║   │   (stdio transport)      │  │    bin/gbrain           │ ║
+║   │    gbrain serve          │  │  single Rust binary     │ ║
+║   └───────────────┬──────────┘  └─────────────┬──────────┘ ║
+║                   │                            │             ║
+║                   └──────────────┬─────────────┘            ║
+║                                  │                           ║
+║              ┌───────────────────▼──────────────┐           ║
+║              │            gbrain-core            │           ║
+║              │              (Rust)               │           ║
+║              │                                   │           ║
+║              │  ┌──────────────────────────────┐ │           ║
+║              │  │  db.rs        (rusqlite)     │ │           ║
+║              │  │  fts.rs       (FTS5 queries) │ │           ║
+║              │  │  inference.rs (candle ML)    │ │           ║
+║              │  │  search.rs    (SMS + union)  │ │           ║
+║              │  │  progressive.rs (retrieval)  │ │           ║
+║              │  │  palace.rs    (wing/room)    │ │           ║
+║              │  │  novelty.rs   (dedup)        │ │           ║
+║              │  │  assertions.rs(heuristics)   │ │           ║
+║              │  │  chunking.rs  (temporal)     │ │           ║
+║              │  │  markdown.rs  (parse/render) │ │           ║
+║              │  │  links.rs     (temporal KG)  │ │           ║
+║              │  │  migrate.rs   (import/export)│ │           ║
+║              │  └──────────────────────────────┘ │           ║
+║              └───────────────────┬────────────────┘          ║
+║                                  │                           ║
+║              ┌───────────────────▼──────────────┐           ║
+║              │           SQLite DB               │           ║
+║              │           brain.db                │           ║
+║              │                                   │           ║
+║              │  ┌──────────────────────────────┐ │           ║
+║              │  │  pages                        │ │           ║
+║              │  │  page_fts      (FTS5 vtable)  │ │           ║
+║              │  │  page_embeddings (vec0 vtable)│ │           ║
+║              │  │  links                        │ │           ║
+║              │  │  assertions                   │ │           ║
+║              │  │  tags                         │ │           ║
+║              │  │  raw_data                     │ │           ║
+║              │  │  timeline_entries             │ │           ║
+║              │  │  ingest_log                   │ │           ║
+║              │  │  config                       │ │           ║
+║              │  └──────────────────────────────┘ │           ║
+║              └───────────────────────────────────┘          ║
+║                                                              ║
+╠══════════════════════════════════════════════════════════════╣
+║                    SKILLS (Fat Markdown)                     ║
+╠══════════════════════════════════════════════════════════════╣
+║                                                              ║
+║  skills/ingest/SKILL.md   — meeting/doc/article ingestion   ║
+║  skills/query/SKILL.md    — search + synthesis              ║
+║  skills/maintain/SKILL.md — lint, contradictions, orphans   ║
+║  skills/enrich/SKILL.md   — external API enrichment         ║
+║  skills/briefing/SKILL.md — daily briefing compilation      ║
+║  skills/alerts/SKILL.md   — interrupt-driven notifications  ║
+║  skills/research/SKILL.md — knowledge gap resolution        ║
+║  skills/upgrade/SKILL.md  — agent-guided binary upgrades    ║
+║                                                              ║
+╚══════════════════════════════════════════════════════════════╝
+```
+
+### Core Philosophy
+
+**Thin harness, fat skills.** The binary is plumbing. The intelligence lives in SKILL.md files. Claude Code, OpenClaw, or any agent reads SKILL.md at session start and knows every workflow, heuristic, and edge case without that logic being compiled into the binary. Default skills are embedded in the binary via `include_str!()` and extracted to `~/.gbrain/skills/` on first run. External skill files in the working directory override embedded defaults. `gbrain skills doctor` shows active resolution order and content hashes.
+
+**Above the line / Below the line.** Every knowledge page has two zones:
+- **compiled_truth** - Always current. Rewritten when new info arrives. The intelligence assessment. The "what we know now."
+- **timeline** - Append-only. Never rewritten. The evidence base. The "what happened and when."
+
+The horizontal rule (`---`) is the boundary. Reconstructed on export.
+
+**Single logical database, total ownership.** `brain.db` is the database. During operation, SQLite WAL mode creates `-wal` and `-shm` sidecars for write performance. Run `gbrain compact` to checkpoint back to a true single file for transport. The practical artifact is: binary + DB + skill pack (embedded defaults, optional overrides). No connection strings. No Docker. No managed database. No API keys required at runtime.
+
+---
+
+## Technology Stack
+
+| Component | Choice | Rationale |
+|-----------|--------|-----------|
+| Language | **Rust** | Single binary via `cargo build --release`. No runtime. No GC pauses. Memory safe. Cross-compiles cleanly. |
+| Database | **rusqlite** with `bundled` feature | SQLite compiled into the binary. Zero system dependency. `bundled` cargo feature = self-contained. |
+| Full-text search | **FTS5** | Built into SQLite. Porter stemmer + unicode61 tokenizer. Handles 100K+ documents trivially. |
+| Vector search | **sqlite-vec** (statically linked) | Alex Garcia's sqlite-vec extension. Stores float32 arrays as BLOBs. Native cosine similarity. Same DB, same query. v0.1+ stable. Statically linked via rusqlite. |
+| Embeddings | **candle + BGE-small-en-v1.5** | HuggingFace's pure-Rust ML framework. Unlike `fastembed` (ONNX runtime), `candle` allows true `musl` static compilation. Weights embedded via `include_bytes!()` for zero-network binary. |
+| CLI | **clap** | Industry standard Rust CLI framework. Auto-generates help text. |
+| MCP server | **rmcp** | Rust MCP crate. Stdio transport. |
+| Markdown | **pulldown-cmark** + **gray-matter** port | Fast CommonMark parser. Frontmatter parsing via custom YAML header extraction. |
+| JSON/YAML | **serde_json** / **serde_yaml** | Standard serialization. |
+
+### Why Rust over TypeScript/Bun (Garry's original stack)
+
+| | Garry's GBrain (TypeScript/Bun) | This spec (Rust) |
+|---|---|---|
+| Binary size | ~10MB (Bun compiled) | ~90MB (includes model weights) |
+| Embeddings | text-embedding-3-small (OpenAI API, costs money, needs internet) | BGE-small-en-v1.5 via candle (local, free, fast, pure Rust) |
+| Internet required | Yes (for embeddings) | No |
+| API keys required | Yes (OPENAI_API_KEY) | No |
+| Cross-compile | Bun's compile works but CGO complications | `cargo cross` or GitHub Actions matrix = trivial |
+| Memory | Node/Bun overhead | Minimal, no GC |
+| sqlite-vec linking | Native addon complications with Bun | `rusqlite` bundled feature handles it cleanly |
+| Air-gapped use | No | Yes |
+
+**The key differentiator:** runs on a plane, in a datacenter without egress, on a client machine with no API keys configured. "Runs on client" is the real value.
+
+---
+
+## Database Schema
+
+```sql
+-- brain.db schema
+-- GigaBrain v4
+
+PRAGMA journal_mode = WAL;
+PRAGMA foreign_keys = ON;
+
+-- Load sqlite-vec extension (statically linked in Rust binary)
+-- SELECT load_extension('./vec0');  -- handled at db init in Rust
+
+-- ============================================================
+-- pages: the core content table
+-- ============================================================
+CREATE TABLE IF NOT EXISTS pages (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    slug            TEXT    NOT NULL UNIQUE,    -- e.g. "people/pedro-franceschi"
+    type            TEXT    NOT NULL,            -- person, company, deal, yc, civic, project, concept, original, source, media, decision, commitment, action_item
+    title           TEXT    NOT NULL,
+    summary         TEXT    NOT NULL DEFAULT '', -- executive summary (blockquote at top of compiled_truth)
+    compiled_truth  TEXT    NOT NULL DEFAULT '', -- markdown, above the line
+    timeline        TEXT    NOT NULL DEFAULT '', -- markdown, below the line
+    frontmatter     TEXT    NOT NULL DEFAULT '{}',-- JSON blob (original YAML converted)
+    wing            TEXT    NOT NULL DEFAULT '', -- palace hierarchy: entity grouping (auto-derived from slug, override via frontmatter)
+    room            TEXT    NOT NULL DEFAULT '', -- palace hierarchy: topic within wing (derived from section headers or frontmatter)
+    version         INTEGER NOT NULL DEFAULT 1,    -- optimistic concurrency: incremented on every write
+    created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),         -- bumped on ANY page-scoped mutation
+    truth_updated_at TEXT   NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),         -- bumped ONLY when compiled_truth changes
+    timeline_updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_pages_type ON pages(type);
+CREATE INDEX IF NOT EXISTS idx_pages_slug ON pages(slug);
+CREATE INDEX IF NOT EXISTS idx_pages_updated ON pages(updated_at);
+CREATE INDEX IF NOT EXISTS idx_pages_wing ON pages(wing);
+CREATE INDEX IF NOT EXISTS idx_pages_wing_room ON pages(wing, room);
+
+-- ============================================================
+-- page_fts: full-text search over compiled_truth + timeline
+-- ============================================================
+CREATE VIRTUAL TABLE IF NOT EXISTS page_fts USING fts5(
+    title,
+    slug,
+    compiled_truth,
+    timeline,
+    content='pages',
+    content_rowid='id',
+    tokenize='porter unicode61'
+);
+
+-- Triggers to keep FTS in sync
+CREATE TRIGGER IF NOT EXISTS pages_ai AFTER INSERT ON pages BEGIN
+    INSERT INTO page_fts(rowid, title, slug, compiled_truth, timeline)
+    VALUES (new.id, new.title, new.slug, new.compiled_truth, new.timeline);
+END;
+
+CREATE TRIGGER IF NOT EXISTS pages_ad AFTER DELETE ON pages BEGIN
+    INSERT INTO page_fts(page_fts, rowid, title, slug, compiled_truth, timeline)
+    VALUES ('delete', old.id, old.title, old.slug, old.compiled_truth, old.timeline);
+END;
+
+CREATE TRIGGER IF NOT EXISTS pages_au AFTER UPDATE ON pages BEGIN
+    INSERT INTO page_fts(page_fts, rowid, title, slug, compiled_truth, timeline)
+    VALUES ('delete', old.id, old.title, old.slug, old.compiled_truth, old.timeline);
+    INSERT INTO page_fts(rowid, title, slug, compiled_truth, timeline)
+    VALUES (new.id, new.title, new.slug, new.compiled_truth, new.timeline);
+END;
+
+-- ============================================================
+-- page_embeddings: vector embeddings via sqlite-vec
+-- vec0 virtual table for native cosine similarity
+-- ============================================================
+-- ── Embedding model registry (single source of truth for active model) ──
+-- Each model gets its own vec0 table (dimension is baked into the virtual table).
+-- The embedding_models table is the ONLY authoritative selector for the active model.
+-- The config keys 'embedding_model' and 'embedding_dimensions' are derived from this
+-- table at init and are read-only aliases — never write them directly.
+CREATE TABLE IF NOT EXISTS embedding_models (
+    name       TEXT PRIMARY KEY,              -- e.g. 'bge-small-en-v1.5'
+    dimensions INTEGER NOT NULL,              -- e.g. 384
+    vec_table  TEXT NOT NULL UNIQUE,          -- e.g. 'page_embeddings_vec_384'
+    active     INTEGER NOT NULL DEFAULT 0,    -- 1 = currently used for writes
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+-- Enforce exactly one active model at all times.
+-- Partial unique index: only rows where active=1 participate in the constraint.
+-- Zero active rows → init/migration must seed one. Multiple active rows → rejected.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_embedding_models_one_active
+    ON embedding_models(active) WHERE active = 1;
+
+-- Seed the default model at init (MUST happen before any embedding operation):
+--   INSERT INTO embedding_models (name, dimensions, vec_table, active)
+--   VALUES ('bge-small-en-v1.5', 384, 'page_embeddings_vec_384', 1);
+-- On model upgrade: INSERT new model with active=0, re-embed all pages under it,
+-- then in a single transaction: UPDATE old model SET active=0, UPDATE new model SET active=1.
+-- The unique index guarantees at most one active=1 row at any point.
+-- Old table is kept until explicitly dropped, so rollback is safe.
+
+-- Default model — vec table created dynamically at init based on registered dimensions.
+-- Example for BGE-small (384-dim):
+--   CREATE VIRTUAL TABLE IF NOT EXISTS page_embeddings_vec_384 USING vec0(
+--       embedding float[384]
+--   );
+-- On model upgrade (e.g. to 768-dim), a new vec table is created and a re-embed
+-- migration populates it before flipping the active flag. Old table is kept until
+-- explicitly dropped, so rollback is safe.
+
+-- Metadata for each embedding chunk — model-scoped to avoid rowid collisions.
+-- Each model's vec table has its own rowid space. page_embeddings stores the
+-- vec_rowid for the specific model's vec table, NOT a shared autoincrement.
+CREATE TABLE IF NOT EXISTS page_embeddings (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,  -- internal metadata ID (NOT vec rowid)
+    page_id         INTEGER NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
+    model           TEXT    NOT NULL DEFAULT 'bge-small-en-v1.5' REFERENCES embedding_models(name),
+    vec_rowid       INTEGER NOT NULL,       -- rowid in the model's vec table (model-scoped)
+    chunk_type      TEXT    NOT NULL,       -- 'truth_section' | 'timeline_entry'
+    chunk_index     INTEGER NOT NULL,       -- 0-based index within page
+    chunk_text      TEXT    NOT NULL,       -- the text that was embedded
+    content_hash    TEXT    NOT NULL,       -- SHA-256 of chunk_text (skip re-embed if unchanged)
+    token_count     INTEGER NOT NULL,       -- approximate token count (whitespace-split)
+    heading_path    TEXT    NOT NULL DEFAULT '',  -- e.g. "## State" or "## Timeline > 2024-03-01"
+    last_embedded_at TEXT   NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    UNIQUE(model, vec_rowid)               -- one metadata row per vector per model
+);
+-- Join: page_embeddings.vec_rowid = <model_vec_table>.rowid
+--        WHERE page_embeddings.model = <active_model>
+-- On model migration: new rows created for new model, old model rows kept for rollback.
+-- Cutover: flip embedding_models.active, queries switch to new model's rows.
+-- Rollback: flip back, old rows + old vec table still intact.
+
+CREATE INDEX IF NOT EXISTS idx_embeddings_page ON page_embeddings(page_id);
+CREATE INDEX IF NOT EXISTS idx_embeddings_model ON page_embeddings(model);
+CREATE INDEX IF NOT EXISTS idx_embeddings_lookup ON page_embeddings(model, page_id, chunk_index);
+
+-- ============================================================
+-- links: cross-references between pages
+-- ============================================================
+-- Surrogate ID is the stable target for link-close operations.
+-- No UNIQUE on (from, to, relationship, valid_from) — multiple intervals with
+-- unknown start dates are allowed. Dedup and non-overlap enforced in app logic.
+-- brain_link_close targets by link ID, not by date columns.
+CREATE TABLE IF NOT EXISTS links (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    from_page_id INTEGER NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
+    to_page_id   INTEGER NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
+    relationship TEXT    NOT NULL DEFAULT 'related',
+    context      TEXT    NOT NULL DEFAULT '',
+    valid_from   TEXT    DEFAULT NULL,
+    valid_until  TEXT    DEFAULT NULL,
+    created_at   TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    -- Temporal ordering: valid_until must be after valid_from when both are known
+    CHECK (valid_from IS NULL OR valid_until IS NULL OR valid_until >= valid_from)
+);
+
+CREATE INDEX IF NOT EXISTS idx_links_from ON links(from_page_id);
+CREATE INDEX IF NOT EXISTS idx_links_to   ON links(to_page_id);
+CREATE INDEX IF NOT EXISTS idx_links_current ON links(valid_until);  -- fast filter for current-only queries
+
+-- ============================================================
+-- assertions: heuristic contradiction detection
+-- Populated by agents during Tier 2 ingest. Enables pure-SQL
+-- consistency checks without burning LLM tokens.
+-- ============================================================
+-- Surrogate ID is the stable target for supersession.
+-- No UNIQUE on (page_id, subject, predicate, object, valid_from) — multiple intervals
+-- with unknown start dates are allowed. Tier 2 rewrites supersede old assertions by
+-- setting valid_until on the prior row AND pointing supersedes_id to it.
+-- Contradiction detection: SELECT WHERE valid_until IS NULL (current beliefs only).
+-- Dedup enforced in application logic during ingest.
+CREATE TABLE IF NOT EXISTS assertions (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    page_id         INTEGER NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
+    subject         TEXT    NOT NULL,
+    predicate       TEXT    NOT NULL,
+    object          TEXT    NOT NULL,
+    valid_from      TEXT    DEFAULT NULL,
+    valid_until     TEXT    DEFAULT NULL,
+    supersedes_id   INTEGER DEFAULT NULL REFERENCES assertions(id),
+    confidence      REAL    DEFAULT 1.0,
+    asserted_by     TEXT    NOT NULL DEFAULT 'agent',
+    source_ref      TEXT    NOT NULL DEFAULT '',
+    evidence_text   TEXT    NOT NULL DEFAULT '',
+    created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    CHECK (valid_from IS NULL OR valid_until IS NULL OR valid_until >= valid_from),
+    CHECK (asserted_by IN ('agent', 'manual', 'import', 'enrichment'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_assertions_subj ON assertions(subject);
+CREATE INDEX IF NOT EXISTS idx_assertions_pred ON assertions(predicate);
+
+-- ============================================================
+-- tags
+-- ============================================================
+CREATE TABLE IF NOT EXISTS tags (
+    id      INTEGER PRIMARY KEY AUTOINCREMENT,
+    page_id INTEGER NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
+    tag     TEXT    NOT NULL,
+    UNIQUE(page_id, tag)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tags_tag     ON tags(tag);
+CREATE INDEX IF NOT EXISTS idx_tags_page_id ON tags(page_id);
+
+-- ============================================================
+-- raw_data: sidecar data (replaces .raw/ JSON files)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS raw_data (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    page_id    INTEGER NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
+    source     TEXT    NOT NULL,    -- "crustdata", "happenstance", "exa", "partiful"
+    data       TEXT    NOT NULL,    -- full JSON response
+    fetched_at TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    UNIQUE(page_id, source)         -- one row per source per page, overwrite on re-enrich
+);
+
+CREATE INDEX IF NOT EXISTS idx_raw_data_page ON raw_data(page_id);
+
+-- ============================================================
+-- timeline_entries: structured timeline (supplements markdown)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS timeline_entries (
+    id      INTEGER PRIMARY KEY AUTOINCREMENT,
+    page_id INTEGER NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
+    date    TEXT    NOT NULL,               -- ISO 8601: YYYY-MM-DD
+    source  TEXT    NOT NULL DEFAULT '',    -- "meeting", "email", "manual", etc.
+    summary      TEXT    NOT NULL,               -- one-line summary
+    summary_hash TEXT    NOT NULL DEFAULT '',    -- SHA-256 of summary for dedupe
+    detail       TEXT    NOT NULL DEFAULT '',    -- full markdown detail
+    created_at   TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    UNIQUE(page_id, date, summary_hash)          -- prevent replay duplicates
+);
+
+CREATE INDEX IF NOT EXISTS idx_timeline_page ON timeline_entries(page_id);
+CREATE INDEX IF NOT EXISTS idx_timeline_date ON timeline_entries(date);
+
+-- ============================================================
+-- raw_imports: original file bytes for byte-exact round-trip
+-- ============================================================
+CREATE TABLE IF NOT EXISTS raw_imports (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    page_id    INTEGER NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
+    import_id  TEXT    NOT NULL,            -- identifies the import batch
+    is_active  INTEGER NOT NULL DEFAULT 1,  -- 1 = current snapshot for this page, 0 = historical
+    raw_bytes  BLOB   NOT NULL,            -- original file content, byte-for-byte
+    file_path  TEXT   NOT NULL,            -- relative path within the import source
+    created_at TEXT   NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    UNIQUE(page_id, import_id)
+);
+-- On re-import: set is_active=0 on prior rows for the same page_id, then insert new row.
+-- Raw export uses the active snapshot by default, or a specific import_id if provided.
+
+CREATE INDEX IF NOT EXISTS idx_raw_imports_page ON raw_imports(page_id);
+CREATE INDEX IF NOT EXISTS idx_raw_imports_active ON raw_imports(page_id, is_active) WHERE is_active = 1;
+
+-- Import manifest: tracks each import batch for rollback/audit
+CREATE TABLE IF NOT EXISTS import_manifest (
+    import_id   TEXT PRIMARY KEY,           -- UUID or timestamp-based batch ID
+    source_dir  TEXT NOT NULL,              -- original import path
+    page_count  INTEGER NOT NULL,
+    created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+-- ============================================================
+-- ingest_log: audit trail for all ingest operations
+-- ============================================================
+CREATE TABLE IF NOT EXISTS ingest_log (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    ingest_key    TEXT NOT NULL UNIQUE,              -- SHA-256 of source content; idempotency key
+    source_type   TEXT NOT NULL,                     -- "meeting", "article", "doc", "conversation", "import"
+    source_ref    TEXT NOT NULL,                     -- meeting ID, URL, file path, etc.
+    pages_updated TEXT NOT NULL DEFAULT '[]',        -- JSON array of page slugs
+    summary       TEXT NOT NULL DEFAULT '',
+    completed_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+-- Fully transactional idempotency protocol:
+--   1. BEGIN TRANSACTION
+--   2. SELECT ingest_key WHERE ingest_key = ? → if row exists, ROLLBACK and skip (already done)
+--   3. Run all mutations (page puts, links, timeline, assertions, embeddings)
+--   4. INSERT ingest_log row (inside the same transaction)
+--   5. COMMIT
+-- The ingest_log row is written atomically with all mutations. If the process
+-- crashes before COMMIT, the entire transaction rolls back — including the
+-- ingest_log row — so the key never appears and the retry starts clean.
+-- No stale-row reclamation needed. No two-phase protocol. Just SQLite ACID.
+
+-- ============================================================
+-- config: brain-level settings
+-- ============================================================
+CREATE TABLE IF NOT EXISTS config (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+INSERT OR IGNORE INTO config (key, value) VALUES
+    ('version',              '4'),
+    -- embedding_model and embedding_dimensions are derived from embedding_models
+    -- at startup and kept in sync automatically. Do not write them directly.
+    ('embedding_model',      'bge-small-en-v1.5'),   -- read-only alias, derived from embedding_models WHERE active=1
+    ('embedding_dimensions', '384'),                  -- read-only alias, derived from embedding_models WHERE active=1
+    ('chunk_strategy',       'section'),            -- "page", "section", or "paragraph"
+    ('search_merge_strategy','set-union'),           -- "set-union" (default) or "rrf" (fallback)
+    ('default_token_budget', '4000');                -- default for progressive retrieval queries
+
+-- ============================================================
+-- contradictions: detected inconsistencies across pages
+-- ============================================================
+CREATE TABLE IF NOT EXISTS contradictions (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    page_id       INTEGER NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
+    other_page_id INTEGER REFERENCES pages(id) ON DELETE SET NULL,
+    type          TEXT    NOT NULL,       -- "temporal", "cross_page", "stale"
+    description   TEXT    NOT NULL,
+    detected_at   TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    resolved_at   TEXT    DEFAULT NULL    -- NULL = unresolved
+);
+
+CREATE INDEX IF NOT EXISTS idx_contradictions_page ON contradictions(page_id);
+CREATE INDEX IF NOT EXISTS idx_contradictions_unresolved ON contradictions(resolved_at) WHERE resolved_at IS NULL;
+
+-- ============================================================
+-- knowledge_gaps: queries the brain couldn't answer well
+-- Privacy-safe by default: raw query text is NOT retained
+-- unless explicitly approved.  Only query_hash is stored on
+-- detection; query_text is populated post-approval.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS knowledge_gaps (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    query_hash       TEXT    NOT NULL,   -- SHA-256 of original query, always stored
+    query_text       TEXT    DEFAULT NULL,  -- raw text retained only after approval
+    context          TEXT    NOT NULL DEFAULT '',
+    confidence_score REAL    DEFAULT NULL,
+    sensitivity      TEXT    NOT NULL DEFAULT 'internal',
+    approved_by      TEXT    DEFAULT NULL,
+    approved_at      TEXT    DEFAULT NULL,
+    redacted_query   TEXT    DEFAULT NULL,
+    resolved_at      TEXT    DEFAULT NULL,
+    resolved_by_slug TEXT    DEFAULT NULL,
+    detected_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    CHECK (sensitivity IN ('internal', 'external', 'redacted')),
+    CHECK (query_text IS NULL OR (approved_by IS NOT NULL AND approved_at IS NOT NULL))
+);
+
+CREATE INDEX IF NOT EXISTS idx_gaps_unresolved ON knowledge_gaps(resolved_at) WHERE resolved_at IS NULL;
+```
+
+### Schema Notes
+
+- **All text fields:** UTF-8
+- **All timestamps:** ISO 8601 (`YYYY-MM-DDTHH:MM:SSZ` for timestamps, `YYYY-MM-DD` for dates)
+- **Embeddings:** BGE-small-en-v1.5 produces 384-dimensional float32 vectors. sqlite-vec stores them natively in `vec0` virtual table. 384 floats × 4 bytes = 1,536 bytes per chunk (vs 6,144 bytes for OpenAI's 1536-dim model - 4x smaller)
+- **JSON fields** (`frontmatter`, `data`, `pages_updated`): stored as TEXT, parsed in application layer
+- **Slugs** include directory prefix: `people/pedro-franceschi`, `companies/river-ai`, `deals/river-ai-series-a`
+- **Embedding model registry (single source of truth):** Each model gets its own vec0 table (dimension is baked in). The `embedding_models` table is the ONLY authoritative selector for the active model — a partial unique index (`WHERE active = 1`) enforces that exactly one model is active at any time. The `config` keys `embedding_model` and `embedding_dimensions` are derived from the registry at startup and are read-only aliases. Switching models: register new model with `active=0`, run `gbrain embed --all` to populate its vec table, then in a single transaction flip `active=0` on old and `active=1` on new. Old table kept for rollback. `gbrain validate --embeddings` checks: (a) exactly one active model exists, (b) all chunks reference the active model, (c) all vec_rowids resolve correctly.
+- **Assertions:** A temporal fact table with provenance (`subject, predicate, object, valid_from, valid_until, supersedes_id, asserted_by, source_ref, evidence_text`). Each assertion has a surrogate `id`. Tier 2 rewrites supersede old assertions by setting `valid_until` on the prior row AND pointing `supersedes_id` to it in the new row. Contradiction detection queries only current beliefs (`valid_until IS NULL`). `valid_from` is nullable (NULL = unknown). Dedup enforced in application logic.
+- **Chunk types:** `page_embeddings.chunk_type` tracks whether a chunk is a `truth_section` or `timeline_entry`. Timeline entries are embedded individually for hyper-specific temporal retrieval.
+- **Palace hierarchy (`wing`, `room`):** Auto-derived from slug by default. `people/pedro-franceschi` → wing: `pedro-franceschi`, room: derived from section headers (State, Assessment, etc.). Override via frontmatter `wing:` and `room:` fields. Wings map to MemPalace's concept of entity groupings; rooms map to topic sub-areas within an entity.
+- **Summary:** Extracted from the first blockquote (`> ...`) in `compiled_truth` during `put`/`ingest`. Used by progressive retrieval to serve lightweight results without loading full pages.
+- **Temporal links (`valid_from`, `valid_until`, `relationship`):** Links carry typed relationships and temporal validity windows. `valid_until IS NULL` = currently active. `valid_from` is nullable (NULL = unknown start date). Each link has a surrogate `id` used by `brain_link_close` for unambiguous targeting. Multiple intervals with unknown start dates are allowed — dedup and non-overlap enforced in application logic.
+- **Freshness timestamps:** `updated_at` bumped on any page-scoped mutation. `truth_updated_at` bumped only when `compiled_truth` changes (Tiers 2-4). `timeline_updated_at` bumped only when timeline content or `timeline_entries` change (Tier 1). Staleness = `timeline_updated_at` > `truth_updated_at` by 30+ days.
+- **Contradictions:** Detected by `gbrain check` (CLI) and `brain_check` (MCP). Stored with `resolved_at` for tracking. Unresolved contradictions surface in briefings and maintenance reports.
+- **Knowledge gaps:** Logged by `brain_gap` (MCP) when `brain_query` returns no results or only low-confidence matches (below configurable threshold). **Privacy-safe by default:** only a SHA-256 `query_hash` is stored at detection time; raw `query_text` is `NULL` until explicitly approved. `confidence_score` stores the highest search score from the triggering query. **Sensitivity is always `internal` at creation — `brain_gap` does not accept a sensitivity parameter.** Escalation to `redacted` or `external` requires a separate `brain_gap_approve` call that records `approved_by`, `approved_at`, and optionally populates `query_text` and `redacted_query` (the anonymised version for `redacted` mode). A CHECK constraint enforces that `query_text` can only be non-NULL when an approval audit trail exists. The research skill (`skills/research/SKILL.md`) refuses external calls for any gap without an approval record. When a gap is resolved via ingest, `resolved_at` and `resolved_by_slug` are set. Unresolved gaps surface in briefings alongside contradictions.
+
+---
+
+## CLI Reference
+
+The CLI is a thin dispatcher. Each command maps to a handler in `src/commands/`.
+
+```
+USAGE:
+    gbrain [OPTIONS] <COMMAND>
+
+OPTIONS:
+    --db <PATH>      Path to brain.db [env: GBRAIN_DB] [default: ./brain.db]
+    --json           Output JSON instead of human-readable text
+    --version        Print version
+    --tools-json     Print MCP tool discovery JSON
+
+COMMANDS:
+    init [PATH]                     Create a new brain.db
+    get <SLUG>                      Read a page by slug
+    put <SLUG> [FILE]               Write/update a page (stdin or file)
+    search <QUERY>                  FTS5 full-text search
+    query <QUESTION>                Hybrid semantic search (FTS5 + vector, set-union merge)
+      --depth <LEVEL>               summary|section|full|auto [default: auto]
+      --token-budget <N>            Max tokens to return [default: from config]
+      --wing <WING>                 Filter to specific palace wing
+    ingest <FILE>                   Ingest a source document
+      --type <TYPE>                 meeting|article|doc|conversation
+    link <FROM> <TO>                Create cross-reference
+      --context <TEXT>              Sentence containing the link
+      --relationship <TYPE>         Relationship type (works_at, founded, invested_in, board_member, related)
+      --valid-from <DATE>           When relationship started (ISO 8601)
+      --valid-until <DATE>          When relationship ended (NULL = still current)
+    link-close <LINK_ID>              Close a temporal link interval by ID
+      --valid-until <DATE>          When relationship ended (required)
+    links <SLUG>                    List all outbound links with IDs (for discovering link IDs)
+      --temporal <current|historical|all>  Filter by temporal state [default: all]
+      --json                        Include link IDs, valid_from, valid_until in output
+    unlink <FROM> <TO>              Remove cross-reference entirely
+      --relationship <TYPE>         Specific relationship to remove (default: all)
+    backlinks <SLUG>                Show pages that link TO this slug (includes link IDs)
+      --temporal <current|historical|all>  Filter by temporal state [default: current]
+    graph <SLUG>                    N-hop neighborhood graph (pages + links as JSON)
+      --depth <N>                   Hops from center node [default: 2]
+      --temporal <current|historical|all>  Filter links by temporal state [default: current]
+      --limit <N>                   Max nodes to return [default: 50]
+    check [SLUG]                    Run contradiction detection
+      --all                         Check entire brain
+      --type <temporal|cross_page|stale>  Filter by check type
+    gaps                            List unresolved knowledge gaps
+      --limit <N>                   Max results [default: 20]
+      --resolved                    Include resolved gaps
+    tags <SLUG>                     List tags for a page
+    tag <SLUG> <TAG>                Add a tag
+    untag <SLUG> <TAG>              Remove a tag
+    timeline <SLUG>                 Show timeline entries
+    timeline-add <SLUG>             Add a structured timeline entry
+      --date <YYYY-MM-DD>           Date of entry (required)
+      --summary <TEXT>              One-line summary (required)
+      --source <SOURCE>             Source identifier (e.g. "meeting/123")
+      --detail <TEXT>               Full markdown detail
+    list                            List pages with filters
+      --type <TYPE>                 Filter by page type
+      --tag <TAG>                   Filter by tag
+      --limit <N>                   Max results [default: 50]
+      --sort <updated|created|title> Sort order [default: updated]
+    stats                           Brain statistics
+    export [--dir <PATH>]           Export to markdown directory [default: ./export/]
+      --raw --import-id <ID>        Byte-exact export from specific import batch
+    import <DIR>                    Import from markdown directory
+    compact                         Checkpoint WAL → single file (for transport/backup)
+    embed [<SLUG>]                  Generate/regenerate embeddings
+      --all                         Embed all pages
+      --stale                       Only pages updated since last embedding
+    config get <KEY>                Read a config value
+    config set <KEY> <VALUE>        Write a config value
+    config list                     List all config
+    serve                           Start MCP server (stdio transport)
+    call <TOOL> <JSON>              Raw tool call (GL pattern)
+    pipe                            JSONL pipe mode (one JSON object per line)
+    validate                        Run integrity checks on brain.db
+      --links                       Check link interval non-overlap, temporal ordering
+      --assertions                  Check assertion dedup, supersession chains
+      --embeddings                  Check all chunks have valid vec_rowids in active model
+      --all                         Run all integrity checks
+    skills                          List active skills (embedded + external)
+    skills doctor                   Verify skill resolution, show versions/hashes
+    version                         Version info
+```
+
+### DB path resolution
+
+1. `--db /path/to/brain.db` flag (highest priority)
+2. `GBRAIN_DB` environment variable
+3. `./brain.db` in current directory (default)
+
+### Output formats
+
+- **Default:** Human-readable markdown/text (Claude-friendly)
+- **`--json`:** JSON for programmatic use
+- **`gbrain pipe`:** JSONL streaming mode
+- **`gbrain --tools-json`:** MCP tool discovery format (compatible with Claude Code tool use)
+
+### Usage examples
+
+```bash
+# Create a new brain
+$ gbrain init ~/my-brain.db
+
+# Import existing markdown directory
+$ gbrain import /data/brain/ --db ~/brain.db
+Importing 7,471 files...
+  people:    1,222 pages
+  companies:   847 pages
+  deals:       234 pages
+  ...
+  links: 14,329 cross-references extracted
+  raw_data: 892 sidecar files loaded
+  timeline_entries: 23,441 entries parsed
+Done. brain.db: 487MB
+Generating embeddings (7,471 pages, section strategy)...
+  Embedded 22,847 chunks in 3m 14s
+brain.db (with embeddings): 521MB
+Validation: 7,471 files → 7,471 pages ✓
+
+# Full-text search
+$ gbrain search "River AI"
+people/ali-partovi.md    (score: 12.3)  ...River AI board member since 2024...
+companies/river-ai.md    (score: 45.7)  ...River AI is building...
+
+# Semantic query
+$ gbrain query "who knows Jensen Huang?"
+Searching 7,471 pages (FTS5 + vec0, set-union merge)...
+people/ali-partovi.md      — mentioned NVIDIA partnership (score: 0.89)
+people/ilya-sutskever.md   — co-presented at NeurIPS (score: 0.84)
+people/marc-andreessen.md  — board connection via Meta (score: 0.81)
+
+# Read a page
+$ gbrain get people/pedro-franceschi
+---
+title: Pedro Franceschi
+type: person
+...
+---
+# Pedro Franceschi
+> Co-founder and CEO of Brex. YC alum (W17)...
+
+# Write/update a page
+$ cat updated-pedro.md | gbrain put people/pedro-franceschi
+
+# Stats
+$ gbrain stats
+Pages: 7,471
+  people:    1,222
+  companies:   847
+  deals:       234
+  ...
+Links: 14,329
+Tags: 8,892
+Raw data: 892
+Timeline entries: 23,441
+Embeddings: 22,847 chunks (bge-small-en-v1.5)
+DB size: 521MB
+
+# Start MCP server
+$ gbrain serve
+GigaBrain MCP server running (stdio)
+Model: bge-small-en-v1.5 (384-dim, local)
+DB: /Users/garry/brain.db (521MB, 7471 pages)
+Tools: search, get, put, ingest, link, query, timeline, tags, list, stats
+```
+
+---
+
+## MCP Server
+
+### Transport
+
+Stdio (standard MCP). The client spawns `gbrain serve` as a subprocess and communicates via stdin/stdout JSON-RPC 2.0.
+
+### Claude Code config (`~/.claude/mcp.json`)
+
+```json
+{
+  "mcpServers": {
+    "gbrain": {
+      "command": "gbrain",
+      "args": ["serve", "--db", "/path/to/brain.db"]
+    }
+  }
+}
+```
+
+### Tools
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| `brain_search` | FTS5 full-text search | `{ query: string, type?: string, wing?: string, limit?: number }` |
+| `brain_query` | Hybrid search (SMS + set-union + progressive retrieval) | `{ question: string, depth?: "summary"\|"section"\|"full"\|"auto", token_budget?: number, wing?: string, limit?: number }` |
+| `brain_get` | Read a page by slug | `{ slug: string }` |
+| `brain_put` | Write/update a page (auto-extracts summary + palace metadata) | `{ slug: string, content: string, expected_version: number, assertions?: Array<{subject, predicate, object, valid_from?, asserted_by?, source_ref?, evidence_text?}> }` or `{ slug: string, compiled_truth?: string, timeline_append?: string, frontmatter?: object, expected_version: number }` |
+| `brain_ingest` | Ingest a source document — **single transactional mutation** | `{ content: string, source_type: string, source_ref: string, force?: boolean, pages: Array<{slug, content, expected_version, assertions?, links?, timeline_entries?, tags?}> }` |
+| `brain_link` | Create a new link interval (returns link ID) | `{ from: string, to: string, relationship?: string, context?: string, valid_from?: string, page_version: number }` |
+| `brain_links` | List outbound links with IDs | `{ slug: string, temporal?: "current"\|"historical"\|"all" }` |
+| `brain_link_close` | Close an existing link interval by ID | `{ link_id: number, valid_until: string, page_version: number }` |
+| `brain_unlink` | Remove cross-reference entirely | `{ from: string, to: string, relationship?: string, page_version: number }` |
+| `brain_timeline` | Get timeline entries | `{ slug: string, limit?: number }` |
+| `brain_timeline_add` | Add timeline entry | `{ slug: string, date: string, summary: string, source?: string, detail?: string, page_version: number }` |
+| `brain_tags` | List tags for a page | `{ slug: string }` |
+| `brain_tag` | Add/remove tag | `{ slug: string, tag: string, remove?: boolean, page_version: number }` |
+| `brain_list` | List pages with filters | `{ type?: string, tag?: string, wing?: string, limit?: number, sort?: string }` |
+| `brain_backlinks` | Pages linking to a slug (temporal filtering) | `{ slug: string, temporal?: "current"\|"historical"\|"all" }` |
+| `brain_graph` | N-hop neighborhood graph (pages + links as JSON) | `{ slug: string, depth?: number, temporal?: "current"\|"historical"\|"all", limit?: number }` |
+| `brain_check` | Run contradiction detection | `{ slug?: string, type?: "temporal"\|"cross_page"\|"stale", resolve?: string }` |
+| `brain_gap` | Log a knowledge gap (always created as `internal` — no caller override) | `{ query_text: string, context?: string, confidence_score?: number }` |
+| `brain_gap_approve` | Escalate gap sensitivity (audited — records approver + timestamp) | `{ gap_id: number, sensitivity: "redacted"\|"external", approver: string, redacted_query?: string }` |
+| `brain_gaps` | List unresolved knowledge gaps | `{ limit?: number, include_resolved?: boolean }` |
+| `brain_stats` | Brain statistics (includes contradiction + gap counts) | `{}` |
+| `brain_raw` | Read/write raw enrichment data | `{ slug: string, source?: string, data?: object, page_version: number }` |
+
+**Concurrency Model:**
+
+- **`brain_put`** requires `expected_version`. Mismatch → MCP Tool Error (conflict). Agent must `brain_get`, merge, retry.
+- **`brain_ingest`** is a single server-side transactional mutation. The agent passes all page updates, links, timeline entries, assertions, and tags in one call. The server wraps everything in a SQLite transaction, checks `expected_version` for each page, and either commits all or rolls back all. This eliminates the window where side tables (links, timeline, tags) can desync from page content.
+- **All page-scoped mutators** (`brain_link`, `brain_unlink`, `brain_timeline_add`, `brain_tag`, `brain_raw`) require `page_version`. The server verifies it matches before mutating and bumps `pages.version` on success. Mismatch → same conflict error as `brain_put`. No write path bypasses the version check.
+
+### Resources
+
+| Resource | URI | Description |
+|----------|-----|-------------|
+| Page | `brain://pages/{slug}` | Full page content as markdown |
+| Index | `brain://index` | All page slugs grouped by type |
+
+### Prompts
+
+| Prompt | Description |
+|--------|-------------|
+| `brain_briefing` | Compile a briefing from current brain state |
+| `brain_ingest_meeting` | Guide for ingesting a meeting transcript |
+
+---
+
+## Hybrid Search (Exact-Match Short-Circuit + Set-Union)
+
+The core search experience uses a 4-step pipeline designed to prevent semantic noise from burying exact keyword matches. FTS5 + vector fan-out, merged using **set-union** (default) or RRF (fallback). Palace-style pre-filtering narrows the search space. SMS (exact-match short-circuit) ensures title/slug matches always rank first.
+
+### Why set-union over RRF
+
+UNC's AutoResearchClaw pipeline (Apr 2026) tested RRF-style score re-ranking and found it **degrades performance** — score-based re-ranking disrupts the semantic ordering that dense retrieval already established. Their discovery: set-union merging (keep vector ranking intact, append BM25-only results) delivered +44% F1 in a single iteration on LoCoMo benchmark. Ablation confirmed: removing the BM25 hybrid component = -14% F1. The sparse results add value, but only when they don't interfere with dense ranking.
+
+Config: `search_merge_strategy` in the config table. Default `set-union`, fallback `rrf` for A/B testing on different corpora.
+
+### Algorithm
+
+```
+query = "who knows Jensen Huang?"
+
+Step 0: Palace pre-filter (intent classification)
+──────────────────────────────────────────────────
+Classify query intent → target wing(s) + room(s).
+Rule-based: extract entity names from query, match against page slugs/titles.
+If match found: constrain Steps 1-2 to matching wing(s).
+If no match: search all pages (no filter).
+
+Example: "who knows Jensen Huang?" → wing filter: '%jensen-huang%'
+Example: "what's our thesis on River AI?" → wing filter: '%river-ai%'
+Example: "all YC founders in batch W25" → no wing filter (cross-cutting query)
+
+When an LLM agent is driving the query (via MCP), the agent can pass explicit
+wing/room filters based on skills/query/SKILL.md guidance.
+
+Step 1: SMS (Exact-Match Short-Circuit) — ABSOLUTE RANKING
+────────────────────────────────────────────────────────────────
+-- If the query exactly matches a page title or slug, it jumps to the top.
+-- This prevents semantic fuzziness from burying the obvious result.
+SELECT id, title, slug FROM page_fts
+WHERE title MATCH ? OR slug MATCH ?
+LIMIT 5;
+-- Result: exact_results[] — these appear first in the final output, always.
+
+Step 2: Vector similarity search (candle + sqlite-vec) — PRIMARY RANKING
+────────────────────────────────────────────────────────────────
+-- Embed the query with pure-Rust candle (local, in-process)
+query_embedding = candle_embed("who knows Jensen Huang?")
+
+-- Resolve active model's vec table from the embedding_models registry
+-- (e.g. active model = 'bge-small-en-v1.5' → vec_table = 'page_embeddings_vec_384')
+active_model = SELECT name, vec_table FROM embedding_models WHERE active = 1;
+
+-- cosine similarity via sqlite-vec, with optional palace filter
+-- NOTE: vec table name is resolved at runtime from active_model.vec_table
+-- Join key: pev.rowid = pe.vec_rowid (NOT pe.id — id is internal metadata key)
+SELECT pe.page_id, pe.chunk_text,
+       vec_distance_cosine(pev.embedding, ?) AS vec_score
+FROM {active_model.vec_table} pev
+JOIN page_embeddings pe ON pev.rowid = pe.vec_rowid
+                       AND pe.model = {active_model.name}
+JOIN pages p ON pe.page_id = p.id
+WHERE (? IS NULL OR p.wing LIKE ?)  -- palace filter (NULL = no filter)
+ORDER BY vec_score
+LIMIT 50;
+
+-- Deduplicate: if same page_id appears multiple times, keep highest-scoring chunk
+-- Result: vec_results[] with original ranking preserved
+
+Step 3: FTS5 keyword search — SUPPLEMENTARY
+────────────────────────────────────────────
+SELECT pages.id, pages.slug, pages.title,
+       bm25(page_fts) AS fts_score
+FROM page_fts
+JOIN pages ON pages.id = page_fts.rowid
+WHERE page_fts MATCH ?
+  AND (? IS NULL OR pages.wing LIKE ?)  -- same palace filter
+ORDER BY fts_score
+LIMIT 50;
+
+-- Result: fts_results[]
+
+Step 4: Set-union merge (default)
+──────────────────────────────────
+-- Start with SMS exact matches (always first)
+merged = exact_results.clone()
+
+-- Then vector results in their original order (primary ranking)
+for result in vec_results:
+    if result.page_id NOT IN merged:
+        merged.append(result)
+
+-- Then FTS5-only results (those NOT in vector set) at the end
+for result in fts_results:
+    if result.page_id NOT IN merged:
+        merged.append(result)
+
+-- Apply lightweight boosts only to break ties within the appended FTS-only set:
+--   +0.01 if page type matches question intent
+--   +0.01 if updated_at within last 30 days
+
+Step 4 (alt): RRF merge (fallback, config: search_merge_strategy = "rrf")
+───────────────────────────────────────────────────────────────────────────
+SMS exact matches still go first. Then for remaining pages, compute:
+  rrf_score = 1/(k + rank_vec) + 1/(k + rank_fts)
+  where k = 60  (standard RRF constant)
+If a page appears in only one set: rrf_score = 1/(k + rank)
+Sort by rrf_score DESC.
+
+Step 5: Final ranking + fetch
+──────────────────────────────
+Top results returned with:
+  - slug
+  - title
+  - summary (executive blockquote — for progressive retrieval Stage 1)
+  - relevant excerpt (chunk_text from best-matching vector chunk, or FTS snippet)
+  - score
+  - type
+  - wing, room
+
+For deeper results, see Progressive Retrieval below.
+```
+
+### Palace filtering impact
+
+MemPalace's published ablation: base retrieval at 60.9% R@5 → 94.8% with wing+room filtering (+34%). gbrain's palace filter is derived from slug structure rather than a separate palace DB, but the principle is identical: constrain the search space before running expensive similarity queries.
+
+### Performance targets
+
+- SMS exact match: < 5ms (FTS5 title/slug lookup)
+- Palace filter classification: < 5ms (regex match against slug index)
+- FTS5 search: < 50ms for 100K pages
+- Vector search: < 200ms for 50K chunks (sqlite-vec with float32[384])
+- Full hybrid query (SMS + palace + vector + FTS5 + merge): < 250ms
+- Embedding generation (query): < 20ms (BGE-small-en-v1.5 via candle on CPU, already loaded)
+
+---
+
+## Progressive Retrieval
+
+Token-budget-gated expansion. Instead of returning full pages and hoping the agent handles context management, gbrain controls how much content it serves based on a configurable token budget.
+
+### Why this matters
+
+OMNIMEM's ablation (AutoResearchClaw, Apr 2026): removing progressive retrieval = -17% F1 — the largest single component contribution. agentmemory reports 92% fewer tokens vs dumping everything into context. The pattern: serve summaries first, expand on demand, stop when the budget is consumed.
+
+### Depth levels
+
+| Level | What's returned | Tokens per result | Use case |
+|-------|----------------|-------------------|----------|
+| `summary` | Title + executive summary blockquote | ~50-100 | Quick scan, "do we know this person?" |
+| `section` | Best-matching chunk from vector search | ~200-500 | Targeted retrieval, "what's the latest on X?" |
+| `full` | Complete `compiled_truth` | ~500-2000 | Deep read, preparing for a meeting |
+| `auto` | Start at summary, expand top results until token budget consumed | varies | Default — agent doesn't need to choose |
+
+### Token budget
+
+Default: 4000 tokens (configurable in `config` table as `default_token_budget`). Override per-query via the `token_budget` parameter.
+
+### Algorithm (auto mode)
+
+```
+1. Run hybrid search → ranked results[]
+2. For each result (in rank order):
+   a. Include summary (title + blockquote). Add to running token count.
+   b. If token_budget - running_count > 500:
+      Include best-matching section/chunk. Add to running count.
+   c. If token_budget - running_count > 1500 AND result is top-3:
+      Include full compiled_truth. Add to running count.
+   d. If running_count >= token_budget: stop expanding, return.
+3. Return results with their expansion level noted.
+```
+
+### MCP integration
+
+The `brain_query` tool gains `depth` and `token_budget` parameters:
+
+```json
+{
+  "question": "who knows Jensen Huang?",
+  "token_budget": 4000,
+  "depth": "auto",
+  "wing": null
+}
+```
+
+Response includes expansion metadata:
+
+```json
+{
+  "results": [
+    {
+      "slug": "people/ali-partovi",
+      "title": "Ali Partovi",
+      "depth": "full",
+      "summary": "Co-founder of Neo. NVIDIA board connection via...",
+      "content": "...full compiled_truth...",
+      "score": 0.89,
+      "tokens_used": 1200
+    },
+    {
+      "slug": "people/ilya-sutskever",
+      "title": "Ilya Sutskever",
+      "depth": "section",
+      "summary": "Co-founder of SSI. Previously Chief Scientist at OpenAI...",
+      "content": "...best matching chunk...",
+      "score": 0.84,
+      "tokens_used": 450
+    }
+  ],
+  "total_tokens": 3800,
+  "budget_remaining": 200
+}
+
+---
+
+## Ingest Pipeline
+
+```
+Source document (meeting notes, article, transcript)
+            │
+            ▼
+    gbrain ingest <file> --type meeting
+            │
+            ├─→ Begin ingest transaction
+            │     - Compute stable ingest key: SHA-256(source file content)
+            │     - BEGIN TRANSACTION
+            │     - SELECT from ingest_log WHERE ingest_key = ? → if exists, ROLLBACK + skip
+            │     - All writes below happen inside this transaction
+            │     - ingest_log row is INSERT'd at the end, inside the same transaction
+            │     - COMMIT writes everything atomically (mutations + log row)
+            │     - Crash before COMMIT → full rollback, key never persists, retry starts clean
+            │
+            ├─→ Parse source (Claude Code reads ingest/SKILL.md, follows workflow)
+            │     - Identify: participants, companies, topics, decisions, action items
+            │
+            ├─→ For each entity mentioned (four-tier consolidation):
+            │     ├─ gbrain get <slug>   → exists? update using tier rules:
+            │     │     Tier 1: Append raw evidence to timeline (ALWAYS — never gated by novelty)
+            │     │     Tier 2: Novelty check THEN update State section facts if changed
+            │     │       ├─ Jaccard similarity vs existing compiled_truth
+            │     │       │   > 0.85 → skip derived rewrite (duplicate content)
+            │     │       ├─ Embedding cosine similarity vs existing chunks
+            │     │       │   > 0.95 → warn (near-duplicate, allow override with --force)
+            │     │       └─ Below thresholds → proceed with Tiers 2-4
+            │     │     Tier 3: Re-evaluate Assessment concepts if facts shifted
+            │     │     Tier 4: Rewrite executive summary blockquote if picture changed
+            │     └─ doesn't exist?     → gbrain put <slug> (create from template)
+            │     Note: page writes use optimistic concurrency — each page has a version
+            │     counter; the update fails if the version changed since read (concurrent
+            │     agent detected). The caller retries from the read step.
+            │
+            ├─→ Extract summary from first blockquote → pages.summary field
+            │
+            ├─→ Derive palace metadata
+            │     wing: from slug (people/pedro → pedro-franceschi)
+            │     room: from section headers or frontmatter override
+            │
+            ├─→ Extract and create links (with temporal metadata)
+            │     gbrain link <from> <to> --relationship "works_at" --valid-from "2024-01-15" --context "sentence..."
+            │
+            ├─→ Add structured timeline entries
+            │     gbrain timeline-add <slug> --date YYYY-MM-DD --summary "..."
+            │     Dedupe: (page_id, date, summary_hash) UNIQUE constraint prevents replay duplicates
+            │
+            ├─→ Update embeddings for modified pages
+            │     gbrain embed <slug>   (or --stale to batch)
+            │
+            ├─→ Auto-log to ingest_log table (keyed by ingest SHA)
+            │
+            └─→ Commit transaction
+```
+
+The `gbrain ingest` command receives the raw source file. The actual intelligence — how to parse a meeting transcript, which entities get pages, how to rewrite compiled_truth, when to append vs rewrite — lives in `skills/ingest/SKILL.md`. The binary handles novelty checking (Jaccard + cosine, scoped to Tiers 2-4 only — Tier 1 evidence is never suppressed) and palace metadata derivation. Everything else is skill-driven.
+
+### Novelty check implementation
+
+```rust
+fn check_novelty(new_content: &str, existing_page: &Page, db: &Connection) -> NoveltyResult {
+    // 1. Jaccard similarity between new compiled_truth and existing
+    let jaccard = jaccard_similarity(new_content, &existing_page.compiled_truth);
+    if jaccard > 0.85 {
+        return NoveltyResult::DuplicateDerived;   // skip Tiers 2-4 (derived rewrites)
+    }                                              // Tier 1 (timeline/links) ALWAYS proceeds
+
+    // 2. Embedding cosine similarity between new content and existing chunks
+    let query_embedding = embed(new_content);
+    let max_sim = max_chunk_similarity(&query_embedding, existing_page.id, db);
+    if max_sim > 0.95 {
+        return NoveltyResult::NearDuplicate;  // warn on Tiers 2-4, proceed with --force
+    }                                         // Tier 1 ALWAYS proceeds
+
+    NoveltyResult::Novel                      // all tiers proceed
+}
+```
+
+**Critical invariant:** Novelty checks only gate derived rewrites (Tiers 2-4: State, Assessment, summary). Tier 1 (raw timeline evidence, links, assertions) is **always** written regardless of similarity score. This prevents silent evidence loss from recurring meetings or incremental notes where compiled_truth looks similar but new timeline events contain material information.
+
+Jaccard similarity uses token-level overlap (whitespace-split, lowercased). Fast and effective for detecting copy-paste or minimal-edit duplicates. The embedding check catches semantic duplicates where wording differs but meaning is identical.
+
+---
+
+## Migration Plan
+
+Importing an existing markdown brain (7,471 files at `/data/brain/`):
+
+### Type mapping
+
+```
+Directory prefix → page type:
+  people/      → person
+  companies/   → company
+  deals/       → deal
+  yc/          → yc
+  civic/       → civic
+  projects/    → project
+  concepts/    → concept
+  originals/   → original
+  sources/     → source
+  media/       → media
+  meetings/    → source
+  programs/    → source
+  decisions/   → decision
+  commitments/ → commitment
+  actions/     → action_item
+```
+
+### Parse algorithm
+
+```rust
+fn parse_markdown_file(content: &str, file_path: &Path) -> ParsedPage {
+    // 1. Extract YAML frontmatter (between first --- and second ---)
+    let (frontmatter_str, body) = split_frontmatter(content);
+    let frontmatter: serde_yaml::Value = serde_yaml::from_str(&frontmatter_str)?;
+
+    // 2. Split body at first horizontal rule (--- on its own line, after frontmatter)
+    //    This separates compiled_truth from timeline
+    let (compiled_truth, timeline) = match body.find("\n---\n") {
+        Some(idx) => (body[..idx].trim(), body[idx + 5..].trim()),
+        None      => (body.trim(), ""),
+    };
+
+    // 3. Extract slug from file path
+    //    /data/brain/people/pedro-franceschi.md → "people/pedro-franceschi"
+    let slug = file_path
+        .strip_prefix(base_dir)?
+        .with_extension("")
+        .to_string_lossy()
+        .to_string();
+
+    ParsedPage { slug, frontmatter, compiled_truth, timeline }
+}
+```
+
+### Link extraction
+
+```rust
+// Wiki-style links: [Display Text](../people/name.md)
+// Convert to slugs: "people/name"
+let link_re = Regex::new(r"\[([^\]]+)\]\((\.\./)?([[\w/-]+)\.md\)")?;
+
+// For each match: record from_slug, to_slug, surrounding sentence as context
+// Resolve relative paths against the source file's directory
+```
+
+### Timeline parsing
+
+```rust
+// Timeline line format: - **YYYY-MM-DD** | Source — Summary. Detail.
+let timeline_re = Regex::new(
+    r"^- \*\*(\d{4}-\d{2}-\d{2})\*\*\s*\|\s*([^—]+)—\s*(.+)$"
+)?;
+// Each match → { date, source, summary }
+// Multi-line continuation (indented) → detail field
+```
+
+### Sidecar files
+
+```rust
+// For people/pedro-franceschi.md, check people/.raw/pedro-franceschi.json
+// Format: { "sources": { "crustdata": {...}, "happenstance": {...} } }
+// → raw_data rows: (page_id, "crustdata", JSON), (page_id, "happenstance", JSON)
+```
+
+### Transaction safety
+
+```rust
+conn.execute("BEGIN TRANSACTION", [])?;
+// Insert all pages
+// Insert all tags (after all pages exist for FK resolution)
+// Insert all links (resolve slugs → page IDs)
+// Insert timeline entries
+// Insert raw data
+conn.execute("COMMIT", [])?;
+```
+
+### Embedding generation (post-import)
+
+```bash
+$ gbrain embed --all
+```
+
+Chunks `compiled_truth` at `##` header boundaries (section strategy, `chunk_type: 'truth_section'`).
+Chunks `timeline` at individual entries — each `- **YYYY-MM-DD**` line becomes its own chunk (`chunk_type: 'timeline_entry'`). This prevents long timelines from becoming a single oversized chunk and enables hyper-specific temporal retrieval ("What did X do in March 2024?").
+- Pages without headers: chunk at ~500-token boundaries
+- Target: ~200-800 tokens per truth section chunk, ~50-200 per timeline entry
+- BGE-small-en-v1.5 on CPU: ~7,500 pages × ~3 chunks avg = ~22,500 embeddings
+- Estimated time: 3-5 minutes on Apple Silicon, 8-12 minutes on Intel
+
+### Validation
+
+```bash
+# Count pages in DB vs files on disk — must match
+# Count links vs parsed wiki links — must match
+# Spot-check 10 random pages: export → diff against original
+# Report any discrepancies
+$ gbrain import /data/brain/ --validate-only   # dry-run validation without writing
+```
+
+### Special files
+
+- `index.md` → stored in `config` table as `original_index`
+- `log.md` → parsed and inserted into `ingest_log` table
+- `schema.md` → stored in `config` table as `original_schema`
+- `README.md` → ignored during import
+
+---
+
+## Export and Round-trip
+
+The export command reconstructs the directory structure from DB state. The round-trip
+contract is **semantic equivalence**, not byte-for-byte identity — frontmatter key
+ordering, trailing whitespace, and YAML formatting may differ from the original source.
+
+To support rollback and diffing, import stores the raw source bytes of every file in
+`raw_imports` (keyed by page_id + import_id). These are **immutable snapshots** — they
+are never updated when pages are mutated after import. This is intentional: raw exports
+represent the state at import time, not current state.
+
+**Important:** `--raw` export requires `--import-id` and only emits bytes from that
+specific import batch. There is no "current state" raw export — use normalized export
+for current state. This prevents the dangerous split-brain where raw export silently
+discards post-import edits.
+
+```rust
+fn export_page(page: &Page, mode: ExportMode) -> String {
+    match mode {
+        // Raw mode: byte-for-byte faithful to a specific import batch (required)
+        ExportMode::Raw { import_id } => {
+            get_raw_import(&page.id, &import_id)
+                .expect("no raw snapshot for this page in the specified import batch")
+        }
+        // Normalized mode: reconstructed from current DB columns (default)
+        ExportMode::Normalized => export_normalized(page),
+    }
+}
+
+fn export_normalized(page: &Page) -> String {
+    // 1. Reconstruct YAML frontmatter from frontmatter JSON
+    let frontmatter = serde_yaml::to_string(
+        &serde_json::from_str::<serde_yaml::Value>(&page.frontmatter)?
+    )?;
+
+    // 2. Reconstruct body
+    let mut body = page.compiled_truth.clone();
+    if !page.timeline.is_empty() {
+        body.push_str("\n\n---\n\n");
+        body.push_str(&page.timeline);
+    }
+
+    // 3. Combine
+    format!("---\n{}---\n\n{}\n", frontmatter, body)
+}
+
+// Write to: <export-dir>/<slug>.md
+// Reconstruct .raw/ sidecars from raw_data table
+// Regenerate index.md from page list
+```
+
+### Round-trip validation
+
+```bash
+# Semantic validation (default): normalized fields must match
+$ gbrain export --dir /tmp/brain-export/
+$ gbrain validate --original /data/brain/ --exported /tmp/brain-export/
+# Checks: same pages, same frontmatter keys/values, same compiled_truth, same timeline entries
+
+# Byte-exact validation: requires --import-id (raw exports are immutable snapshots)
+$ gbrain export --raw --import-id <ID> --dir /tmp/brain-export-raw/
+$ diff -r /data/brain/ /tmp/brain-export-raw/   # should be empty
+
+# --raw without --import-id is an error (prevents accidental stale-byte export)
+$ gbrain export --raw --dir /tmp/brain-export-raw/
+# Error: --raw requires --import-id. Use normalized export for current state.
+```
+
+Semantic validation is the primary correctness test. Byte-exact round-trip is available
+via `--raw` for rollback scenarios but is not the default contract.
+
+---
+
+## Skills (Fat Markdown)
+
+Skills live in `skills/` at the repo root. Each is a standalone SKILL.md that Claude Code, OpenClaw, or any agent reads and follows. No logic is compiled into the binary.
+
+---
+
+### skills/ingest/SKILL.md
+
+```markdown
+---
+name: gbrain-ingest
+description: |
+  Ingest meetings, articles, docs, and conversations into the brain.
+  Follows the compiled truth + timeline architecture: update existing
+  pages with new info, create pages for new entities, maintain cross-references.
+---
+
+# Ingest Skill
+
+## Workflow
+
+1. **Read the source.** Meeting transcript, article, document, conversation log.
+   Identify: participants, companies, topics, decisions, commitments, action items.
+
+2. **For each entity mentioned (four-tier consolidation):**
+   - `gbrain get <slug>` — does a page exist? Note the `version` number.
+   - **If yes:** Apply tier-by-tier update:
+     - **Tier 1 (Raw Evidence):** Append to timeline. Always. The exact words, dates, sources. Never summarised. → `gbrain timeline-add`
+     - **Tier 2 (Extracted Facts):** Update State section with structured assertions derived from evidence. Rewrite when facts change. Extract strict factual assertions (roles, statuses, locations) for the `assertions` table. When a fact changes, set `valid_until` on the old assertion before inserting the new one. → e.g., `{subject: "Pedro Franceschi", predicate: "is_ceo_of", object: "Brex", valid_from: "2018-01-01"}`
+     - **Tier 3 (Synthesised Concepts):** Re-evaluate Assessment section if underlying facts shifted. Cross-reference patterns across linked pages. → e.g., "Brex's leadership team has been stable since 2024, with Pedro driving the enterprise pivot"
+     - **Tier 4 (Narrative Intelligence):** Rewrite executive summary blockquote ONLY if the overall picture changed. This is the one-sentence answer to "what do we know and why does it matter?" → e.g., `> Pedro Franceschi runs Brex. Strong enterprise traction.`
+     - `gbrain put <slug>` with updated content, `expected_version` from step 2, and `assertions` array. If ConflictError, re-read and merge. The system auto-extracts the summary from the blockquote and derives palace metadata.
+   - **If no:** Create page using the appropriate template (see templates below).
+     `gbrain put <slug>` with new content and `assertions`.
+
+3. **Extract work-context entities.**
+   - For each **decision** made: create/update a `decisions/<slug>` page. Link to stakeholders and projects.
+     Record assertion: `{subject: "<decision-slug>", predicate: "decided_by", object: "<person>", valid_from: "<date>"}`
+   - For each **commitment** with an owner and deadline: create/update a `commitments/<slug>` page.
+     Record assertion: `{subject: "<person>", predicate: "committed_to", object: "<deliverable>", valid_from: "<date>"}`
+     If a prior commitment shifted (new deadline, changed scope), set `valid_until` on the old assertion and create a new one. Update the commitment page's State section.
+   - For each **action item** assigned: create/update an `actions/<slug>` page.
+   - Link all work-context entities to the people, companies, and projects involved.
+
+4. **Extract and create links (with temporal metadata).**
+   - For every entity-to-entity reference:
+     `gbrain link <from> <to> --relationship "works_at" --valid-from "2024-01-15" --context "..."`.
+   - Links are bidirectional in meaning but stored directionally. Create both if both pages exist.
+   - When evidence shows a relationship ended, close the specific interval by its link ID:
+     `gbrain link-close <link_id> --valid-until "2026-03-01"`.
+     The link ID is returned by `brain_link` on creation and by `brain_backlinks` on query.
+     The binary enforces non-overlapping intervals: rejects close if it would create overlap.
+
+5. **Parse timeline entries.**
+   - For each datable event in the source:
+     `gbrain timeline-add <slug> --date YYYY-MM-DD --summary "..." --source "meeting/123"`
+
+6. **Log the ingest.**
+   - The system auto-logs to ingest_log. Verify with `gbrain stats`.
+
+7. **Refresh embeddings.**
+   - After all puts: `gbrain embed --stale`
+   - This ensures search reflects the new content immediately.
+
+8. **Handle raw data.**
+   - If the source includes structured data (API responses, JSON):
+     `gbrain call brain_raw '{"slug":"...","source":"meeting","data":{...}}'`
+
+## Entry criteria
+
+Not everything gets a page. The bar:
+- Anyone you met 1:1 or in a small group: YES
+- YC staff, partners, active batch founders: YES
+- Companies discussed in deal context: YES
+- **Decisions** that affect multiple people or projects: YES
+- **Commitments** with a specific owner and deadline: YES
+- **Action items** assigned to a person with a due date: YES
+- Casual mentions with no substance: NO
+- Vague intentions without owner or deadline: NO (wait until they crystallize)
+- Create the page only if its existence serves future retrieval.
+
+## Quality rules
+
+- Executive summary (blockquote at top) must reflect latest state
+- State section gets REWRITTEN, not appended to
+- Timeline is append-only, reverse-chronological (newest first)
+- Open Threads: add new items, remove resolved ones (move to timeline)
+- Every wiki link uses relative path format: `[Name](../people/name.md)`
+
+## Source attribution format
+
+Every fact in compiled_truth needs inline source citation with full provenance. A tweet reference without a URL is a broken citation — this is the #1 failure mode at scale.
+
+Standard format:
+```
+[Source: User, direct message, 2026-04-07]
+[Source: Meeting "Team Sync" #12345, 2026-04-03](meetings/2026-04-03-team-sync.md)
+[Source: X/@handle, topic, 2026-04-05](https://x.com/handle/status/ID)
+[Source: email from Name re Subject, 2026-04-05]
+[Source: Crustdata LinkedIn enrichment, 2026-04-07]
+[Source: Wall Street Journal, 2026-04-05](https://wsj.com/...)
+```
+
+### Source authority hierarchy
+
+When sources conflict, note the contradiction in compiled_truth with BOTH citations. Never silently pick one.
+
+1. **User's direct statements** (highest authority)
+2. **Primary sources** (meetings, emails, direct conversations)
+3. **Enrichment APIs** (Crustdata, Happenstance, Captain)
+4. **Web search results**
+5. **Social media posts** (lowest — require URL, context, date)
+
+## Filing disambiguation
+
+When filing entities, apply these rules to prevent duplicate pages in wrong categories:
+
+| Question | Answer |
+|----------|--------|
+| Could you teach it as a framework? | → `concepts/` |
+| Is it the user's own idea, synthesis, or observation? | → `originals/` |
+| Could you build it, but nobody is working on it yet? | → Use `ideas/` directory (stored as `project` type with `status: idea` frontmatter) |
+| Is someone actively building it? | → `projects/` |
+| About them as a human? | → `people/` |
+| About the organisation? | → `companies/` (both pages link to each other) |
+| Nothing fits? | → Flag for human review. The schema may need to evolve. |
+
+**Key rule for originals:** Capture the user's EXACT phrasing. The language IS the insight. Use their words for the slug. `meatsuit-maintenance-tax.md` not `biological-needs-maintenance-overhead.md`. The vividness IS the concept.
+
+## Page templates
+
+### Person
+
+```markdown
+---
+title: First Last
+type: person
+tags: []
+linkedin: ""
+twitter: ""
+score: 0
+---
+# First Last
+
+> [Executive summary in one sentence.]
+
+## State
+
+**As of YYYY-MM-DD:** [What we know now. Current role, context, relationship status.]
+
+## Assessment
+
+[Intelligence assessment. What makes this person interesting or relevant.]
+
+## Open Threads
+
+- [ ] [Action item or open question]
+
+---
+
+## Timeline
+
+- **YYYY-MM-DD** | meeting — [What happened]
+```
+
+#### Optional enrichment sections (Tier 1 contacts — 5+ interactions)
+
+For high-engagement contacts, expand the person template with these sections between Assessment and Open Threads when evidence supports them. Don't add speculatively — each section requires direct observation or sourced claims.
+
+```markdown
+## What They Believe
+- [Belief] — observed: [source, date]
+- [Belief] — self-described: [interview/bio, date]
+- [Belief] — inferred: [pattern across N interactions, confidence: high/medium/low]
+
+## What They're Building
+Current projects, recent ships, product direction.
+
+## Hobby Horses
+Topics they return to obsessively across conversations.
+
+## Trajectory
+Ascending, plateauing, pivoting, declining? Evidence-based, not speculative.
+
+## Network
+- **Close to:** People frequently seen with
+- **Crew:** Which cluster or community
+```
+
+### Company
+
+```markdown
+---
+title: Company Name
+type: company
+tags: []
+domain: ""
+linkedin: ""
+stage: ""
+---
+# Company Name
+
+> [What they do in one sentence.]
+
+## State
+
+**As of YYYY-MM-DD:** [Current status, funding, relevant context.]
+
+## Assessment
+
+[Thesis, opportunity, concerns.]
+
+---
+
+## Timeline
+
+- **YYYY-MM-DD** | source — [Event]
+```
+
+### Decision
+
+```markdown
+---
+title: "Decision: [Short description]"
+type: decision
+tags: []
+date: YYYY-MM-DD
+status: active           # active | superseded | reversed
+stakeholders: []         # slugs of people involved
+---
+# Decision: [Short description]
+
+> [One-sentence summary of what was decided and why.]
+
+## Context
+
+**Decided YYYY-MM-DD** by [who]. Discussed in [meeting/thread/email].
+
+[What problem this solves. What alternatives were considered.]
+
+## Implications
+
+- [What changes as a result]
+- [What depends on this holding]
+
+## Open Threads
+
+- [ ] [Follow-up or risk to monitor]
+
+---
+
+## Timeline
+
+- **YYYY-MM-DD** | meeting — Original decision made
+```
+
+### Commitment
+
+```markdown
+---
+title: "Commitment: [Who] → [What] by [When]"
+type: commitment
+tags: []
+owner: ""                # slug of person who committed
+due: YYYY-MM-DD
+status: open             # open | completed | shifted | dropped
+---
+# Commitment: [Who] → [What] by [When]
+
+> [Owner] committed to [deliverable] by [date]. Status: [open/completed/shifted/dropped].
+
+## State
+
+**As of YYYY-MM-DD:** [Current status. On track? Shifted? Why?]
+
+## Context
+
+Made during [meeting/conversation]. Linked to [decision/project].
+
+---
+
+## Timeline
+
+- **YYYY-MM-DD** | meeting — Commitment made
+```
+
+### Action Item
+
+```markdown
+---
+title: "Action: [Short description]"
+type: action_item
+tags: []
+owner: ""                # slug of person responsible
+due: YYYY-MM-DD
+status: open             # open | done | blocked | dropped
+priority: normal         # low | normal | high | urgent
+---
+# Action: [Short description]
+
+> [Owner] to [do what] by [when]. Priority: [level].
+
+## Context
+
+From [meeting/conversation/decision]. Blocked by: [nothing / dependency].
+
+---
+
+## Timeline
+
+- **YYYY-MM-DD** | source — Created
+```
+
+### Original (user's own thinking)
+
+```markdown
+---
+title: "[Exact user phrasing]"
+type: original
+tags: []
+origin: ""               # meeting, conversation, shower thought, riff on [concept]
+confidence: high         # high | medium | low | speculative
+---
+# [Exact user phrasing]
+
+> [One-sentence summary of the original idea in the user's voice.]
+
+## The Idea
+
+[Full articulation. Use the user's exact words wherever possible.
+The language IS the insight — preserve phrasing, metaphors, and framing.]
+
+## Why It Matters
+
+[What this connects to. What it explains. What it predicts.]
+
+## Connections
+
+- Shaped by: [people who influenced the thinking]
+- Played out at: [companies/projects where it applied]
+- Discussed in: [meetings/conversations]
+- Builds on: [other originals, concepts]
+
+---
+
+## Timeline
+
+- **YYYY-MM-DD** | source — First articulated
+```
+```
+
+---
+
+### skills/query/SKILL.md
+
+```markdown
+---
+name: gbrain-query
+description: |
+  Answer questions from the brain using FTS5 + semantic search + structured queries.
+  Synthesize across multiple pages. Cite sources.
+---
+
+# Query Skill
+
+## Strategy: Four-layer search
+
+1. **Palace-filtered hybrid search** — `gbrain query "<question>" --wing "<entity>"` —
+   the primary search path. Set-union merging with palace pre-filtering.
+   Best for: most questions. The wing filter narrows the search space before
+   vector + FTS5 run, dramatically improving precision.
+
+2. **FTS5 keyword search** — `gbrain search "<query>"` — fast, exact matches.
+   Best for: names, company names, specific terms, known slugs.
+
+3. **Semantic vector search** — `gbrain query "<question>"` (no wing filter) — meaning-based.
+   Best for: cross-cutting queries where the entity isn't known upfront.
+
+4. **Structured queries** — `gbrain list --type person --tag yc-alum` +
+   `gbrain backlinks <slug> --temporal current` — relational navigation.
+   Best for: "all YC founders in batch W25", "who currently works at X?"
+
+## Workflow
+
+1. Decompose the question into search strategies.
+2. Identify target wing(s) from entity names in the question.
+3. Run hybrid query with palace filter and progressive retrieval:
+   `gbrain query "<question>" --wing "<entity>" --depth auto --token-budget 4000`
+4. Review summaries first (Tier 4 narrative). Expand to sections/full only if needed.
+5. For temporal questions, check link validity:
+   `gbrain backlinks <slug> --temporal current` vs `--temporal historical`
+6. Before surfacing, verify with contradiction check:
+   `gbrain check <slug>` — flag any unresolved contradictions in the answer.
+7. Synthesize answer with citations: `[Pedro Franceschi](people/pedro-franceschi)`
+8. If the answer is valuable enough to persist, consider creating a new source page.
+
+## When you don't know
+
+Say so. "The brain doesn't have info on X" is better than hallucinating.
+Suggest enrichment: "Want me to research X and add them?"
+```
+
+---
+
+### skills/maintain/SKILL.md
+
+```markdown
+---
+name: gbrain-maintain
+description: |
+  Periodic brain maintenance. Find contradictions, stale info, orphan pages,
+  missing cross-references. Keep the knowledge graph healthy.
+---
+
+# Maintain Skill
+
+## Lint checks (run every few days)
+
+1. **Contradiction detection** — Run `gbrain check --all` to detect:
+   - **Link vs Assertion:** Current assertions (`valid_until IS NULL`) like `(Pedro, is_ceo, Brex)` where the link to `companies/brex` has a `valid_until` in the past. Pure SQL join.
+   - **Temporal contradictions:** Page says "left X in 2025" but link to X has no `valid_until`. Compiled_truth dates vs link validity windows.
+   - **Cross-page contradictions:** Multiple current assertions (`valid_until IS NULL`) with the same subject+predicate but different objects across pages. Superseded assertions (with `valid_until` set) are excluded — they're history, not contradictions.
+   - **Staleness:** Pages where `timeline_updated_at` > `truth_updated_at` by 30+ days. These need Tier 2-4 rewrites.
+   All findings stored in the `contradictions` table. Surface unresolved items in briefings.
+
+2. **Stale info** — Pages where `timeline_updated_at` > `truth_updated_at` by 30+ days.
+   Compiled truth is stale relative to new evidence. These need Tier 2 consolidation.
+
+3. **Orphan pages** — `gbrain backlinks <slug>` = 0 inbound links.
+   Either add links from related pages or flag for deletion.
+
+4. **Missing cross-references** — Scan compiled_truth for mentions of known
+   page titles that aren't formally linked. Add via `gbrain link` with relationship type.
+
+5. **Dead links** — For each link, verify both pages still exist.
+
+6. **Temporal link audit** — Links with `valid_until IS NULL` where evidence
+   suggests the relationship ended. Flag for invalidation.
+
+7. **Open thread audit** — Items older than 30 days. Resolved items
+   still listed as open.
+
+8. **Tag consistency** — Normalize: lowercase, hyphens. Merge near-duplicates.
+
+9. **Palace metadata audit** — Pages with empty `wing` or `room` fields.
+   Derive from slug structure and section headers.
+
+10. **Embedding freshness** — Pages updated since last embedding:
+    `gbrain embed --stale`
+
+## Output
+
+Write maintenance report:
+`gbrain put sources/maintenance-YYYY-MM-DD` with findings and actions taken.
+Include: contradictions found/resolved, stale pages rewritten, orphans linked/flagged, temporal links invalidated.
+```
+
+---
+
+### skills/enrich/SKILL.md
+
+```markdown
+---
+name: gbrain-enrich
+description: |
+  Enrich person and company pages from external sources.
+  Crustdata, Happenstance, Exa, Captain (Pitchbook). Validation rules enforced.
+---
+
+# Enrich Skill
+
+## Sources
+
+| Source | Best for | Auth |
+|--------|----------|------|
+| Crustdata | LinkedIn profile data (90+ fields) | API key |
+| Happenstance | Career history, network search | Credits |
+| Exa | Web search, articles, mentions | API key |
+| Captain/Pitchbook | Company financials, deals, investors | API key |
+
+## Person enrichment workflow
+
+1. Find LinkedIn URL (frontmatter, contacts, or Happenstance search)
+2. Hit Crustdata: `GET /screener/person/enrich?linkedin_profile_url=...`
+   - Auth: `Token` (NOT Bearer!)
+3. Validate before writing:
+   - Connection count < 20 → likely wrong person. Save raw_data with flag, don't update page.
+   - Name mismatch (different last name) → skip.
+4. Store raw: `gbrain call brain_raw '{"slug":"people/name","source":"crustdata","data":{...}}'`
+5. Distill to page: update compiled_truth with location, title, company, career arc, top skills.
+   DO NOT dump full 90-field data into the page.
+
+## Batch rules
+
+- Checkpoint every 20 items
+- Exponential backoff on 429s: 10s → 20s → 40s → ... → 5min cap
+- Dry-run: `--dry-run` shows what would be enriched
+- Never re-enrich already-enriched pages (check raw_data table first)
+```
+
+---
+
+### skills/briefing/SKILL.md
+
+```markdown
+---
+name: gbrain-briefing
+description: |
+  Compile a daily briefing from brain state plus real-time sources.
+  What changed, what's coming, who's waiting, what needs attention.
+---
+
+# Briefing Skill
+
+## Briefing structure
+
+1. **Calendar** — Today's meetings. For each: pull brain pages for participants using progressive retrieval (`--depth summary`).
+2. **Active deals** — `gbrain list --type deal --tag active`
+3. **Commitments due** — `gbrain list --type commitment --tag open` filtered to due within 7 days. Flag overdue.
+4. **Action items** — `gbrain list --type action_item --tag open` sorted by priority + due date.
+5. **What shifted overnight** — Query assertions where `valid_until` was set in the last 24h (superseded facts, shifted commitments, reversed decisions). This is the "overnight shift report."
+6. **Open threads** — Scan pages for time-sensitive Open Threads items.
+7. **Unresolved contradictions** — `gbrain check --all` → surface any unresolved items from the `contradictions` table.
+8. **Recent brain changes** — `gbrain list --sort updated` filtered to last 24h.
+9. **People in play** — Person pages updated in last 7 days with score ≥ 3.
+10. **Stale alerts** — Pages flagged by maintain skill (including temporal link issues).
+
+## Output
+
+Write briefing to `sources/briefing-YYYY-MM-DD`.
+Return formatted markdown suitable for Telegram delivery.
+Alert-worthy items are handled by the alerts skill, not the briefing.
+```
+
+---
+
+### skills/alerts/SKILL.md
+
+```markdown
+---
+name: gbrain-alerts
+description: |
+  Interrupt-driven notification thresholds. Defines what warrants an
+  immediate push notification vs. waiting for the next scheduled briefing.
+  Pairs with the briefing skill — briefing is pull, alerts are push.
+---
+
+# Alerts Skill
+
+## Alert tiers
+
+### Immediate alert (push via Telegram within minutes)
+- High-priority entity first appears (e.g. RIFT first post, major competitor launch)
+- Extreme price moves (BTC +/-15% in an hour, portfolio company token event)
+- Legislative/regulatory events (CLARITY Act floor vote, SEC filing deadline)
+- Commitment overdue by 24h+ with no update
+- Contradiction detected on a page updated in last 24h (active deal or person)
+
+### Next briefing (include in next scheduled digest)
+- New followers or engagement on our posts
+- Non-urgent replies to monitored threads
+- Routine enrichment completions
+- Knowledge gaps detected by `brain_gap`
+- Stale pages flagged by maintain skill
+
+### Silent log (no notification, recorded in timeline)
+- Routine social media engagement
+- Minor price moves within normal range
+- Link saves and bookmarks
+- Background enrichment data updates
+
+## How it works
+
+1. Events arrive via agent monitoring (cron, webhooks, MCP tools).
+2. Agent classifies event against the tier definitions above.
+3. **Immediate:** Format for Telegram delivery (short, no markdown tables, action-oriented). Push immediately.
+4. **Next briefing:** Write to `sources/alerts-queue-YYYY-MM-DD` for the briefing skill to pick up.
+5. **Silent:** Write to relevant page timeline via `gbrain timeline-add`. No notification.
+
+## Customisation
+
+Alert thresholds are in this skill file, not in the binary. Adjust tiers by editing this file.
+The agent should surface its classification reasoning if borderline ("I classified this as next-briefing because...").
+```
+
+---
+
+### skills/research/SKILL.md
+
+```markdown
+---
+name: gbrain-research
+description: |
+  Resolve knowledge gaps logged by brain_gap. Run on schedule or on demand.
+  Respects sensitivity classification: internal gaps resolved from existing
+  brain only, redacted gaps anonymised before external queries, external gaps
+  may use web search and enrichment APIs. Default sensitivity is internal.
+---
+
+# Research Skill
+
+## Workflow
+
+1. **Read gap log.** `gbrain gaps` — list unresolved knowledge gaps.
+
+2. **Prioritise.** Rank by:
+   - Age (older gaps first — they've been unresolved longest)
+   - Context (gaps from high-priority queries rank higher)
+   - Frequency (same query_text appearing multiple times = high demand)
+
+3. **Check sensitivity classification and approval before researching.**
+
+   | Sensitivity | Approval required? | Allowed research methods |
+   |-------------|-------------------|------------------------|
+   | `internal` (default) | No | Search existing brain pages only (`brain_query`, `brain_search`). No network calls. If the brain can't answer it, leave the gap unresolved and note "requires external research — escalate sensitivity via `brain_gap_approve` to proceed." |
+   | `redacted` | Yes (`brain_gap_approve` with `approved_by`, `redacted_query`) | External search permitted using ONLY the `redacted_query` stored in the approval record (entity names, deal terms, dollar amounts stripped). **Never send the original `query_text` externally.** If no `redacted_query` exists in the approval record, refuse and ask for one. |
+   | `external` | Yes (`brain_gap_approve` with `approved_by`) | External search permitted with the original query text. Use only for non-sensitive topics (public companies, open-source projects, general concepts). |
+
+   **Hard rule:** The research skill MUST verify that `approved_by IS NOT NULL AND approved_at IS NOT NULL` before any external call. If the approval record is missing (which shouldn't happen due to the CHECK constraint, but defense in depth), treat as `internal`.
+
+4. **Research each gap (per sensitivity rules above).**
+   - `internal`: re-query brain with alternate phrasing, check backlinks, scan related pages
+   - `redacted`/`external`: Web search (Exa, Brave) for the (redacted or original) query text
+   - If entity-related: check enrichment APIs (Crustdata, Happenstance) — `external` only
+   - If topic-related: search for recent articles, papers, threads
+   - Compile findings into a draft page or update to existing page
+
+4. **Ingest findings.** Follow `skills/ingest/SKILL.md` — standard four-tier consolidation.
+   - New entity discovered → create page via `gbrain put`
+   - Existing entity enriched → update via `brain_ingest` with `expected_version`
+   - Topic research → create `concepts/` or `sources/` page
+
+5. **Resolve gap.** After successful ingest:
+   - The system marks the gap resolved with the slug of the page that filled it
+   - If research yields nothing useful, add a note to the gap context and leave unresolved
+   - Re-check after 7 days (topics evolve, new sources appear)
+
+6. **Report.** Write research summary to `sources/research-YYYY-MM-DD` for audit trail.
+
+## When to run
+
+- **Scheduled:** Daily, after the morning briefing compile. Process top 5 unresolved gaps.
+- **On demand:** Agent notices a gap during conversation and wants to fill it immediately.
+- **Batch:** Weekly deep run — process all gaps older than 3 days.
+
+## Quality rules
+
+- Never fabricate. If research yields no results, say so.
+- Cite every source using the standard attribution format (see ingest skill).
+- Prefer primary sources over social media summaries.
+- If a gap is genuinely unanswerable (e.g. "what is X planning internally?"), mark it as `context: "unanswerable — requires insider access"` and leave unresolved.
+```
+
+---
+
+### skills/upgrade/SKILL.md
+
+```markdown
+---
+name: gbrain-upgrade
+description: |
+  Agent-guided upgrade path for the gbrain binary and skills.
+  Inspired by Garry Tan's v0.8.0 "just ask your agent to upgrade" pattern.
+  The skill file IS the upgrade guide — the binary handles mechanics.
+---
+
+# Upgrade Skill
+
+## Pre-upgrade checklist
+
+1. **Check current version:** `gbrain version`
+2. **Record the resolved DB path:** `echo "${GBRAIN_DB:-./brain.db}"` — needed for rollback.
+3. **Stop MCP server if running:** `pgrep -f "gbrain serve" && echo "STOP: kill gbrain serve before upgrading"`
+4. **Backup:** `gbrain compact` then manual backup if desired (the binary creates its own WAL-safe backup during migration)
+5. **Validate current state:** `gbrain validate --all` — fix any issues before upgrading
+6. **Check for new version:** query GitHub releases API for latest version tag
+7. **Record current binary path:** `which gbrain` — needed for rollback
+
+## Upgrade steps
+
+1. **Download new binary to a staging path (NOT directly to the install location):**
+   ```bash
+   TARGET_VERSION="v0.2.0"  # always pin an explicit version, never use 'latest' unverified
+   PLATFORM="$(uname -s | tr A-Z a-z)-$(uname -m)"
+   STAGING="/tmp/gbrain-${TARGET_VERSION}"
+
+   # Download binary and checksum file
+   curl -fsSL "https://github.com/[owner]/gbrain/releases/download/${TARGET_VERSION}/gbrain-${PLATFORM}" \
+     -o "${STAGING}"
+   curl -fsSL "https://github.com/[owner]/gbrain/releases/download/${TARGET_VERSION}/gbrain-${PLATFORM}.sha256" \
+     -o "${STAGING}.sha256"
+   ```
+
+2. **Verify integrity before installing:**
+   ```bash
+   # Verify SHA-256 checksum matches published hash
+   echo "$(cat ${STAGING}.sha256)  ${STAGING}" | shasum -a 256 --check
+   # If check fails: STOP. Do not install. Report the mismatch.
+   ```
+
+3. **Preserve the current binary for rollback, then install:**
+   ```bash
+   INSTALL_PATH="$(which gbrain)"
+   cp "${INSTALL_PATH}" "${INSTALL_PATH}.rollback"
+   cp "${STAGING}" "${INSTALL_PATH}" && chmod +x "${INSTALL_PATH}"
+   ```
+
+4. **Run migrations:** `gbrain version` — the binary auto-migrates on startup if needed.
+   It creates a WAL-safe backup via `VACUUM INTO` to `brain.db.backup-v{N}` before any schema migration.
+   Migration does not proceed until backup succeeds.
+
+5. **Validate post-migration:**
+   - `gbrain validate --all` — all integrity checks pass
+   - `gbrain stats` — page counts match pre-upgrade
+   - `gbrain embed --stale` — re-embed any pages affected by model changes
+
+6. **Update skills:** Pull latest `skills/` from the repo. External skill files
+   in the working directory override embedded defaults.
+   `gbrain skills doctor` — verify resolution order and content hashes.
+
+7. **Verify round-trip:** `gbrain import --validate-only` if upgrading from a version
+   with schema changes. Confirms no data loss.
+
+8. **Clean up:** Remove staging file and rollback binary if everything passed.
+   ```bash
+   rm -f "${STAGING}" "${STAGING}.sha256"
+   # Keep rollback binary for 7 days, then clean: rm "${INSTALL_PATH}.rollback"
+   ```
+
+9. **Report:** Tell the user what changed — version number, any schema migrations run,
+   any skills updated, any action required.
+
+## Rollback
+
+If anything goes wrong:
+
+1. **Stop all clients.** Ensure no `gbrain serve` process is running. Check:
+   `pgrep -f "gbrain serve"` — kill any running MCP servers before restoring.
+
+2. **Restore prior binary:**
+   `cp "$(which gbrain).rollback" "$(which gbrain)"`
+
+3. **Restore pre-migration DB backup (WAL-safe):**
+   The backup file is the resolved DB path — respect `--db`/`GBRAIN_DB` if set.
+   ```bash
+   # Resolve the actual DB path (same logic as the binary uses)
+   DB_PATH="${GBRAIN_DB:-./brain.db}"
+
+   # Delete WAL sidecars — they contain post-migration state that would
+   # replay into the restored backup and corrupt the rollback.
+   rm -f "${DB_PATH}-wal" "${DB_PATH}-shm"
+
+   # Restore the backup over the actual DB path
+   cp "${DB_PATH}.backup-v{N}" "${DB_PATH}"
+   ```
+   **Critical:** You MUST delete `-wal` and `-shm` before restoring. Without this,
+   SQLite will replay the WAL on next open, re-applying the migration you're trying to undo.
+
+4. **Verify:** `gbrain version` — should show the pre-upgrade version.
+   `gbrain validate --all` — confirm DB integrity.
+
+5. Report what failed for debugging.
+
+## CI release requirements
+
+Every GitHub release MUST publish:
+- Platform binaries: `gbrain-linux-x86_64`, `gbrain-darwin-arm64`, etc.
+- SHA-256 checksums: `gbrain-linux-x86_64.sha256`, `gbrain-darwin-arm64.sha256`, etc.
+- Each `.sha256` file contains the hex digest only (no filename), one line.
+- The release workflow generates checksums in CI, not locally, to prevent tampering.
+```
+
+---
+
+## Repository Structure
+
+```
+gbrain/
+├── README.md               # Project overview + quick start
+├── CLAUDE.md               # Claude Code session instructions
+├── AGENTS.md               # Generic agent session instructions
+├── LICENSE                 # MIT
+├── Cargo.toml
+├── Cargo.lock
+│
+├── bin/                    # Compiled binaries (gitignored, built in CI)
+│   ├── gbrain-darwin-arm64
+│   ├── gbrain-darwin-x86_64
+│   └── gbrain-linux-x86_64
+│
+├── src/
+│   ├── main.rs             # Entry point: arg parsing + command dispatch (clap)
+│   ├── commands/
+│   │   ├── mod.rs
+│   │   ├── get.rs
+│   │   ├── put.rs
+│   │   ├── search.rs
+│   │   ├── query.rs
+│   │   ├── ingest.rs
+│   │   ├── link.rs
+│   │   ├── tags.rs
+│   │   ├── timeline.rs
+│   │   ├── list.rs
+│   │   ├── stats.rs
+│   │   ├── export.rs
+│   │   ├── import.rs
+│   │   ├── embed.rs
+│   │   ├── graph.rs        # N-hop neighborhood traversal
+│   │   ├── gaps.rs         # Knowledge gap list/management
+│   │   ├── serve.rs
+│   │   ├── call.rs
+│   │   ├── init.rs
+│   │   ├── config.rs
+│   │   └── version.rs
+│   ├── core/
+│   │   ├── mod.rs
+│   │   ├── db.rs           # Database: open(), schema init, WAL, sqlite-vec load
+│   │   ├── fts.rs          # FTS5: search_fts(query, wing_filter) → ranked results
+│   │   ├── inference.rs    # candle init, embed(text), search_vec(query, k, wing_filter)
+│   │   ├── search.rs       # hybrid_search(query): SMS + palace filter + FTS5 + vec + set-union merge
+│   │   ├── progressive.rs  # progressive_retrieve(results, token_budget, depth) → expanded results
+│   │   ├── novelty.rs      # check_novelty(content, page): Jaccard + cosine dedup
+│   │   ├── assertions.rs   # heuristic contradiction detection via assertions table
+│   │   ├── graph.rs        # neighborhood_graph(slug, depth): N-hop BFS over links table
+│   │   ├── gaps.rs         # knowledge gap detection and resolution tracking
+│   │   ├── chunking.rs     # temporal sub-chunking: truth sections + timeline entries
+│   │   ├── palace.rs       # derive_wing(slug), derive_room(content), classify_intent(query)
+│   │   ├── markdown.rs     # parse_frontmatter(), split_content(), extract_summary(), render_page()
+│   │   ├── links.rs        # extract_links(), resolve_slug(), temporal validity
+│   │   ├── migrate.rs      # import_dir(), export_dir(), validate_roundtrip()
+│   │   └── types.rs        # Page, Link, Tag, TimelineEntry, SearchResult, Contradiction, KnowledgeGap, etc.
+│   ├── mcp/
+│   │   ├── mod.rs
+│   │   └── server.rs       # MCP stdio server: tool definitions + handlers
+│   └── schema.sql          # DDL (embedded in db.rs via include_str!, also standalone)
+│
+├── skills/
+│   ├── ingest/SKILL.md
+│   ├── query/SKILL.md
+│   ├── maintain/SKILL.md
+│   ├── enrich/SKILL.md
+│   ├── briefing/SKILL.md
+│   ├── alerts/SKILL.md
+│   ├── research/SKILL.md
+│   └── upgrade/SKILL.md
+│
+├── benchmarks/
+│   ├── longmemeval.rs      # LongMemEval multi-session memory (R@5 ≥ 85%)
+│   ├── locomo.rs           # LoCoMo conversational memory (F1 regression)
+│   ├── beir_subset.rs      # BEIR retrieval regression (nDCG@10)
+│   ├── ragas_eval.rs       # Ragas answer quality (context_precision, recall)
+│   └── datasets/           # gitignored, downloaded by prep script
+│
+├── tests/
+│   ├── roundtrip_semantic.rs # import → normalized export → semantic validate (MUST pass)
+│   ├── roundtrip_raw.rs     # import → raw export by import_id → byte-exact diff (MUST pass)
+│   ├── fts.rs              # FTS5 search correctness
+│   ├── inference.rs        # candle embedding + vector search quality
+│   ├── links.rs            # link extraction + temporal interval enforcement
+│   ├── mcp.rs              # MCP tool call correctness
+│   └── fixtures/
+│       ├── person.md
+│       ├── company.md
+│       └── .raw/person.json
+│
+└── .github/
+    └── workflows/
+        ├── ci.yml          # cargo test + cargo build --release
+        └── release.yml     # cross-compile matrix → GitHub release assets
+```
+
+### CLAUDE.md (embedded)
+
+```markdown
+# GigaBrain
+
+Personal knowledge brain. SQLite + FTS5 + local vector embeddings. One binary.
+
+## Architecture
+
+Thin CLI (src/main.rs) dispatches to commands (src/commands/).
+Core library (src/core/) handles DB, search, embeddings, markdown parsing.
+Skills (skills/) are fat markdown files - all intelligence lives there.
+
+## Key files
+
+- `src/core/db.rs`         — rusqlite connection, schema init, WAL, sqlite-vec load
+- `src/core/fts.rs`        — FTS5 search: `search_fts(query, wing_filter, db)` → ranked results
+- `src/core/inference.rs`  — candle model init, `embed(text)`, `search_vec(query, k, wing_filter, db)`
+- `src/core/search.rs`     — `hybrid_search(query, db)`: SMS + palace filter + FTS5 + vec + set-union merge
+- `src/core/progressive.rs`— `progressive_retrieve(results, budget, depth)`: token-budget expansion
+- `src/core/novelty.rs`    — `check_novelty(content, page, db)`: Jaccard + cosine dedup
+- `src/core/assertions.rs`  — `check_assertions(slug, db)`: heuristic contradiction detection via SQL
+- `src/core/graph.rs`      — `neighborhood_graph(slug, depth, db)`: N-hop BFS over links table
+- `src/core/gaps.rs`       — `log_gap(query, context, score, db)`, `list_gaps(db)`: knowledge gap tracking
+- `src/core/chunking.rs`   — temporal sub-chunking: truth sections + individual timeline entries
+- `src/core/palace.rs`     — `derive_wing(slug)`, `derive_room(content)`, `classify_intent(query)`
+- `src/core/markdown.rs`   — parse frontmatter, split compiled_truth/timeline, extract_summary, render
+- `src/mcp/server.rs`      — MCP stdio server exposing all tools (including brain_graph, brain_gap, brain_check)
+
+## Build
+
+```bash
+cargo build --release
+# Output: target/release/gbrain (~90MB with embedded model weights)
+
+# Cross-compile
+cargo install cross
+cross build --release --target aarch64-apple-darwin
+cross build --release --target x86_64-unknown-linux-musl
+```
+
+## Test
+
+```bash
+cargo test
+# Key tests: tests/roundtrip_semantic.rs (normalized export validate) + tests/roundtrip_raw.rs (byte-exact diff by import_id).
+```
+
+## Embedding model
+
+BGE-small-en-v1.5 via candle (pure Rust). 384 dimensions. Model weights embedded
+into binary by default via include_bytes!(). Truly zero-dependency, no network
+required. For smaller binary with on-demand download: `--features online-model`.
+
+## Skills
+
+Read skills/ before doing brain operations. They contain all workflow logic.
+```
+
+---
+
+## Build and Release
+
+### Cargo.toml (core dependencies)
+
+```toml
+[package]
+name = "gbrain"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "gbrain"
+path = "src/main.rs"
+
+[dependencies]
+# CLI
+clap = { version = "4", features = ["derive"] }
+
+# Database - bundled = SQLite compiled into binary, no system dep
+rusqlite = { version = "0.31", features = ["bundled"] }
+
+# sqlite-vec - vector search as SQLite extension, statically linked
+sqlite-vec = "0.1"   # or inline via rusqlite loadable extension
+
+# Embeddings - pure Rust ML, no ONNX runtime, true static linking
+candle-core = "0.8"
+candle-nn = "0.8"
+candle-transformers = "0.8"
+safetensors = "0.4"
+tokenizers = "0.20"
+
+# MCP server
+rmcp = "0.1"
+
+# Serialization
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+serde_yaml = "0.9"
+
+# Markdown
+pulldown-cmark = "0.11"
+
+# Regex
+regex = "1"
+
+# Async runtime (for MCP server)
+tokio = { version = "1", features = ["full"] }
+
+# Error handling
+anyhow = "1"
+thiserror = "1"
+
+[features]
+default = ["bundled", "embed-model"]
+bundled = ["rusqlite/bundled"]
+embed-model = []                         # include_bytes!() model weights into binary (default)
+online-model = []                        # download weights on first run instead
+```
+
+### Build commands
+
+```bash
+# Development
+cargo build
+
+# Release (optimized)
+cargo build --release
+
+# Release with embedded model weights (~90MB binary, zero first-run download) — default
+cargo build --release
+
+# Run tests
+cargo test
+
+# Cross-compile — candle enables true musl static linking
+cross build --release --target aarch64-apple-darwin          # macOS ARM
+cross build --release --target x86_64-apple-darwin           # macOS Intel
+cross build --release --target x86_64-unknown-linux-musl     # Linux x86_64 (static)
+cross build --release --target aarch64-unknown-linux-musl    # Linux ARM64 (static)
+
+# Install locally
+cargo install --path .
+```
+
+### CI/CD (GitHub Actions)
+
+```yaml
+# .github/workflows/release.yml
+strategy:
+  matrix:
+    include:
+      - target: aarch64-apple-darwin
+        os: macos-latest
+      - target: x86_64-apple-darwin
+        os: macos-latest
+      - target: x86_64-unknown-linux-musl    # static binary — no glibc dependency
+        os: ubuntu-latest
+      - target: aarch64-unknown-linux-musl   # static binary — no glibc dependency
+        os: ubuntu-latest
+
+# Post-build verification (release gate):
+# - run: file target/${{ matrix.target }}/release/gbrain
+# - run: ldd target/${{ matrix.target }}/release/gbrain 2>&1 | grep -q "not a dynamic" || exit 1  # Linux
+# - run: otool -L target/${{ matrix.target }}/release/gbrain | grep -qv "\.dylib" || true           # macOS (system libs OK)
+
+# Post-build: generate SHA-256 checksums for integrity verification
+# - run: shasum -a 256 target/${{ matrix.target }}/release/gbrain | awk '{print $1}' > gbrain-${{ matrix.target }}.sha256
+# Publish both binary and .sha256 file as release assets
+```
+
+Release artifacts published to GitHub Releases on tag push. Each release includes platform binaries and SHA-256 checksum files (generated in CI, not locally). Install via the upgrade skill (see `skills/upgrade/SKILL.md`) which handles version pinning and checksum verification. Quick install for first-time users:
+
+```bash
+VERSION="v0.1.0"
+PLATFORM="darwin-arm64"
+curl -fsSL "https://github.com/[owner]/gbrain/releases/download/${VERSION}/gbrain-${PLATFORM}" -o /tmp/gbrain
+curl -fsSL "https://github.com/[owner]/gbrain/releases/download/${VERSION}/gbrain-${PLATFORM}.sha256" -o /tmp/gbrain.sha256
+echo "$(cat /tmp/gbrain.sha256)  /tmp/gbrain" | shasum -a 256 --check
+cp /tmp/gbrain /usr/local/bin/gbrain && chmod +x /usr/local/bin/gbrain
+```
+
+---
+
+## Phased Delivery
+
+The spec describes the full vision. Build in phases — earn the right to add complexity.
+
+### Phase 1: Core (ship this first)
+
+The smallest thing that proves the value proposition:
+
+- `gbrain init`, `get`, `put`, `list`, `stats`
+- `pages` table with `version`, split timestamps
+- `knowledge_gaps` table (schema only — tools in Phase 3)
+- `original` page type (in type mapping, template in ingest skill)
+- FTS5 search (`gbrain search`)
+- Candle embeddings + sqlite-vec (`gbrain embed`, `gbrain query`)
+- SMS exact-match short-circuit
+- Basic set-union hybrid search (no palace filtering yet)
+- `gbrain import` / `gbrain export` (normalized only)
+- `gbrain compact` (WAL checkpoint)
+- MCP server with `brain_get`, `brain_put`, `brain_query`, `brain_search`, `brain_list`
+- Transactional ingest with idempotency
+- Embedded default skills (including source attribution format and filing disambiguation in ingest skill)
+- Round-trip test, corpus-reality tests, static binary verification
+
+**Ship gate:** imports a real corpus, retrieves correctly, exports faithfully, binary is static.
+
+### Phase 2: Intelligence Layer
+
+- Temporal links (`brain_link`, `brain_link_close`, backlinks with `--temporal`)
+- Graph neighborhood traversal (`brain_graph`, `gbrain graph`)
+- Assertions with provenance
+- Contradiction detection (`gbrain check`)
+- Progressive retrieval with token budgets
+- Novelty checking (Tiers 2-4 gating)
+- Work-context entities (decision, commitment, action_item)
+- Palace wing filtering (validate with benchmarks before committing to room-level)
+- Full MCP write surface with version checks
+- Optional person template enrichment sections (What They Believe, Hobby Horses, Trajectory, Network) for Tier 1 contacts
+
+### Phase 3: Polish + Benchmarks
+
+- Briefing skill with "what shifted" report
+- Alerts skill (interrupt-driven notifications vs scheduled briefings)
+- Research skill (knowledge gap resolution)
+- Knowledge gap detection (`brain_gap`, `brain_gaps` MCP tools, `gbrain gaps` CLI)
+- Upgrade skill (agent-guided binary + skill updates)
+- Enrichment skill
+- LongMemEval, LoCoMo, BEIR, Ragas benchmarks
+- `gbrain skills doctor`
+- `gbrain validate --all` integrity checker
+- `--json` output on all commands
+- `pipe` mode
+- CI/CD release pipeline with all gates
+
+### Deliberate Deferrals
+
+- **First-class chunks table:** The current `page_embeddings` table serves as both chunk metadata and embedding join table. This is intentionally not split into a separate `chunks` table for v1 — the enriched columns (content_hash, token_count, heading_path) are sufficient. If progressive retrieval, re-embedding, or chunk lifecycle management becomes painful at scale, promote chunks to their own table in a future version. This is a deliberate deferral, not an oversight.
+- **Room-level palace filtering:** Deferred until benchmarks on real corpus prove it helps. Wing-only in v1.
+- **LLM-assisted contradiction detection:** Binary stays dumb. Cross-page semantic reasoning happens via the maintain skill.
+- **WASM compilation:** Rust has strong WASM support. PGLite proves browser portability is viable. If we ever need gbrain in a browser or serverless context, WASM is the path. Not a current priority.
+- **Overnight consolidation cycle:** Garry's DREAMS.md pattern (overnight entity sweep, enrichment, citation fixing) is powerful but is agent configuration, not gbrain binary. Could be a skill added post-v1.
+
+---
+
+## Implementation Roadmap
+
+### Week 1 - Foundation
+
+- [ ] `cargo init` + `Cargo.toml` with dependencies
+- [ ] `src/core/types.rs` — Page (with summary, wing, room), Link (with relationship, valid_from, valid_until), Tag, TimelineEntry, SearchResult, Contradiction, KnowledgeGap structs
+- [ ] `src/core/db.rs` — rusqlite connection, schema DDL via `include_str!`, WAL, sqlite-vec load
+- [ ] `src/core/markdown.rs` — `parse_frontmatter()`, `split_content()`, `extract_summary()`, `render_page()`
+- [ ] `src/core/palace.rs` — `derive_wing(slug)`, `derive_room(content)` — auto-derive palace metadata from slug structure and section headers
+- [ ] Unit tests for markdown parsing (round-trip frontmatter, compiled_truth/timeline split, summary extraction)
+- [ ] `src/main.rs` — clap CLI scaffold, command dispatch
+- [ ] `src/commands/init.rs` — create new brain.db (v4 schema with palace + temporal + contradictions + knowledge_gaps)
+- [ ] `src/commands/get.rs` — read page by slug
+- [ ] `src/commands/put.rs` — write/update page (auto-extract summary, auto-derive wing/room)
+- [ ] `src/commands/list.rs` — list pages with filters (including `--wing`)
+- [ ] `src/commands/stats.rs` — brain statistics (including contradiction count)
+- [ ] `src/commands/tags.rs` + tag/untag — tag operations
+- [ ] `src/commands/link.rs` + unlink + backlinks — with `--relationship`, `--valid-from`, `--valid-until`, `--temporal` flags
+
+**Checkpoint:** `gbrain init`, `gbrain put` (with auto-summary/palace), `gbrain get`, `gbrain list`, `gbrain stats`, `gbrain link --relationship works_at --valid-from 2024-01-15` all working.
+
+### Week 2 - Search + Progressive Retrieval
+
+- [ ] `src/core/fts.rs` — FTS5 search logic, BM25 scoring, palace wing/room filter
+- [ ] `src/commands/search.rs` — full-text search command with `--wing` filter
+- [ ] `src/core/inference.rs` — candle model init, `embed(text)`, batch embedding, palace-filtered vector search
+- [ ] `src/core/chunking.rs` — temporal sub-chunking: truth sections at `##` boundaries, timeline entries individually
+- [ ] `src/commands/embed.rs` — generate/refresh embeddings, `--all` and `--stale` flags
+- [ ] `src/core/search.rs` — hybrid search: SMS + palace pre-filter + FTS5 + vec0 fan-out + **set-union merge** (default) with RRF fallback via config flag
+- [ ] `src/core/progressive.rs` — `progressive_retrieve(results, token_budget, depth)`: summary → section → full expansion gated by token budget
+- [ ] `src/commands/query.rs` — semantic query command with `--depth`, `--token-budget`, `--wing` flags
+- [ ] Unit tests for set-union vs RRF merge correctness, progressive retrieval token counting
+
+**Checkpoint:** `gbrain search "River AI"` and `gbrain query "who knows Jensen Huang?" --depth auto --token-budget 4000` both return ranked results with progressive expansion. Set-union merge is default, RRF switchable via `gbrain config set search_merge_strategy rrf`.
+
+### Week 3 - Ingest + MCP + Integrity
+
+- [ ] `src/core/links.rs` — extract wiki-links from markdown, resolve slugs, temporal validity management
+- [ ] `src/core/novelty.rs` — `check_novelty()`: Jaccard similarity + cosine similarity dedup
+- [ ] `src/core/migrate.rs` — `import_dir()`: recursive scan, parse, transaction insert, validate (populate wing/room/summary during import)
+- [ ] `src/commands/import.rs` — full migration command (derive palace metadata for all imported pages)
+- [ ] `src/commands/export.rs` — reconstruct markdown directory
+- [ ] `tests/roundtrip_semantic.rs` — import → normalized export → semantic validate (primary correctness test)
+- [ ] `tests/roundtrip_raw.rs` — import → `export --raw --import-id` → byte-exact diff
+- [ ] `src/commands/timeline.rs` — read timeline entries
+- [ ] `src/commands/ingest.rs` — source document ingestion command (with novelty check, `--force` override)
+- [ ] `src/core/assertions.rs` — heuristic contradiction detection via assertions table: link vs assertion, temporal staleness
+- [ ] `src/core/graph.rs` — `neighborhood_graph(slug, depth, db)`: N-hop BFS over links table with temporal filtering
+- [ ] `src/core/gaps.rs` — `log_gap()`, `list_gaps()`, `resolve_gap()`: knowledge gap tracking
+- [ ] `src/commands/check.rs` — `gbrain check [SLUG] --all --type temporal|cross_page|stale`
+- [ ] `src/commands/graph.rs` — `gbrain graph <SLUG> --depth N --temporal current|historical|all`
+- [ ] `src/commands/gaps.rs` — `gbrain gaps --limit N --resolved`
+- [ ] `src/mcp/server.rs` — MCP stdio server with all tools (including `brain_graph`, `brain_gap`, `brain_gaps`, `brain_check`, progressive `brain_query`, temporal `brain_backlinks`)
+- [ ] `src/commands/serve.rs` — start MCP server
+
+**Checkpoint:** `gbrain import /data/brain/` completes with zero diff (palace metadata populated). `gbrain ingest` rejects duplicates (Jaccard > 0.85). `gbrain check --all` detects temporal contradictions. `gbrain graph people/pedro-franceschi --depth 2` returns the 2-hop neighborhood as JSON. `gbrain serve` connects to Claude Code with all 20 MCP tools.
+
+### Week 4 - Polish + Release
+
+- [ ] `src/commands/call.rs` — raw tool call (GL pattern)
+- [ ] `src/commands/config.rs` — config get/set/list (including `search_merge_strategy`, `default_token_budget`)
+- [ ] `src/commands/version.rs`
+- [ ] `--tools-json` output (MCP tool discovery)
+- [ ] `pipe` mode (JSONL streaming)
+- [ ] `--json` output flag on all commands
+- [ ] Full test suite: fts.rs, inference.rs, links.rs, mcp.rs, novelty.rs, assertions.rs, progressive.rs, palace.rs, chunking.rs, graph.rs, gaps.rs
+- [ ] `skills/` markdown files finalized (four-tier consolidation + source attribution + filing disambiguation in ingest, palace-aware query, contradiction-aware maintain/briefing, alerts, research, upgrade)
+- [ ] `CLAUDE.md`, `AGENTS.md`, `README.md`
+- [ ] CI/CD: `cargo test` + cross-compile matrix → GitHub Releases
+- [ ] `gbrain import --validate-only` dry-run mode
+- [ ] `gbrain embed --stale` incremental re-embedding
+
+**Checkpoint:** Full test suite passes. Cross-compiled binaries on GitHub Releases. Round-trip validated against production brain. Contradiction detection runs clean on imported data.
+
+### Week 5 - Release Gates (corpus-reality first, leaderboards second)
+
+- [ ] `benchmarks/` directory with dataset prep scripts, pinned dataset versions, and evaluation harness
+
+#### Offline CI gates (mandatory, no API keys, fully local)
+
+- [ ] **BEIR (retrieval subset)** — Retrieval regression gate. Runs entirely offline.
+  - Dataset: `https://github.com/beir-cellar/beir` — pin to specific commit hash in `benchmarks/datasets.lock`
+  - Subsets: NQ + FiQA (closest to personal KB workload)
+  - Metrics: nDCG@10. Target: no regression > 2% between releases
+  - Harness: custom Rust binary in `benchmarks/beir_eval.rs` — embeds corpus, runs queries, compares to baseline
+- [ ] **Corpus-reality tests** (see below) — fully local, no LLM judge
+
+#### API-dependent evaluation (optional, run manually or in separate CI job)
+
+- [ ] **LongMemEval** — Multi-session memory benchmark.
+  - Dataset: `https://github.com/xiaowu0162/LongMemEval` — pin commit in `benchmarks/datasets.lock`
+  - Harness: official `evaluate_qa.py` (requires `OPENAI_API_KEY` for LLM judge)
+  - Metrics: R@5 (Recall at 5). Target: ≥ 85%
+  - Adapter: `benchmarks/longmemeval_adapter.py` converts gbrain queries to LongMemEval format
+- [ ] **LoCoMo** — Long conversational memory benchmark.
+  - Dataset: `https://github.com/snap-research/locomo` — pin commit in `benchmarks/datasets.lock`
+  - Harness: official evaluation scripts (API-dependent)
+  - Metrics: F1 on single-iteration retrieval. Target: ≥ +30% over naive FTS5 baseline
+- [ ] **Ragas** — Answer and context quality metrics for progressive retrieval.
+  - Framework: `https://docs.ragas.io/` — pin version in `benchmarks/requirements.txt`
+  - Metrics: context_precision, context_recall, faithfulness
+  - Note: Ragas requires an LLM judge. Use local Ollama model or API key. Results are advisory, not a release gate.
+- [ ] **Corpus-reality tests** — The benchmarks that actually matter for users.
+  - Import a messy real markdown corpus (7K+ files) → verify zero page loss
+  - Retrieve a known entity by name → correct page in top 1 (SMS test)
+  - Retrieve a known fact from timeline → correct entry within top 5 (temporal sub-chunk test)
+  - Ingest the same source twice → no duplicate timeline entries, no duplicate assertions
+  - Ingest two conflicting sources → contradiction detected
+  - Normalized export → reimport → normalized export → semantic diff = zero (idempotent round-trip)
+  - Run 100 queries against imported corpus → measure p50/p95 latency (target: p95 < 250ms)
+- [ ] **Concurrency and crash-safety stress tests** — CI gate for safety invariants.
+  - Parallel writers: 4 threads calling `brain_put` on the same slug with stale `expected_version` → all but one must get ConflictError, zero data corruption
+  - Overlapping ingest: 2 threads ingesting the same source simultaneously → exactly one succeeds (idempotency key), zero duplicate timeline/assertion rows
+  - Kill-before-commit: start ingest, `kill -9` before COMMIT, retry → clean state, no partial mutations, ingest_log has no stale rows
+  - WAL compact under load: run `gbrain compact` while a reader holds an open query → compact succeeds, reader gets consistent snapshot
+  - Invariants: monotonic `pages.version`, no lost timeline rows, no duplicate side-table rows across all stress scenarios
+- [ ] **Embedding model migration correctness** — CI gate for vec search contract.
+  - Embed corpus with model A, run 20 queries, record top-5 results per query
+  - Register model B (same dimensions, different weights — or re-embed with same model under a new name)
+  - Re-embed all pages under model B, flip active flag
+  - Run same 20 queries → verify: (a) all results come from model B's vec table, (b) no vec_rowid/id confusion, (c) no stale model A results leak through
+  - Rollback: flip active flag back to model A → verify original top-5 results return identically
+  - Gate: zero cross-model contamination across all queries
+- [ ] **Round-trip integrity** — CI gate (two separate tests).
+  - **Semantic:** Import corpus → normalized export → `gbrain validate` against original. Checks same pages, same frontmatter keys/values, same compiled_truth, same timeline entries. MUST pass.
+  - **Byte-exact:** Import corpus → `export --raw --import-id <ID>` → `diff -r` against original source. MUST pass. Only valid for the specific import batch, not after mutations.
+- [ ] **Static binary verification** — CI release gate.
+  - `ldd` / `file` / `otool` on every release artifact. Reject any binary with dynamic library dependencies.
+  - Gate: `file gbrain-linux-x86_64 | grep "statically linked"` must succeed.
+
+**Checkpoint:** All offline CI gates pass: BEIR nDCG regression, corpus-reality tests, concurrency stress tests, round-trip integrity (both semantic and raw), static binary verification. API-dependent benchmarks (LongMemEval R@5 ≥ 85%, LoCoMo F1, Ragas) run manually before major releases. A failing offline gate blocks the release; API-dependent benchmarks are advisory.
+
+**Philosophy:** Corpus-reality beats benchmark theater. The leaderboard benchmarks validate architectural decisions; the corpus tests validate that the tool actually works for its intended user.
+
+---
+
+## Design Decisions
+
+### Why SQLite over Postgres/Qdrant/Chroma
+
+**Postgres:** Better for multi-user writes, replication, row-level security. None of those apply here. This is one person's brain. One writer, many readers. SQLite's sweet spot is exactly this workload.
+
+**Qdrant/Chroma/Pinecone:** External services. Require network. Require containers or API keys. A personal brain shouldn't need a sidecar container or a paid API to do semantic search. sqlite-vec gives native cosine similarity in the same file, same connection, same query.
+
+**The fundamental principle:** `brain.db` is a 500MB file you can `scp`, `rsync`, back up to S3, or carry on a USB stick. No connection strings. No Docker. No managed database.
+
+### Why candle over fastembed (ONNX)
+
+The primary promise of this tool is a "single binary that runs anywhere." `fastembed` relies on the ONNX runtime. Linking `libonnxruntime` statically — especially across `musl` for Linux or various macOS architectures — is fragile and often results in missing shared object errors at runtime.
+
+**candle** is HuggingFace's pure-Rust ML framework. By using candle to load safetensors for BGE-small-en-v1.5, we achieve true 100% static linking with zero C-dependencies (other than SQLite, which is bundled via `rusqlite`).
+
+### Why local embeddings over OpenAI
+
+Garry's spec uses `text-embedding-3-small` (OpenAI API, 1536 dims, $0.02/1M tokens). Reasonable for a server-side tool. The problem: it requires internet access and an API key at embedding time.
+
+**BGE-small-en-v1.5 via candle:**
+- Pure Rust inference, no ONNX runtime
+- 384 dimensions (4x smaller than OpenAI's 1536-dim - smaller DB, faster search)
+- Quality: excellent for personal knowledge base retrieval tasks (competitive with OpenAI small)
+- No internet required (model weights embedded in binary by default)
+- No API key
+- No cost
+- Runs in-process
+
+**Trade-off:** Slightly lower quality on some retrieval benchmarks vs OpenAI text-embedding-3-large. Acceptable for a personal knowledge base where recall@10 matters more than recall@1.
+
+**Future:** The `model` column in `page_embeddings` and `embedding_models` registry table allow swapping models. Upgrade path: register new model, run `gbrain embed --all`, flip active flag.
+
+### Why Rust over TypeScript/Bun
+
+Garry's spec is TypeScript/Bun. That's a solid choice for his use case (server, API keys available). Rust is better for this spec because:
+
+1. `rusqlite --features bundled` = SQLite compiled into the binary. No system SQLite version issues.
+2. sqlite-vec statically linked = no native extension loading complications
+3. candle is pure Rust = in-process ML inference, no ONNX runtime, true musl static linking
+4. `cargo cross` = trivial cross-compilation to arm64 + x86_64 macOS and Linux
+5. No runtime (no Bun, no Node installed on target machine)
+6. Lower memory footprint
+
+Bun's compiled binary is ~10MB. This binary is ~90MB (including model weights). The 80MB difference is the cost of zero runtime dependencies. Worth it for a personal tool deployed on client machines.
+
+### Why RRF over weighted sum
+
+Garry's spec uses `FTS5 score × 0.4 + vector similarity × 0.6`. This requires choosing weights and normalizing scores across two different scoring systems with different distributions.
+
+RRF (Reciprocal Rank Fusion) is more robust: it only uses rank position, not raw scores. No normalization needed. No magic numbers. Works well empirically. Standard in hybrid search literature (SIGIR 2009).
+
+Formula: `RRF(d) = Σ 1/(k + rank(d, r))` where k=60, summed over result sets r.
+
+### Chunk strategy: section-level
+
+- **Per-page:** Too coarse. A 5,000-word person page has many distinct topics. Vector of whole page loses specificity.
+- **Per-paragraph:** Too fine. Loses context. Short paragraphs embed poorly.
+- **Per-section (`##` headers):** Right balance. Each `## State`, `## Assessment`, `## Timeline` section becomes a chunk. ~200-800 tokens. Good quality, good retrieval precision.
+- **Fallback:** Pages without headers chunk at ~500-token boundaries.
+
+### Multiple brains
+
+A different DB file = a different brain. No application-level complexity.
+
+```bash
+GBRAIN_DB=/path/to/work.db gbrain stats
+GBRAIN_DB=/path/to/personal.db gbrain serve --port 3001
+```
+
+### Why set-union over RRF (v2 change)
+
+v1 spec used RRF (Reciprocal Rank Fusion). UNC's AutoResearchClaw pipeline (Apr 2026) tested score-based re-ranking approaches and found they degrade performance — disrupting the semantic ordering dense retrieval already established. Set-union (vector results first in original order, FTS5-only results appended) delivered +44% F1 on LoCoMo in a single iteration. Ablation confirmed the gain. RRF is retained as a config fallback for A/B testing.
+
+### Why exact-match short-circuit (SMS)
+
+Set-union merging starts with vector results, which means searching for "Pedro Franceschi" might not return that person's actual page first if other pages have higher embedding similarity. In a personal brain, searching for a specific name MUST return that entity's page at #1. SMS guarantees title and slug exact matches bypass semantic fuzziness entirely.
+
+### Why palace filtering (v2 addition)
+
+MemPalace's ablation: 60.9% → 94.8% R@5 with wing+room pre-filtering (+34%). Constraining the search space before running expensive vector queries is cheaper and more effective than post-hoc re-ranking. gbrain's palace metadata is auto-derived from slug structure (zero manual effort) with frontmatter override for custom taxonomies.
+
+**Caveat:** The +34% improvement is from MemPalace's synthetic benchmark, not validated on gbrain's corpus. Wing-level filtering ships in v1 as a low-cost bet (auto-derived, zero manual effort). Room-level filtering is deferred until benchmark results on real data confirm it helps. If benchmarks show palace filtering doesn't materially improve retrieval on a personal knowledge corpus, demote it to optional.
+
+### Why progressive retrieval (v2 addition)
+
+OMNIMEM's ablation: removing progressive retrieval = -17% F1 (largest single component). Serving full pages is wasteful when the agent only needs a summary to decide relevance. Token-budget-gated expansion lets the system serve the right amount of content for the context window available.
+
+### Why temporal links (v2 addition)
+
+Knowledge graphs without temporal validity can't distinguish "who works at Brex?" from "who ever worked at Brex?". MemPalace's temporal triples (valid_from/valid_until) enable this distinction. Contradiction detection builds directly on temporal metadata — you can't catch "page says he left, but the link is still active" without it.
+
+### Why selective ingestion (v2 addition)
+
+OMNIMEM's three principles: selective ingestion, multimodal atomic units, progressive retrieval. Jaccard overlap + cosine similarity dedup at ingest time prevents the corpus from accumulating noise. Cleaner corpus = better retrieval precision without any search algorithm changes.
+
+### Why SQLite over PGLite (v4 validation)
+
+Garry Tan's GBrain v0.8.0 (Apr 2026) moved from Supabase to PGLite — an in-process Postgres that runs in a browser or Node.js via WASM. Same principle as our SQLite choice: zero external dependencies, fully local. Three independent teams in the same week (us with SQLite, Garry with PGLite, @ansubkhan with Fastify/SQLite) converged on local embedded databases for agent memory. The architecture is validated.
+
+| | SQLite (gbrain) | PGLite (Garry's GBrain) |
+|---|---|---|
+| Transport | `cp brain.db` / `scp` / USB stick | Requires WASM runtime to read |
+| Runtime | None (statically linked into Rust binary) | Node.js/Bun + WASM |
+| True single file | Yes (after `gbrain compact`) | No (PGLite has its own data directory) |
+| Vector search | sqlite-vec (statically linked) | pgvector via WASM |
+| Cross-compile | `cargo cross` to any musl target | Requires WASM-compatible platform |
+| Browser portability | No (desktop binary) | Yes (WASM) |
+
+Both are good choices for their respective stacks. We chose SQLite because `cp brain.db` is the entire backup and migration story. PGLite's browser portability is a future option for us via Rust→WASM compilation, but not a current priority.
+
+### The links table as a graph layer (v4 positioning)
+
+gbrain's `links` table with typed relationships and temporal validity windows is a knowledge graph without Neo4j. Combined with `brain_graph` (N-hop neighborhood traversal), `brain_backlinks` (temporal filtering), and palace-style hierarchy (wing/room), gbrain provides GraphRAG capabilities in a single SQLite file — no separate graph database required.
+
+This is worth calling out because the "separate graph + vector store" problem is a known pain point in the GraphRAG community. Every implementation (nano-graphrag, LangChain GraphRAG, etc.) makes you choose between a graph database and a vector store. gbrain doesn't — wikilink traversal in the links table, vector similarity in sqlite-vec, FTS5 keyword search, all in one file, one connection, one query.
+
+### No file watcher (v1)
+
+The brain is written by AI agents using the CLI or MCP. There's no "file on disk changed" event to watch for. `gbrain import` and `gbrain put` are explicit writes. A `gbrain watch` command that syncs a markdown directory to the DB is a v2 feature.
+
+---
+
+## Schema Versioning and DB Migration
+
+The `config` table stores `version` (currently `'4'`). On startup, the binary compares the DB schema version to its own expected version:
+
+| Scenario | Behavior |
+|----------|----------|
+| DB version == binary version | Normal operation |
+| DB version < binary version | Acquire exclusive write lock, WAL-safe backup, then run entire migration chain + version bump in a single transaction. Rollback on any error. The binary ships with a migration chain (v1→v2, v2→v3, etc.). **No concurrent writers during migration.** |
+| DB version > binary version | Refuse to open. Print error: "brain.db is version N, but this binary supports up to version M. Upgrade gbrain." |
+
+Migrations are tested by importing a fixture brain at each prior schema version and verifying post-migration integrity via `gbrain validate --all`.
+
+```rust
+fn migrate(conn: &Connection, db_path: &Path) -> Result<()> {
+    let db_version: u32 = get_config(conn, "version")?.parse()?;
+    let target_version: u32 = SCHEMA_VERSION;  // compiled into binary
+
+    if db_version > target_version {
+        bail!("brain.db v{} is newer than this binary (supports up to v{})", db_version, target_version);
+    }
+
+    if db_version == target_version {
+        return Ok(());  // no migration needed
+    }
+
+    // Step 1: Acquire exclusive write lock BEFORE backup.
+    // BEGIN IMMEDIATE prevents concurrent writers from committing between
+    // backup and migration, ensuring the backup is a consistent snapshot.
+    conn.execute("BEGIN IMMEDIATE", [])?;
+
+    // Step 2: WAL-safe backup inside the exclusive lock.
+    // VACUUM INTO runs as a read operation on the current snapshot,
+    // producing a standalone copy with all WAL content checkpointed.
+    let backup_path = db_path.with_extension(format!("db.backup-v{}", db_version));
+    if let Err(e) = conn.execute(
+        &format!("VACUUM INTO '{}'", backup_path.display()), []
+    ) {
+        conn.execute("ROLLBACK", [])?;
+        bail!("WAL-safe backup failed, migration aborted: {}", e);
+    }
+
+    // Step 3: Run entire migration chain inside the same transaction.
+    // If ANY step fails, the entire chain rolls back — no partial migration.
+    for step in (db_version + 1)..=target_version {
+        if let Err(e) = conn.execute_batch(MIGRATIONS[step]) {
+            conn.execute("ROLLBACK", [])?;
+            bail!("Migration v{}→v{} failed at step {}, rolled back: {}",
+                  db_version, target_version, step, e);
+        }
+    }
+
+    // Step 4: Bump version inside the same transaction.
+    set_config(conn, "version", &target_version.to_string())?;
+
+    // Step 5: Commit atomically. All migrations + version bump succeed or none do.
+    conn.execute("COMMIT", [])?;
+    Ok(())
+}
+```
+
+**Migration protocol:**
+
+1. **Exclusive lock first:** `BEGIN IMMEDIATE` blocks all concurrent writers before the backup snapshot. No writes can interleave between backup and migration.
+2. **WAL-safe backup under lock:** `VACUUM INTO` produces a standalone, fully-checkpointed copy at `{db_path}.backup-v{N}`. Because the exclusive lock is held, the backup is guaranteed to reflect the exact state that migration will operate on.
+3. **Atomic migration chain:** All migration steps + version bump run inside the same transaction. If any step fails, `ROLLBACK` restores the DB to its pre-migration state — no partial migration possible.
+4. **Rollback safety:** The backup file is a complete, self-contained SQLite database (no WAL sidecars). Restoring it requires replacing the DB file AND deleting any `-wal`/`-shm` sidecars (see rollback procedure below).
+
+**Important:** Migration requires no concurrent clients. The MCP server should not be running during migration. The CLI handles this naturally (single process), but the upgrade skill should verify no `gbrain serve` process is active before proceeding.
+
+---
+
+## Security and Data Sensitivity
+
+brain.db contains sensitive personal intelligence: deal assessments, people evaluations, relationship context, business strategy. The security model:
+
+**At rest:**
+- brain.db is a regular file. Protect it with filesystem permissions (`chmod 600`).
+- For encryption at rest, use OS-level full-disk encryption (FileVault, LUKS) or SQLite's SEE extension (commercial). gbrain does not implement its own encryption — that's a footgun.
+- `gbrain compact` before transport to ensure no WAL sidecar contains unencrypted data.
+
+**In transit:**
+- MCP server runs on stdio (local pipes only). No network listener. No remote access by default.
+- `scp`/`rsync` for transfer. Use encrypted channels.
+
+**Operational:**
+- No telemetry. No analytics. No phone-home. The gbrain binary itself makes zero network calls at runtime.
+- Skills are local markdown files. The binary does not exfiltrate data.
+- **Network boundary for agent-driven skills:** The enrichment skill (`skills/enrich/SKILL.md`) and research skill (`skills/research/SKILL.md`) instruct the agent to call external APIs (Crustdata, Exa, Brave, Happenstance). These network calls are made by the agent, not by the gbrain binary — but the effect is the same: brain content (queries, entity names) can reach third-party services. The `knowledge_gaps.sensitivity` field controls this: gaps default to `internal` (no external research), and must be explicitly upgraded to `redacted` or `external` before the research skill will issue network calls. Raw query text (`query_text`) is never retained at detection time — only a `query_hash` is stored; `query_text` is populated only after explicit approval. Agents must respect this classification.
+- `gbrain export` writes plaintext markdown. Treat export directories with the same sensitivity as the DB.
+- `.env` files or API keys for enrichment skills (Crustdata, Exa) are the user's responsibility. gbrain never stores them in brain.db.
+
+**Non-goals:** gbrain does not implement user auth, access control, audit logging, or data classification. It is a single-user tool on a single machine. If the machine is compromised, the brain is compromised.
+
+---
+
+## Error Handling and Graceful Degradation
+
+| Failure | Behavior |
+|---------|----------|
+| Candle model fails to load | Fatal on startup. Binary refuses to serve if embeddings can't work. Clear error message with path to model weights. |
+| sqlite-vec not available | Fall back to pure-Rust cosine similarity (O(n) scan). Log warning. Performance degrades but search still works. |
+| Skill file missing | Use embedded default. If embedded default also missing (shouldn't happen), warn and continue — the binary still works for read/write/search, just without agent workflows. |
+| DB file corrupt | `gbrain validate --all` reports errors. `gbrain` refuses destructive operations on a corrupt DB. Recommend restore from backup. |
+| WAL sidecar missing | SQLite handles this — rolls back uncommitted transactions, creates fresh WAL. No data loss for committed writes. |
+| Disk full during write | SQLite transaction rolls back cleanly. No partial state. Error surfaced to caller. |
+| Concurrent writer conflict | ConflictError returned to caller with current version. Caller retries. No data corruption. |
+
+**Principle:** Fail loud, fail safe. Never silently corrupt. Never silently drop data. If in doubt, refuse the operation and tell the user why.
+
+---
+
+## Comparison Table
+
+| | Garry's GBrain (v0.8) | This spec (v4) | MemPalace | agentmemory | Obsidian | Notion |
+|---|---|---|---|---|---|---|
+| Language | TypeScript/Bun | Rust | Python | Node.js | Electron | Web/Cloud |
+| Binary | ~10MB + API dep | ~90MB self-contained | pip install | npm install | Heavy app | SaaS |
+| Embeddings | PGLite (local, v0.8) | BGE-small local (free) | ChromaDB (local) | BM25 + vector | Plugin | Built-in AI |
+| Storage | PGLite (local Postgres) | Single SQLite | ChromaDB + SQLite | SQLite | Markdown files | Cloud DB |
+| Search | FTS5 + vector + weighted | Set-union + palace filter + progressive | Palace-filtered semantic | Triple-stream (BM25+vec+KG) | Plugin | Cloud |
+| Graph traversal | No | Yes (N-hop `brain_graph`) | No | Yes (KG edges) | No | No |
+| Retrieval | Full pages | Progressive (budget-gated) | Closet → drawer drill-down | Context injection + budget | Manual | Full pages |
+| Dedup/novelty | None | Jaccard + cosine | None published | TTL + importance eviction | None | None |
+| Temporal graph | No | Yes (valid_from/until) | Yes (KG triples) | Yes (versioned) | No | No |
+| Contradiction detection | No | Yes (CLI + MCP) | Yes (fact_checker.py) | Yes (cascading staleness) | No | No |
+| Knowledge gap detection | No | Yes (`brain_gap` + research skill) | No | No | No | No |
+| Memory tiers | 2 (truth + timeline) | 4 (evidence → fact → concept → narrative) | 4 (L0-L3) | 4 (observation → narrative) | 1 (flat notes) | 1 (pages) |
+| Knowledge model | Compiled truth + timeline | Compiled truth + timeline (tiered) | Palace (wings/halls/rooms) | Knowledge graph | Flat notes | Pages + DBs |
+| LongMemEval | Not published | Est. 85-92% R@5 | 96.6% R@5 (raw mode) | 64% Recall@10 | N/A | N/A |
+| Air-gapped | No (PGLite OK, but Bun runtime) | Yes (true static binary) | Yes | No (needs MCP client) | Yes | No |
+| API keys | None (v0.8) | None | None | None | None | None |
+| Backup story | PGLite data dir | `cp brain.db` | ChromaDB dir | SQLite file | rsync | Cloud |
+
+---
+
+## Open Questions
+
+### 1. Embed model weights into binary?
+
+**Option A:** `include_bytes!()` the ONNX model file into the binary at compile time
+- Pros: Truly zero-dependency, no network ever, guaranteed version consistency
+- Cons: ~90MB binary, model updates require recompile
+
+**Option B:** fastembed downloads BGE-small to `~/.cache/fastembed/` on first run (33MB download, then cached)
+- Pros: Smaller binary distribution (~55MB vs ~90MB), model updates independent of binary
+- Cons: Requires internet on first run, breaks offline/air-gapped deployment
+
+**Decision:** Ship Option A (embedded weights) as the default — the spec's core promise is
+zero-dependency, offline-first operation. Option B available via `--features online-model`
+for users who prefer smaller binaries and accept the network dependency.
+
+### 2. sqlite-vec linking mechanism — RESOLVED
+
+**Decision:** Compile `vec0.c` directly into rusqlite via a custom build script. sqlite-vec is a single C file (~3K lines) with no external dependencies beyond SQLite itself. The approach:
+
+1. Add `vec0.c` and `vec0.h` to `src/vendor/sqlite-vec/`
+2. In `build.rs`, compile `vec0.c` with `cc::Build` and link it into the rusqlite bundled SQLite
+3. Register the extension at runtime via `sqlite3_auto_extension` (no `load_extension` call needed)
+
+This produces a single statically linked binary on all targets including `musl`. The approach is proven by other SQLite extension projects (e.g., sqlean bundles extensions the same way).
+
+**Fallback:** If vec0.c integration is blocked, pure-Rust cosine similarity (O(n) scan over all embeddings) is acceptable for < 100K chunks. Performance is ~50ms for 50K chunks on Apple Silicon — within the 200ms target.
+
+**CI verification:** Every release build runs `ldd` (Linux) / `otool -L` (macOS) / `file` to confirm no dynamic dependencies. This is a release gate — see Week 5 benchmarks.
+
+### 3. Embedding dimension: 384 vs higher
+
+BGE-small-en-v1.5 = 384 dims. BGE-base = 768 dims. BGE-large = 1024 dims.
+- Larger = better quality, larger DB, slower search
+- 384 is fast and good enough for personal knowledge base retrieval
+- Config table and `model` column make it trivial to switch
+
+### 4. MCP server: which rmcp version?
+
+`rmcp` is newer and less battle-tested than `@modelcontextprotocol/sdk` (used in Garry's spec). Alternatives:
+- Implement MCP protocol directly (it's JSON-RPC 2.0 over stdio, relatively simple)
+- Use a thin wrapper layer
+
+### 5. Ingest command UX
+
+Does `gbrain ingest <file>` attempt to parse entities itself (requiring an LLM call), or is it a pass-through that stores the file and expects the agent (via MCP `brain_ingest` tool) to do the parsing?
+
+**Recommendation:** `gbrain ingest` stores the raw source + auto-logs it + runs novelty check. The actual entity extraction and page creation happens via the agent following `skills/ingest/SKILL.md`. This keeps the binary dumb and the intelligence in markdown.
+
+### 6. Palace room derivation granularity (v2)
+
+Wing derivation from slug is straightforward. Room derivation from section headers is less obvious. Options:
+- **Section-based:** Each `## Header` in compiled_truth becomes a room. Simple but creates many rooms per page.
+- **Fixed enum:** Map to standardised halls (facts, events, discoveries, preferences, advice) like MemPalace. More structured but requires classification.
+- **Hybrid:** Use fixed halls for embedding metadata (which hall does this chunk belong to?), section headers for page-level room. Best of both worlds but more complex.
+
+**Recommendation:** Start with wing-only filtering (v2.0). Add room-level filtering as v2.1 once we have empirical data on palace filter effectiveness with real corpus.
+
+### 7. Contradiction detection: heuristic vs LLM-assisted (v2) — RESOLVED
+
+**Decision:** Heuristic-only in the binary, powered by the `assertions` table. Agents populate temporal assertions during Tier 2 ingest (`{subject, predicate, object, valid_from, valid_until}`). Fact changes supersede old assertions (`valid_until` set). The binary runs pure-SQL consistency checks on current beliefs only (`valid_until IS NULL`):
+- **Link vs Assertion:** Current assertions where the corresponding link has `valid_until` in the past.
+- **Cross-page conflicts:** Multiple current assertions with same subject+predicate but different objects.
+- **Temporal staleness:** `timeline_updated_at` > `truth_updated_at` by more than 30 days.
+
+LLM-assisted cross-page checks happen via the maintain skill. Binary stays dumb.
+
+---
+
+## Spec History
+
+| Date | Event |
+|------|-------|
+| 2026-04-05 | Garry Tan specs GBrain v1 (TypeScript/Bun, OpenAI embeddings). Inspired by hitting git scaling limits at 7,471 files / 2.3GB. |
+| 2026-04-05 | Garry posts spec to GitHub Gist. Architecture: SQLite + FTS5 + vector, thin CLI, fat skills, MCP-first. |
+| 2026-04-06 | Initial architecture review of Garry's spec. Key improvements identified: Rust over TypeScript, local BGE-small-en-v1.5 over OpenAI embeddings, sqlite-vec over pure-JS cosine similarity, RRF over weighted sum. |
+| 2026-04-06 | Full standalone spec written (v1). Incorporates Garry's schema verbatim (adapted for 384-dim vectors), all CLI commands, all skill files. Adds: Rust implementation details, cross-compile CI, embedding decision rationale. |
+| 2026-04-08 | Memory research integration (v2). Incorporated techniques from MemPalace (500/500 LongMemEval), UNC AutoResearchClaw/OMNIMEM (+411% F1), agentmemory (92% token reduction), and Obsidian Mind. Seven changes: (1) palace-style hierarchical filtering (+34% retrieval), (2) set-union hybrid search replacing RRF (+44% F1), (3) progressive retrieval with token budgets, (4) selective ingestion via Jaccard/cosine novelty checks, (5) temporal knowledge graph with validity windows, (6) contradiction detection (CLI + MCP), (7) four-tier memory consolidation in ingest skill. Schema version bumped to v2. |
+| 2026-04-08 | **v3 Architecture Review.** Five changes: (1) Exact-Match Short-Circuit (SMS) ensures title/slug matches always rank first, (2) Temporal sub-chunking embeds timeline entries individually instead of as one blob, (3) Assertions table enables pure-SQL heuristic contradiction detection, (4) Strict optimistic concurrency with `expected_version` on MCP writes, (5) Switched from `fastembed`/ONNX to pure-Rust `candle` for true `musl` static binary. Also: embedding model registry for safe model upgrades, temporal link uniqueness fix, ingest idempotency, semantic round-trip contract, raw_imports table. |
+| 2026-04-09 | **Work-context entity types.** Inspired by Rowboat (rowboatlabs/rowboat) knowledge-graph-vs-wiki insight: added `decision`, `commitment`, `action_item` as first-class page types with templates. Updated ingest skill to extract work-context entities from meetings. Updated briefing skill with commitments due, action items, and "what shifted overnight" report (superseded assertions in last 24h). |
+| 2026-04-09 | **External review integration.** Accepted 11 of 12 findings from adversarial review. Added: Non-Goals section, Phased Delivery (core → intelligence → polish), WAL/single-file honesty (`gbrain compact`), embedded skills with external override + `skills doctor`, enriched chunk model (content_hash, token_count, heading_path, last_embedded_at), assertion provenance (asserted_by, source_ref, evidence_text), `brain_link_close` for targeted temporal closure, corpus-reality benchmarks alongside leaderboard benchmarks, palace filtering caveat. Rejected: `valid_from = 'unknown'` sentinel replacement (alternatives add complexity for marginal benefit). |
+| 2026-04-13 | **v4 Community Research + Garry v0.8.0 integration.** Reviewed new research notes from Apr 9-12. Eight spec changes: (1) `knowledge_gaps` table + `brain_gap`/`brain_gaps` MCP tools for self-improving knowledge base — agent detects what it doesn't know and logs it for research skill resolution. (2) `brain_graph` MCP tool + `gbrain graph` CLI for N-hop neighborhood traversal — returns pages + links as JSON for UI/graph visualization. (3) `original` as first-class page type with template — distinguishes the user's own thinking from world concepts. (4) Standardised source attribution format with authority hierarchy — inline citation format, URL requirement for social refs, source conflict rules. (5) Filing disambiguation rules in ingest skill — concept vs original vs idea vs project decision tree. (6) Richer person template with optional enrichment sections (What They Believe, Hobby Horses, Trajectory, Network) for Tier 1 contacts. (7) Three new skills: `alerts/SKILL.md` (interrupt-driven vs scheduled notifications), `research/SKILL.md` (knowledge gap resolution), `upgrade/SKILL.md` (agent-guided binary + skill updates inspired by Garry's v0.8.0 auto-upgrade UX). (8) "Why SQLite over PGLite" design decision + links-table-as-graph-layer positioning. Comparison table updated for Garry v0.8.0 + PGLite. Schema version bumped to v4. |
+
+---
+
+*This spec is designed to stand alone. Everything needed to build GigaBrain is above — no prior context required. It is explicitly inspired by Garry Tan's GBrain work while pursuing a Rust + SQLite implementation with different deployment trade-offs. v4 integrates memory research from MemPalace, OMNIMEM, and agentmemory, plus community research and Garry Tan's v0.8.0 GBrain skillpack analysis. Architecture additions: knowledge gap detection, graph traversal, source attribution standards, filing disambiguation, and three new skills (alerts, research, upgrade).*

--- a/website/src/env.d.ts
+++ b/website/src/env.d.ts
@@ -1,0 +1,2 @@
+/// <reference path="../.astro/types.d.ts" />
+/// <reference types="astro/client" />

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -1,0 +1,81 @@
+/* GigaBrain — viral dark theme */
+:root {
+  --sl-color-accent-low: #3b0764;
+  --sl-color-accent: #7c3aed;
+  --sl-color-accent-high: #c4b5fd;
+  --sl-color-white: #ffffff;
+  --sl-color-gray-1: #f1f0f5;
+  --sl-color-gray-2: #c2c0cc;
+  --sl-color-gray-3: #86849a;
+  --sl-color-gray-4: #504e63;
+  --sl-color-gray-5: #2a2838;
+  --sl-color-gray-6: #13111c;
+  --sl-color-black: #09080e;
+}
+
+:root[data-theme="dark"] {
+  --sl-color-bg: radial-gradient(
+      1200px 800px at 20% 10%,
+      rgba(124, 58, 237, 0.20),
+      transparent 55%
+    ),
+    radial-gradient(
+      900px 650px at 80% 20%,
+      rgba(6, 182, 212, 0.14),
+      transparent 60%
+    ),
+    linear-gradient(180deg, #09080e 0%, #07060c 45%, #05040a 100%);
+  --sl-color-bg-nav: rgba(9, 8, 14, 0.7);
+  --sl-color-bg-sidebar: rgba(9, 8, 14, 0.75);
+}
+
+header.header {
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border-bottom: 1px solid rgba(124, 58, 237, 0.18);
+}
+
+/* Neon code blocks */
+.expressive-code .frame {
+  border: 1px solid rgba(124, 58, 237, 0.4);
+  box-shadow: 0 0 20px rgba(124, 58, 237, 0.1);
+}
+
+.expressive-code .copy button {
+  border: 1px solid rgba(124, 58, 237, 0.25);
+}
+
+.sl-markdown-content a {
+  text-decoration-color: rgba(124, 58, 237, 0.55);
+}
+
+.sl-markdown-content a:hover {
+  text-decoration-color: rgba(6, 182, 212, 0.9);
+}
+
+/* Gradient hero headline */
+.hero h1 {
+  background: linear-gradient(135deg, #7c3aed 0%, #06b6d4 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+/* Glowing sidebar active item */
+[aria-current="page"] {
+  background: rgba(124, 58, 237, 0.15) !important;
+  border-left: 2px solid #7c3aed;
+}
+
+.sl-card {
+  border: 1px solid rgba(124, 58, 237, 0.16);
+  background: rgba(9, 8, 14, 0.55);
+  box-shadow: 0 0 0 rgba(124, 58, 237, 0);
+  transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+}
+
+.sl-card:hover {
+  transform: translateY(-2px);
+  border-color: rgba(6, 182, 212, 0.30);
+  box-shadow: 0 0 40px rgba(124, 58, 237, 0.12);
+}

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "astro/tsconfigs/strict",
+  "compilerOptions": {
+    "types": ["astro/client"]
+  }
+}


### PR DESCRIPTION
## What

Adds a full Astro Starlight documentation site for GigaBrain, deployable to GitHub Pages.

## Highlights
- Dark theme with electric purple accent (`#7c3aed`) and neon code blocks
- Hero landing page with feature CardGrid
- Full CLI reference (all 24 commands)
- MCP server integration guide
- Architecture docs from spec + README
- Contributing guide + roadmap

## Structure
```
website/
  src/content/docs/
    index.mdx                    # Hero splash page
    guides/
      getting-started.md
      quick-start.md
      why-gigabrain.md
      how-it-works.md
      mcp-server.md
    reference/
      cli.mdx                    # Full CLI reference
      architecture.md
      spec.md
    contributing/
      contributing.md
      roadmap.md
```

## Deploy
GitHub Actions (`.github/workflows/docs.yml`) auto-deploys to GitHub Pages on push to `main` with path filter `website/**`.

Enable Pages in repo Settings → Pages → Source: GitHub Actions.

## Run locally
```
cd website && npm install && npm run dev
```

## Tech
- Astro 6.1.6 + Starlight 0.38.3
- Pagefind full-text search (12 pages indexed)
- Build: `npm run build` ✅ zero errors