### PR TITLE
fix: define BSD types for sqlite-vec musl cross-compilation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,13 @@ jobs:
 
       - name: Build (Linux musl via cross)
         if: matrix.os == 'ubuntu-latest'
+        env:
+          CFLAGS: >-
+            -Du_int8_t=uint8_t
+            -Du_int16_t=uint16_t
+            -Du_int32_t=uint32_t
+            -Du_int64_t=uint64_t
+            -Wno-incompatible-pointer-types
         run: cross build --release --target ${{ matrix.target }}
 
       - name: Rename binary

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,11 @@
+# Cross-compilation configuration for musl static builds.
+#
+# sqlite-vec uses BSD-style types (u_int8_t, u_int16_t, etc.) which are
+# not defined in strict musl environments. We pass CFLAGS through to
+# the container so cc-rs can inject the necessary -D defines.
+
+[target.x86_64-unknown-linux-musl.env]
+passthrough = ["CFLAGS"]
+
+[target.aarch64-unknown-linux-musl.env]
+passthrough = ["CFLAGS"]


### PR DESCRIPTION
## Problem

The v0.1.0 release workflow failed on both Linux musl targets (run 24458209239). sqlite-vec uses BSD-style types (u_int8_t, u_int16_t, u_int32_t, u_int64_t) that are not available in strict musl libc environments. Without these definitions, the types implicitly resolve to int, causing -Wincompatible-pointer-types errors in modern GCC.

## Fix

- **Cross.toml**: Passes CFLAGS environment variable into musl cross-compilation Docker containers via cross.
- **release.yml**: Sets CFLAGS with -D defines mapping BSD types to C99 standard types (uint8_t, uint16_t, etc.) and adds -Wno-incompatible-pointer-types as a safety net for vendored C code.

## After merge

Delete and recreate the v0.1.0 tag on the new HEAD so the release workflow runs with the corrected configuration.