### PR TITLE
docs: fix release-contract wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,11 @@ Every knowledge page is a markdown file with this structure. GigaBrain stores th
 | `npm install -g gbrain` | ⏳ Deferred — planned follow-on, not in this release |
 | One-command curl installer | ⏳ Deferred — planned follow-on, not in this release |
 
-**GitHub Releases** and **build from source** are the only supported binary distribution channels for this release.
+**Build from source** is the only supported installation channel today. **GitHub Releases** (pre-built binaries) will ship when v0.1.0 is cut — that happens after Phase 1 gates pass.
 
-Download a pre-built binary from a GitHub Release:
+> **Not yet available.** The commands below will work once v0.1.0 is published. They are shown here so you know exactly what to run when the release lands.
+
+Download a pre-built binary from a GitHub Release (available once v0.1.0 ships):
 
 ```bash
 VERSION="v0.1.0"

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -175,7 +175,7 @@ gh issue create --title "[Phase 1] Code review: db.rs, search.rs, inference.rs" 
 gh issue create --title "[Phase 1] Adversarial review: MCP server" --body "Nibbler adversarially reviews the MCP server for OCC enforcement and injection risks." --label "squad:nibbler,phase-1"
 gh issue create --title "[Phase 2] Intelligence layer" --body "Fry implements Phase 2. OpenSpec: openspec/changes/p2-intelligence-layer/proposal.md. Blocked until Phase 1 gate passes." --label "squad:fry,phase-2"
 gh issue create --title "[Phase 3] Benchmarks + release gates" --body "Kif establishes BEIR baseline and all release gates. OpenSpec: openspec/changes/p3-polish-benchmarks/proposal.md" --label "squad:kif,phase-3"
-gh issue create --title "[Phase 3] v0.1.0 release" --body "Zapp coordinates the v0.1.0 GitHub Release after Phase 3 gates pass." --label "squad:zapp,phase-3"
+gh issue create --title "[Phase 1] v0.1.0 release" --body "Zapp coordinates the v0.1.0 GitHub Release after Phase 1 gates pass." --label "squad:zapp,phase-1"
 ```
 
 > **Note:** Labels must exist before issue creation — `gh issue create --label` silently ignores labels that do not exist yet.


### PR DESCRIPTION
Two wording fixes — no release exists yet, docs should say so clearly.

- README.md: replaced ambiguous 'for this release' language; curl snippet now has explicit 'Not yet available' callout; build-from-source vs GitHub Releases split is now unambiguous.
- docs/contributing.md: issue script had '[Phase 3] v0.1.0 release' (wrong phase) — corrected to '[Phase 1] v0.1.0 release'. Matches website/contributing.md which was already correct.

No implementation changes. Release contract unchanged: v0.1.0 ships after Phase 1 gates pass.