### PR TITLE
fix: aarch64 char signedness and static-pie binary check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           file ${{ matrix.artifact }}
-          file ${{ matrix.artifact }} | grep -q "statically linked" \
+          file ${{ matrix.artifact }} | grep -qE "statically linked|static-pie linked" \
             || (echo "ERROR: binary is not statically linked" && exit 1)
 
       - name: Generate SHA-256 checksum

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -19,9 +19,9 @@ fn ensure_sqlite_vec() {
                 *const (),
                 unsafe extern "C" fn(
                     *mut rusqlite::ffi::sqlite3,
-                    *mut *const i8,
+                    *mut *const std::ffi::c_char,
                     *const rusqlite::ffi::sqlite3_api_routines,
-                ) -> i32,
+                ) -> std::ffi::c_int,
             >(sqlite_vec::sqlite3_vec_init as *const ());
             rusqlite::ffi::sqlite3_auto_extension(Some(init_fn));
         }


### PR DESCRIPTION
Follow-up to #20. Fixes two remaining issues from release run 24462025506:

1. **aarch64 type mismatch**: On aarch64, C char is unsigned (u8), but db.rs hardcoded i8 in the sqlite-vec init function transmute. Fixed by using std::ffi::c_char and c_int which are platform-correct.

2. **static-pie check**: cross 0.2.5 produces static-pie linked binaries, but the release verify step only matched 'statically linked'. Updated grep to accept both forms.