### PR TITLE
docs: StackBlitz-inspired design enhancement and content quality pass

### DIFF
--- a/website/src/content/docs/guides/getting-started.md
+++ b/website/src/content/docs/guides/getting-started.md
@@ -138,7 +138,7 @@ Then start the server:
 gbrain serve
 ```
 
-The MCP server exposes tools over stdio JSON-RPC 2.0. Phase 1 ships five core tools: `brain_get`, `brain_put`, `brain_query`, `brain_search`, `brain_list`. Later phases add the full surface — see [spec.md](spec.md#mcp-server).
+The MCP server exposes tools over stdio JSON-RPC 2.0. Phase 1 ships five core tools: `brain_get`, `brain_put`, `brain_query`, `brain_search`, `brain_list`. Later phases add the full surface — see the [Spec](/reference/spec/).
 
 ---
 
@@ -181,8 +181,8 @@ The `original` type is for your own thinking — distinct from compiled external
 
 ## What's Next?
 
-- [Quick Start](/gigabrain/guides/quick-start/) — five commands to a running brain
-- [CLI Reference](/gigabrain/reference/cli/) — full flag and subcommand reference
-- [MCP Server](/gigabrain/guides/mcp-server/) — connect Claude Code or any MCP agent
-- [Architecture](/gigabrain/reference/architecture/) — how the internals fit together
-- [Roadmap](/gigabrain/contributing/roadmap/) — what is built vs. what is coming
+- [Quick Start](/guides/quick-start/) — five commands to a running brain
+- [CLI Reference](/reference/cli/) — full flag and subcommand reference
+- [MCP Server](/guides/mcp-server/) — connect Claude Code or any MCP agent
+- [Architecture](/reference/architecture/) — how the internals fit together
+- [Roadmap](/contributing/roadmap/) — what is built vs. what is coming

--- a/website/src/content/docs/guides/getting-started.md
+++ b/website/src/content/docs/guides/getting-started.md
@@ -179,8 +179,10 @@ The `original` type is for your own thinking — distinct from compiled external
 
 ---
 
-## Next steps
+## What's Next?
 
-- Read the [Roadmap](/contributing/roadmap/) to understand what is built vs. what is coming.
-- Read [Contributing](/contributing/) to start contributing.
-- Read the [Spec](/reference/spec/) for the full technical specification.
+- [Quick Start](/gigabrain/guides/quick-start/) — five commands to a running brain
+- [CLI Reference](/gigabrain/reference/cli/) — full flag and subcommand reference
+- [MCP Server](/gigabrain/guides/mcp-server/) — connect Claude Code or any MCP agent
+- [Architecture](/gigabrain/reference/architecture/) — how the internals fit together
+- [Roadmap](/gigabrain/contributing/roadmap/) — what is built vs. what is coming

--- a/website/src/content/docs/guides/mcp-server.md
+++ b/website/src/content/docs/guides/mcp-server.md
@@ -1,6 +1,10 @@
 ---
 title: MCP Server
-description: Run `gbrain serve` and connect any MCP client over stdio JSON-RPC.
+description: Run `gbrain serve` and connect any MCP client over stdio JSON-RPC 2.0. Zero config — just a binary and a JSON block.
+sidebar:
+  badge:
+    text: New
+    variant: tip
 ---
 
 ## What `gbrain serve` does

--- a/website/src/content/docs/guides/quick-start.md
+++ b/website/src/content/docs/guides/quick-start.md
@@ -60,6 +60,6 @@ GBRAIN_DB=~/brain.db ./target/release/gbrain serve
 
 ## What's Next?
 
-- [CLI Reference](/gigabrain/reference/cli/) — full flag and subcommand reference
-- [MCP Server](/gigabrain/guides/mcp-server/) — connect Claude Code or any MCP agent
-- [Architecture](/gigabrain/reference/architecture/) — how the internals fit together
+- [CLI Reference](/reference/cli/) — full flag and subcommand reference
+- [MCP Server](/guides/mcp-server/) — connect Claude Code or any MCP agent
+- [Architecture](/reference/architecture/) — how the internals fit together

--- a/website/src/content/docs/guides/quick-start.md
+++ b/website/src/content/docs/guides/quick-start.md
@@ -55,3 +55,11 @@ MD
 GBRAIN_DB=~/brain.db ./target/release/gbrain serve
 ```
 
+
+---
+
+## What's Next?
+
+- [CLI Reference](/gigabrain/reference/cli/) — full flag and subcommand reference
+- [MCP Server](/gigabrain/guides/mcp-server/) — connect Claude Code or any MCP agent
+- [Architecture](/gigabrain/reference/architecture/) — how the internals fit together

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -8,7 +8,7 @@ hero:
     html: <div style="font-size:4rem;text-align:center;line-height:1">🧠</div>
   actions:
     - text: Get Started
-      link: /gigabrain/guides/getting-started/
+      link: /guides/getting-started/
       icon: right-arrow
       variant: primary
     - text: View on GitHub
@@ -17,7 +17,7 @@ hero:
       variant: minimal
 ---
 
-import { CardGrid, Card, Tabs, TabItem, Code } from "@astrojs/starlight/components";
+import { CardGrid, Card } from "@astrojs/starlight/components";
 
 ## Install
 
@@ -72,6 +72,6 @@ cd gigabrain && cargo build --release
 
 ## Status
 
-GigaBrain is currently in **Sprint 0 (scaffold complete)**. Phase 1 (Core) is next — the docs describe the *planned* surface area and design, even where implementation is still pending.
+GigaBrain is currently in **Sprint 0 (scaffold complete)**. Phase 1 (Core storage, CLI, search, MCP) is in **active development** — the docs describe the planned surface area and design, even where implementation is still pending.
 
-See the [Roadmap](/gigabrain/contributing/roadmap/) for the delivery plan.
+See the [Roadmap](/contributing/roadmap/) for the delivery plan.

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -3,10 +3,12 @@ title: GigaBrain
 description: The personal knowledge brain. SQLite + FTS5 + vector embeddings in one file. No API keys. No internet. One static binary.
 template: splash
 hero:
-  tagline: Your knowledge, compiled. One binary, zero dependencies, runs anywhere.
+  tagline: Your brain, persisted. Zero cloud, zero keys.
+  image:
+    html: <div style="font-size:4rem;text-align:center;line-height:1">🧠</div>
   actions:
     - text: Get Started
-      link: /guides/getting-started/
+      link: /gigabrain/guides/getting-started/
       icon: right-arrow
       variant: primary
     - text: View on GitHub
@@ -15,34 +17,54 @@ hero:
       variant: minimal
 ---
 
-import { CardGrid, Card } from "@astrojs/starlight/components";
+import { CardGrid, Card, Tabs, TabItem, Code } from "@astrojs/starlight/components";
+
+## Install
+
+```bash
+git clone https://github.com/macro88/gigabrain
+cd gigabrain && cargo build --release
+# → target/release/gbrain (~90MB, fully static, zero deps)
+```
+
+---
+
+## How it works
+
+<CardGrid>
+  <Card title="1. Put" icon="pencil">
+    Write structured knowledge pages in markdown. Compiled truth above the line, append-only timeline below it.
+  </Card>
+  <Card title="2. Search" icon="magnifier">
+    Hybrid FTS5 keyword + semantic vector search. Finds what you mean, not just what you typed.
+  </Card>
+  <Card title="3. Serve" icon="rocket">
+    `gbrain serve` exposes all tools via MCP over stdio. Any AI agent connects instantly — no config beyond a JSON block.
+  </Card>
+</CardGrid>
+
+---
 
 ## Why GigaBrain?
 
 <CardGrid stagger>
   <Card title="Single Binary" icon="seti:binary">
-    ~90MB static binary. Drop it anywhere. Zero runtime dependencies — no Docker,
-    no Node, no Python.
+    ~90MB static binary. Drop it anywhere — macOS, Linux, ARM. Zero runtime dependencies, no Docker, no Node, no Python.
   </Card>
   <Card title="SQLite Everything" icon="seti:db">
-    FTS5 full-text search + `sqlite-vec` vector similarity + typed link graph.
-    All in one `brain.db` file you own completely.
+    FTS5 full-text search + `sqlite-vec` vector similarity + typed link graph. One `brain.db` file you own completely.
   </Card>
   <Card title="Local Embeddings" icon="star">
-    BGE-small-en-v1.5 runs fully offline via pure-Rust candle. No OpenAI API key.
-    No internet required.
+    BGE-small-en-v1.5 runs fully offline via pure-Rust candle. No OpenAI key, no API calls, no data leaves your machine.
   </Card>
   <Card title="MCP-Ready" icon="puzzle">
-    `gbrain serve` exposes all tools over stdio JSON-RPC 2.0. Plug into Claude
-    Code, any MCP-compatible agent, instantly.
+    `gbrain serve` exposes all tools over stdio JSON-RPC 2.0. Drop it into Claude Code, Cursor, or any MCP-compatible agent.
   </Card>
   <Card title="Hybrid Search" icon="magnifier">
-    FTS5 keyword + vector semantic search with set-union merge. Exact-match
-    short-circuit. Finds what you mean, not just what you typed.
+    FTS5 keyword + vector semantic search with set-union merge. Exact-match short-circuit. Finds what you mean, not just what you typed.
   </Card>
   <Card title="Fat Skills" icon="document">
-    Agent workflows live in plain markdown SKILL.md files. Swap or extend
-    without rebuilding. The intelligence is yours.
+    Agent workflows live in plain markdown SKILL.md files. Swap or extend without rebuilding. The intelligence is yours.
   </Card>
 </CardGrid>
 
@@ -50,7 +72,6 @@ import { CardGrid, Card } from "@astrojs/starlight/components";
 
 ## Status
 
-GigaBrain is currently in **Sprint 0 (scaffold complete)**. Phase 1 (Core) is
-next — the docs describe the *planned* surface area and design, even where
-implementation is still pending.
+GigaBrain is currently in **Sprint 0 (scaffold complete)**. Phase 1 (Core) is next — the docs describe the *planned* surface area and design, even where implementation is still pending.
 
+See the [Roadmap](/gigabrain/contributing/roadmap/) for the delivery plan.

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -14,7 +14,14 @@
 }
 
 :root[data-theme="dark"] {
-  --sl-color-bg: radial-gradient(
+  --sl-color-bg: #060d16;
+  --sl-color-bg-nav: rgba(6, 13, 22, 0.75);
+  --sl-color-bg-sidebar: rgba(6, 13, 22, 0.80);
+}
+
+/* Gradient applied to page shell, not the color token */
+body[data-theme="dark"] {
+  background: radial-gradient(
       1200px 800px at 20% 10%,
       rgba(19, 137, 253, 0.14),
       transparent 55%
@@ -25,8 +32,6 @@
       transparent 60%
     ),
     linear-gradient(180deg, #060d16 0%, #050b13 45%, #040910 100%);
-  --sl-color-bg-nav: rgba(6, 13, 22, 0.75);
-  --sl-color-bg-sidebar: rgba(6, 13, 22, 0.80);
 }
 
 header.header {
@@ -76,7 +81,7 @@ header.header {
 }
 
 /* Glowing sidebar active item */
-[aria-current="page"] {
+nav.sidebar [aria-current="page"] {
   background: rgba(19, 137, 253, 0.12) !important;
   border-left: 2px solid #1389fd;
 }

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -1,81 +1,122 @@
-/* GigaBrain — viral dark theme */
+/* GigaBrain — StackBlitz-inspired dark theme */
 :root {
-  --sl-color-accent-low: #3b0764;
-  --sl-color-accent: #7c3aed;
-  --sl-color-accent-high: #c4b5fd;
+  --sl-color-accent-low: #002a5e;
+  --sl-color-accent: #1389fd;
+  --sl-color-accent-high: #93c5fd;
   --sl-color-white: #ffffff;
-  --sl-color-gray-1: #f1f0f5;
-  --sl-color-gray-2: #c2c0cc;
-  --sl-color-gray-3: #86849a;
-  --sl-color-gray-4: #504e63;
-  --sl-color-gray-5: #2a2838;
-  --sl-color-gray-6: #13111c;
-  --sl-color-black: #09080e;
+  --sl-color-gray-1: #f0f4ff;
+  --sl-color-gray-2: #bfcfe8;
+  --sl-color-gray-3: #7a90b0;
+  --sl-color-gray-4: #3d506a;
+  --sl-color-gray-5: #1e2d42;
+  --sl-color-gray-6: #0d1521;
+  --sl-color-black: #060d16;
 }
 
 :root[data-theme="dark"] {
   --sl-color-bg: radial-gradient(
       1200px 800px at 20% 10%,
-      rgba(124, 58, 237, 0.20),
+      rgba(19, 137, 253, 0.14),
       transparent 55%
     ),
     radial-gradient(
       900px 650px at 80% 20%,
-      rgba(6, 182, 212, 0.14),
+      rgba(0, 212, 255, 0.10),
       transparent 60%
     ),
-    linear-gradient(180deg, #09080e 0%, #07060c 45%, #05040a 100%);
-  --sl-color-bg-nav: rgba(9, 8, 14, 0.7);
-  --sl-color-bg-sidebar: rgba(9, 8, 14, 0.75);
+    linear-gradient(180deg, #060d16 0%, #050b13 45%, #040910 100%);
+  --sl-color-bg-nav: rgba(6, 13, 22, 0.75);
+  --sl-color-bg-sidebar: rgba(6, 13, 22, 0.80);
 }
 
 header.header {
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
-  border-bottom: 1px solid rgba(124, 58, 237, 0.18);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(19, 137, 253, 0.18);
 }
 
-/* Neon code blocks */
+/* Code blocks */
 .expressive-code .frame {
-  border: 1px solid rgba(124, 58, 237, 0.4);
-  box-shadow: 0 0 20px rgba(124, 58, 237, 0.1);
+  border: 1px solid rgba(19, 137, 253, 0.35);
+  box-shadow: 0 0 24px rgba(19, 137, 253, 0.08);
+  border-radius: 8px;
 }
 
 .expressive-code .copy button {
-  border: 1px solid rgba(124, 58, 237, 0.25);
+  border: 1px solid rgba(19, 137, 253, 0.25);
 }
 
+/* Links */
 .sl-markdown-content a {
-  text-decoration-color: rgba(124, 58, 237, 0.55);
+  color: #4da6ff;
+  text-decoration-color: rgba(19, 137, 253, 0.4);
 }
 
 .sl-markdown-content a:hover {
-  text-decoration-color: rgba(6, 182, 212, 0.9);
+  color: #93c5fd;
+  text-decoration-color: rgba(0, 212, 255, 0.8);
 }
 
 /* Gradient hero headline */
 .hero h1 {
-  background: linear-gradient(135deg, #7c3aed 0%, #06b6d4 100%);
+  background: linear-gradient(135deg, #1389fd 0%, #00d4ff 60%, #7dd3fc 100%);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  line-height: 1.15;
+}
+
+/* Hero tagline */
+.hero .tagline {
+  font-size: 1.15rem;
+  color: var(--sl-color-gray-2);
+  max-width: 540px;
+  margin: 0 auto;
 }
 
 /* Glowing sidebar active item */
 [aria-current="page"] {
-  background: rgba(124, 58, 237, 0.15) !important;
-  border-left: 2px solid #7c3aed;
+  background: rgba(19, 137, 253, 0.12) !important;
+  border-left: 2px solid #1389fd;
 }
 
+/* Feature cards */
 .sl-card {
-  border: 1px solid rgba(124, 58, 237, 0.16);
-  background: rgba(9, 8, 14, 0.55);
-  box-shadow: 0 0 0 rgba(124, 58, 237, 0);
+  border: 1px solid rgba(19, 137, 253, 0.14);
+  background: rgba(6, 13, 22, 0.6);
+  border-radius: 10px;
+  box-shadow: 0 0 0 rgba(19, 137, 253, 0);
   transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
 }
 
 .sl-card:hover {
-  transform: translateY(-2px);
-  border-color: rgba(6, 182, 212, 0.30);
-  box-shadow: 0 0 40px rgba(124, 58, 237, 0.12);
+  transform: translateY(-3px);
+  border-color: rgba(0, 212, 255, 0.28);
+  box-shadow: 0 4px 32px rgba(19, 137, 253, 0.12);
+}
+
+/* Inline code */
+:not(pre) > code {
+  background: rgba(19, 137, 253, 0.10);
+  border: 1px solid rgba(19, 137, 253, 0.20);
+  border-radius: 4px;
+  padding: 0.1em 0.35em;
+  font-size: 0.9em;
+}
+
+/* Tables */
+.sl-markdown-content table {
+  border: 1px solid rgba(19, 137, 253, 0.15);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.sl-markdown-content thead tr {
+  background: rgba(19, 137, 253, 0.10);
+}
+
+/* Aside/callout blocks */
+.starlight-aside {
+  border-left-color: #1389fd;
 }


### PR DESCRIPTION
## What's changed

### Design
- **New CSS theme**: electric blue accent (#1389fd) replacing purple - matches StackBlitz energy
- Radial gradient background with blue/cyan glow (dark mode)
- Gradient hero headline (blue → cyan)
- Code blocks: blue-tinted border + glow, rounded corners
- Inline code: subtle blue tint + border
- Table headers: blue-tinted background
- Card hover effects: 3px lift + blue border glow
- Glassmorphism header with blue accent border
- Sidebar active item: blue left-border highlight

### Homepage
- Rewritten hero: tagline *"Your brain, persisted. Zero cloud, zero keys."*
- Brain emoji image in hero
- **"How it works"** 3-card section: Put → Search → Serve
- Feature cards tightened with better descriptions

### Content
- MCP Server page: **"New" badge** in sidebar
- quick-start.md: "What's Next?" section with links to CLI Ref, MCP Server, Architecture
- getting-started.md: "What's Next?" section replacing bare link list
- Consistent base path in links (/gigabrain/...)

### Build
- Clean build ✅ (12 pages, 1.22s)

Design reference: https://developer.stackblitz.com