### PR TITLE
docs: Phase 1 is complete - fix stale status and document v0.1.0 release gap

### DIFF
--- a/.squad/agents/zapp/history.md
+++ b/.squad/agents/zapp/history.md
@@ -18,7 +18,22 @@
 - When a status table lists phases without version tags, readers cannot cross-reference the roadmap — always include both the phase label and the version target in the same row.
 - Operational scripts (issue creation commands, label helpers) are docs too: a mismatched label like `[Phase 3] v0.1.0 release` teaches contributors the wrong mental model before they've even opened a file.
 
-## 2026-04-15 P3 Release — Release Checklist & Final Doc Fix & Completion
+## 2026-04-15 Release Contract Audit — Fix 'for this release' ambiguity
+
+**Role:** Release-facing copy, release contract clarity
+
+**What happened:**
+- User flagged that docs appeared to imply a release existed or would happen after each phase but no release was present.
+- Audit found two concrete issues: (1) README.md used "this release" language implying v0.1.0 was already shipped, and the curl snippet was presented as immediately usable; (2) docs/contributing.md had `[Phase 3] v0.1.0 release` in the issue script, contradicting the version target table (`v0.1.0 = Phase 1`).
+- Discovered PR #19 (`fix/v0.1.0-release-gap`) already existed, correctly documenting that Phase 1 is complete and v0.1.0 is pending tag push.
+- Added two commits to PR #19: (1) replaced "only supported binary distribution channels for this release" with explicit build-from-source (available now) / GitHub Releases (pending v0.1.0 tag) split, plus a "Not yet available" callout on the curl block; (2) corrected contributing.md issue script label from phase-3 to phase-1.
+- Decision logged to `.squad/decisions/inbox/zapp-release-contract.md` (gitignored; local only).
+
+**Outcome:** PR #19 now carries full release-contract clarity: Phase 1 complete, v0.1.0 pending tag, no false implication of an existing release. PR #18 (opened on wrong base) was already closed.
+
+**Decision:** Option (b) — tighten wording. No premature release was published.
+
+
 
 **Role:** Release-facing copy, checklist, phase/version alignment sign-off
 

--- a/.squad/decisions/inbox/fry-release-gap.md
+++ b/.squad/decisions/inbox/fry-release-gap.md
@@ -1,0 +1,33 @@
+# Decision: Phase 1 Release Gap — v0.1.0 Tag Never Pushed
+
+**Date:** 2026-04-15  
+**Author:** Fry  
+**Status:** Proposed
+
+## Context
+
+Phase 1 (Core Storage, CLI, Search, MCP) is fully complete:
+- All 34 tasks (T01–T34) are `[x]` in the archived tasks.md
+- All 9 ship gates (SG-1 through SG-9) are `[x]`
+- PR #12 merged Phase 1 to main
+- PR #15 merged release-readiness work to main
+- CI passes on main (conclusion: success)
+- `Cargo.toml` already has `version = "0.1.0"`
+- The release workflow (`.github/workflows/release.yml`) triggers on `v*.*.*` tag pushes
+
+But **no v0.1.0 tag was ever pushed**, so the release workflow never fired, and no GitHub Release exists.
+
+Meanwhile, all public docs (README, getting-started, roadmap, website) still said "Phase 1 in progress" and "not yet available", which is now inaccurate.
+
+## Decision
+
+1. **Update all docs** to reflect Phase 1 as complete (README, docs/, website/).
+2. **After this PR merges**, push the `v0.1.0` tag on main to trigger the release workflow:
+   ```bash
+   git tag v0.1.0 && git push origin v0.1.0
+   ```
+3. **Verify** the release against `.github/RELEASE_CHECKLIST.md` once the workflow completes.
+
+## Rationale
+
+The roadmap commits to releasing v0.1.0 after Phase 1. Phase 1 is done. The gap is purely operational — nobody pushed the tag. The docs over-promised "in progress" status when the work was already shipped.

--- a/README.md
+++ b/README.md
@@ -85,9 +85,11 @@ Every knowledge page is a markdown file with this structure. GigaBrain stores th
 | `npm install -g gbrain` | ⏳ Deferred — planned follow-on, not in this release |
 | One-command curl installer | ⏳ Deferred — planned follow-on, not in this release |
 
-**GitHub Releases** and **build from source** are the only supported binary distribution channels for this release.
+**Build from source** is the only supported installation channel today. **GitHub Releases** (pre-built binaries) will ship when v0.1.0 is cut — that happens after Phase 1 gates pass and the tag is pushed.
 
-Download a pre-built binary from a GitHub Release:
+> **Not yet available.** The commands below will work once v0.1.0 is published on GitHub Releases. They are shown here so you know exactly what to run when the release lands.
+
+Download a pre-built binary from a GitHub Release (available once v0.1.0 ships):
 
 ```bash
 VERSION="v0.1.0"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Open-source personal knowledge brain. SQLite + FTS5 + vector embeddings in one file. Thin CLI harness, fat skill files. MCP-ready from day one. Runs anywhere. No API keys, no internet, no Docker. Truly static single binary.
 
-**Status:** `Phase 1 in progress` — Sprint 0 (scaffold) is complete. Phase 1 (Core storage, CLI, search, MCP) is in active development. No release yet. [See the roadmap →](#roadmap)
+**Status:** `Phase 1 complete` — all ship gates passed. `v0.1.0` release pending tag push. [See the roadmap →](#roadmap)
 
 ---
 
@@ -15,7 +15,7 @@ GigaBrain is built in explicit phases. Each phase has a hard gate — no phase b
 | Phase | Status | What ships |
 | ----- | ------ | ---------- |
 | **Sprint 0** — Repository scaffold | ✅ Complete | `Cargo.toml`, module stubs, `schema.sql`, skill stubs, CI/CD workflows |
-| **Phase 1** — Core storage + CLI | 🔨 In progress | `gbrain init`, `import`, `get`, `put`, `search`, local embeddings, hybrid search, MCP server, `query`, `compact` |
+| **Phase 1** — Core storage + CLI | ✅ Complete | `gbrain init`, `import`, `get`, `put`, `search`, local embeddings, hybrid search, MCP server, `query`, `compact` |
 | **Phase 2** — Intelligence layer | 🔜 Not started | `link`, `graph`, `stats`, `check`, `gaps` |
 | **Phase 3** — Polish + release | 🔜 Not started | Benchmarks, cross-compiled binaries, fat skill finalization |
 
@@ -48,7 +48,7 @@ Every knowledge page is a markdown file with this structure. GigaBrain stores th
 
 ## Planned features
 
-> These are the target features for v0.1. None are implemented yet. The spec and OpenSpec proposals define exactly how each will work.
+> These features ship with v0.1.0. Phase 1 implementation is complete — build from source or wait for the GitHub Release binary.
 
 - **Single static binary** — ~90MB including embedded BGE-small-en-v1.5 model weights. Zero runtime dependencies.
 - **SQLite everything** — FTS5 full-text search, `sqlite-vec` vector similarity, typed link graph — all in one `brain.db` file
@@ -74,14 +74,14 @@ Every knowledge page is a markdown file with this structure. GigaBrain stores th
 
 ## Quick start
 
-> **Not yet available.** Phase 1 (Core) is in active development — Sprint 0 (scaffold) is complete. The install options below show the full matrix: what works today, what ships with v0.1.0, and what is explicitly deferred.
+> Phase 1 is complete. Build from source today or download a pre-built binary once the v0.1.0 GitHub Release is published.
 
 ### Install options
 
 | Method | Status |
 | ------ | ------ |
-| Build from source (`cargo build --release`) | ✅ Scaffold compiles today; full implementation ships with Phase 1 |
-| GitHub Release binary (macOS ARM/x86, Linux x86_64/ARM64) | 🔜 Ships when v0.1.0 releases |
+| Build from source (`cargo build --release`) | ✅ Available now — Phase 1 complete |
+| GitHub Release binary (macOS ARM/x86, Linux x86_64/ARM64) | 🔜 Pending v0.1.0 tag push |
 | `npm install -g gbrain` | ⏳ Deferred — planned follow-on, not in this release |
 | One-command curl installer | ⏳ Deferred — planned follow-on, not in this release |
 
@@ -119,7 +119,7 @@ cargo build --release
 
 ## Usage
 
-> **Planned API.** These commands are the target surface for Phase 1 and Phase 2. They reflect the spec exactly but are not yet implemented. See [`docs/spec.md`](docs/spec.md) for full command signatures.
+> Phase 1 commands are implemented. Phase 2 commands (`link`, `graph`, `check`, `gaps`) are planned. See [`docs/spec.md`](docs/spec.md) for full command signatures.
 
 ```bash
 # Create a new brain

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -175,7 +175,7 @@ gh issue create --title "[Phase 1] Code review: db.rs, search.rs, inference.rs" 
 gh issue create --title "[Phase 1] Adversarial review: MCP server" --body "Nibbler adversarially reviews the MCP server for OCC enforcement and injection risks." --label "squad:nibbler,phase-1"
 gh issue create --title "[Phase 2] Intelligence layer" --body "Fry implements Phase 2. OpenSpec: openspec/changes/p2-intelligence-layer/proposal.md. Blocked until Phase 1 gate passes." --label "squad:fry,phase-2"
 gh issue create --title "[Phase 3] Benchmarks + release gates" --body "Kif establishes BEIR baseline and all release gates. OpenSpec: openspec/changes/p3-polish-benchmarks/proposal.md" --label "squad:kif,phase-3"
-gh issue create --title "[Phase 3] v0.1.0 release" --body "Zapp coordinates the v0.1.0 GitHub Release after Phase 3 gates pass." --label "squad:zapp,phase-3"
+gh issue create --title "[Phase 1] v0.1.0 release" --body "Zapp coordinates the v0.1.0 GitHub Release after Phase 1 gates pass." --label "squad:zapp,phase-1"
 ```
 
 > **Note:** Labels must exist before issue creation — `gh issue create --label` silently ignores labels that do not exist yet.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,7 +15,7 @@ You search it with full-text keywords and semantic queries. Any MCP-compatible A
 
 ## Status
 
-> **GigaBrain is not yet released.** Sprint 0 (repository scaffold + CI) is complete. Phase 1 (core storage, CLI, search, MCP) is in active development.
+> **Phase 1 is complete.** All ship gates passed. The `v0.1.0` GitHub Release will be published when the tag is pushed. Build from source is available now.
 >
 > See [roadmap.md](roadmap.md) for the full delivery plan.
 
@@ -25,8 +25,8 @@ You search it with full-text keywords and semantic queries. Any MCP-compatible A
 
 | Method | Status |
 | ------ | ------ |
-| Build from source (`cargo build --release`) | ✅ Scaffold compiles today; full implementation ships with Phase 1 |
-| GitHub Release binary (macOS ARM/x86, Linux x86_64/ARM64) | 🔜 Ships when v0.1.0 releases |
+| Build from source (`cargo build --release`) | ✅ Available now — Phase 1 complete |
+| GitHub Release binary (macOS ARM/x86, Linux x86_64/ARM64) | 🔜 Pending v0.1.0 tag push |
 | `npm install -g gbrain` | ⏳ Deferred — planned follow-on, not in this release |
 | One-command curl installer | ⏳ Deferred — planned follow-on, not in this release |
 
@@ -57,7 +57,7 @@ cross build --release --target aarch64-unknown-linux-musl     # Linux ARM64 (ful
 
 ## Your first brain
 
-> **Planned commands — not yet available.** The steps below are the target workflow for Phase 1. They reflect the spec exactly but are not yet implemented. Build from source to track progress; see [Status](#status) and [Install options](#install-options) above.
+> Phase 1 commands are implemented and available. Build from source to use them now; see [Status](#status) and [Install options](#install-options) above.
 
 ### 1. Initialize
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -25,11 +25,13 @@ Sprint 0 establishes the full repository structure before any core implementatio
 
 ---
 
-## Phase 1 — Core Storage, CLI, Search, and MCP 🔨
+## Phase 1 — Core Storage, CLI, Search, and MCP ✅
 
-**Status: In progress**  
+**Status: Complete**  
 **Owner:** Fry  
 **Depends on:** Sprint 0
+
+**Release:** `v0.1.0` — tag pending. All ship gates passed; pushing the `v0.1.0` tag triggers the release workflow.
 
 The smallest complete slice that proves GigaBrain's value proposition. When Phase 1 ships, a real user can import their markdown brain, search it semantically and by keyword, export without data loss, and connect any MCP-compatible agent via `gbrain serve`.
 
@@ -59,7 +61,7 @@ The smallest complete slice that proves GigaBrain's value proposition. When Phas
 - Full unit test suite
 - Embedded skills finalized
 
-**Ship gate (all must pass before Phase 2):**
+**Ship gate (all passed — Phase 2 unblocked):**
 1. `cargo test` passes
 2. `gbrain import <corpus>` → `gbrain export` → semantic diff = 0
 3. `gbrain serve` connects to Claude Code with all 5 MCP tools responding correctly

--- a/website/src/content/docs/contributing/roadmap.md
+++ b/website/src/content/docs/contributing/roadmap.md
@@ -28,11 +28,13 @@ Sprint 0 establishes the full repository structure before any core implementatio
 
 ---
 
-## Phase 1 — Core Storage, CLI, Search, and MCP 🔨
+## Phase 1 — Core Storage, CLI, Search, and MCP ✅
 
-**Status: In progress**  
+**Status: Complete**  
 **Owner:** Fry  
 **Depends on:** Sprint 0
+
+**Release:** `v0.1.0` — tag pending. All ship gates passed; pushing the `v0.1.0` tag triggers the release workflow.
 
 The smallest complete slice that proves GigaBrain's value proposition. When Phase 1 ships, a real user can import their markdown brain, search it semantically and by keyword, export without data loss, and connect any MCP-compatible agent via `gbrain serve`.
 
@@ -62,7 +64,7 @@ The smallest complete slice that proves GigaBrain's value proposition. When Phas
 - Full unit test suite
 - Embedded skills finalized
 
-**Ship gate (all must pass before Phase 2):**
+**Ship gate (all passed — Phase 2 unblocked):**
 1. `cargo test` passes
 2. `gbrain import <corpus>` → `gbrain export` → semantic diff = 0
 3. `gbrain serve` connects to Claude Code with all 5 MCP tools responding correctly

--- a/website/src/content/docs/guides/getting-started.md
+++ b/website/src/content/docs/guides/getting-started.md
@@ -18,7 +18,7 @@ You search it with full-text keywords and semantic queries. Any MCP-compatible A
 
 ## Status
 
-> **GigaBrain is not yet released.** Sprint 0 (repository scaffold + CI) is complete. Phase 1 (core storage, CLI, search, MCP) is in active development.
+> **Phase 1 is complete.** All ship gates passed. The `v0.1.0` GitHub Release will be published when the tag is pushed. Build from source is available now.
 >
 > See the [Roadmap](/contributing/roadmap/) for the full delivery plan.
 
@@ -60,7 +60,7 @@ cross build --release --target aarch64-unknown-linux-musl     # Linux ARM64 (ful
 
 ## Your first brain
 
-> **Planned commands — not yet available.** The steps below are the target workflow for Phase 1. They reflect the spec exactly but are not yet implemented. See [Status](#status) and [Install options](#install-options) above.
+> Phase 1 commands are implemented and available. Build from source to use them now; see [Status](#status) and [Install options](#install-options) above.
 
 ### 1. Initialize
 

--- a/website/src/content/docs/guides/install.md
+++ b/website/src/content/docs/guides/install.md
@@ -5,12 +5,12 @@ description: Current project status, supported install paths, and planned future
 
 ## Project Status
 
-GigaBrain has completed **Sprint 0** — the repository scaffold, CI, schema, and skill stubs are in place. Phase 1 (core storage, CLI, search, and MCP server) is in active development.
+GigaBrain has completed **Phase 1** — core storage, CLI, search, and MCP server are implemented. All Phase 1 ship gates passed.
 
 | Phase | Status | What ships |
 | ----- | ------ | ---------- |
 | **Sprint 0** — Repository scaffold | ✅ Complete | `Cargo.toml`, module stubs, `schema.sql`, skill stubs, CI workflows |
-| **Phase 1** — Core storage + CLI | 🔨 In progress | `gbrain init`, `import`, `get`, `put`, `search`, embeddings, hybrid search, MCP server — ships as **v0.1.0** |
+| **Phase 1** — Core storage + CLI | ✅ Complete | `gbrain init`, `import`, `get`, `put`, `search`, embeddings, hybrid search, MCP server — ships as **v0.1.0** |
 | **Phase 2** — Intelligence layer | ⏳ Planned | `link`, `graph`, `check`, `gaps`, progressive retrieval, full MCP surface — ships as **v0.2.0** |
 | **Phase 3** — Polish + release | ⏳ Planned | Benchmark suite, full skill suite, release pipeline hardening — ships as **v1.0.0** |
 
@@ -22,7 +22,7 @@ See the [Roadmap](/contributing/roadmap/) for ship gates and detailed scope.
 
 ### Build from source
 
-The scaffold compiles today. Full functionality ships in Phase 1.
+The full Phase 1 binary compiles today. Build from source for all features.
 
 **Requirements:** Rust stable toolchain. No other system dependencies — SQLite and sqlite-vec are bundled. Embeddings are offline-first: the build uses cached BGE-small weights from the HuggingFace cache when present, can download them when built with the `online-model` feature, and otherwise falls back to a hash-based shim.
 
@@ -45,13 +45,13 @@ cross build --release --target aarch64-unknown-linux-musl     # Linux ARM64
 
 ---
 
-## Install — Planned (Not Yet Available)
+## Install — Pending v0.1.0 Tag
 
-> The following install paths are **planned for future releases** and are not available today.
+> The following install path will be available once the `v0.1.0` tag is pushed, triggering the release workflow.
 
-### GitHub Releases (planned for v0.1.0)
+### GitHub Releases (pending v0.1.0 tag push)
 
-Once Phase 1 ships (v0.1.0), pre-built binaries will be available from GitHub Releases:
+Pre-built binaries will be available from GitHub Releases once `v0.1.0` is tagged:
 
 ```bash
 VERSION="v0.1.0"

--- a/website/src/content/docs/guides/quick-start.md
+++ b/website/src/content/docs/guides/quick-start.md
@@ -3,14 +3,14 @@ title: Quick Start
 description: "Get a brain running in minutes: init, put, search, serve."
 ---
 
-> **Planned API.** These commands are the target surface for Phase 1 and Phase 2. Phase 1 is in active development — these commands are not yet available. See [Getting Started](/guides/getting-started/) for current status.
+> Phase 1 commands are implemented and available. Build from source to use them now. See [Getting Started](/guides/getting-started/) for current status.
 
 ## 1) Install
 
 | Method | Status |
 | ------ | ------ |
-| Build from source | ✅ Available today |
-| GitHub Release binary (macOS ARM/x86, Linux x86_64/ARM64) | 🔜 Ships with v0.1.0 |
+| Build from source | ✅ Available now |
+| GitHub Release binary (macOS ARM/x86, Linux x86_64/ARM64) | 🔜 Pending v0.1.0 tag push |
 | `npm install -g gbrain` | ⏳ Deferred — planned follow-on, not in this release |
 | One-command curl installer | ⏳ Deferred — planned follow-on, not in this release |
 

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -25,7 +25,7 @@ import { CardGrid, Card } from "@astrojs/starlight/components";
 
 ## Current Status
 
-> **Phase 1 in progress.** The repository scaffold, CI, schema, and skill stubs are in place. Phase 1 (core storage, CLI, search, MCP) is in active development. Build from source works today. Pre-built binaries ship when v0.1.0 releases. npm and one-command installer are deferred follow-on work.
+> **Phase 1 complete.** All ship gates passed. Build from source is available now. Pre-built binaries will be published when the `v0.1.0` tag is pushed. npm and one-command installer are deferred follow-on work.
 
 **[Install & Status →](/guides/install/)** — supported-now vs planned channels  
 **[Roadmap →](/contributing/roadmap/)** — phased delivery plan and ship gates  


### PR DESCRIPTION
## Problem

Phase 1 (Core Storage, CLI, Search, MCP) is **fully complete**:
- All 34 tasks (T01-T34) are done in the archived tasks.md
- All 9 ship gates (SG-1 through SG-9) passed
- PR #12 merged Phase 1 to main
- PR #15 merged release-readiness work to main
- CI passes on main
- Cargo.toml already has version 0.1.0
- Release workflow is ready and triggers on v*.*.* tag pushes

**But no v0.1.0 tag was ever pushed**, so the release workflow never fired and no GitHub Release exists.

All public docs still said Phase 1 in progress and not yet available, which is now inaccurate.

## Changes

- Updates README, docs/, and website/ to reflect Phase 1 as complete
- Replaces stale in progress / not yet available / none are implemented yet messaging
- Documents that v0.1.0 release is pending tag push
- Adds squad decision note

## After merge

Push the tag to trigger the release:

    git tag v0.1.0 && git push origin v0.1.0

Then verify the release against .github/RELEASE_CHECKLIST.md once the workflow completes.