### PR TITLE
fix: skip optional Codecov upload without token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,11 +112,13 @@ jobs:
 
       - name: Upload to Codecov (optional, non-blocking)
         if: >-
-          secrets.CODECOV_TOKEN != '' &&
+          env.CODECOV_TOKEN != '' &&
           (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
         uses: codecov/codecov-action@v4
         continue-on-error: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           files: lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ env.CODECOV_TOKEN }}
           fail_ci_if_error: false


### PR DESCRIPTION
## Summary
- fix the optional Codecov upload guard in CI
- skip the upload cleanly when `CODECOV_TOKEN` is not configured
- keep GitHub-native coverage artifacts and summaries working without any secret

## Why
The previous workflow referenced `secrets.CODECOV_TOKEN` directly in an `if:` expression. GitHub Actions rejects that before jobs start, which caused CI to fail even though Codecov is meant to be optional.