### PR TITLE
openspec: beta feedback — three lanes (install-profile-flow, assertion-extraction-tightening, import-type-inference)

### DIFF
--- a/.squad/agents/leela/history.md
+++ b/.squad/agents/leela/history.md
@@ -601,3 +601,36 @@
 **Learning:**
 - Empty tasks.md on an OpenSpec change should be surfaced as a blocker during proposal validation, not discovered during cleanup. The tooling should catch this.
 - Duplicate changes with conflicting naming conventions should be explicitly archived or deleted, not left to create hazard for future implementation references.
+
+---
+
+## 2026-04-19: Beta Feedback Triage — Three OpenSpec Lanes
+
+**Session:** leela-beta-openspec  
+**Branch:** squad/beta-feedback-openspec
+
+**What happened:**
+- Triaged four GitHub issues (#36, #38, #40, #41) from beta tester doug-aillm.
+- Determined #41 is a duplicate of #36 (same root cause; #41 adds the two-step sandbox install note only).
+- Created three separate OpenSpec lanes — separate is correct because ownership, risk level, and code areas are distinct.
+
+**Lanes created:**
+
+| Lane | Closes | Owner | Risk |
+|------|--------|-------|------|
+| `install-profile-flow` | #36, #41 | fry | Low — shell scripting + docs only |
+| `assertion-extraction-tightening` | #38 | professor | High — changes runtime behavior for all vaults; Nibbler review gated |
+| `import-type-inference` | #40 | fry | Low — 1-function change in migrate.rs + docs |
+
+**Key file paths:**
+- `openspec/changes/install-profile-flow/` — proposal, design, tasks
+- `openspec/changes/assertion-extraction-tightening/` — proposal, design, tasks
+- `openspec/changes/import-type-inference/` — proposal, design, tasks
+- `.squad/decisions/inbox/leela-beta-openspec.md` — routing decision
+
+## Learnings
+
+- **Issue #41 as duplicate pattern:** When two issues share a root cause, the right call is to close one as duplicate and capture the additive notes (two-step sandbox install) in the surviving lane's tasks, not create two proposals.
+- **Assertion false positives are a trust problem, not just a bug:** The fix scope should be narrow (scoped extraction) to avoid introducing new false negatives. The structural choice — `## Assertions` section as opt-in contract — makes the behavior teachable and predictable.
+- **PARA is the dominant Obsidian structure:** Any import tooling that ignores top-level folder names will fail this user base on first run. The folder-to-type mapping is a first-class feature, not a nice-to-have.
+- **High-risk core changes should be explicitly gated on Nibbler adversarial review in the proposal.** Putting Nibbler in `reviewers:` in the frontmatter is insufficient; the tasks.md should have an explicit Nibbler phase gate (Phase D.1 pattern from p3-skills-benchmarks).

--- a/openspec/changes/assertion-extraction-tightening/design.md
+++ b/openspec/changes/assertion-extraction-tightening/design.md
@@ -1,0 +1,60 @@
+## Context
+
+`src/core/assertions.rs` extracts subject-predicate-object triples from page content
+using three regex patterns (is_a, works_at, founded). These run against the full
+`compiled_truth` text of each page. The extracted triples are stored in the `assertions`
+table and compared across pages by `check_assertions` to detect contradictions.
+
+The `asserted_by` column distinguishes `'agent'` (heuristic extraction) from `'user'`
+(manually inserted). This fix only affects the `'agent'` path.
+
+---
+
+## Decisions
+
+### 1. Scope extraction to an explicit `## Assertions` section
+
+**Decision:** Run regex extraction only against the content between a `## Assertions`
+(or `## assertions`) heading and the next `##`-level heading. If no such section exists,
+extract zero agent assertions.
+
+**Rationale:** This is the minimal, backward-compatible change that eliminates false
+positives. Users who want assertions extracted must add a dedicated section — this
+creates a clear, teachable contract. It does not require a new syntax or schema change.
+
+### 2. Frontmatter field extraction as tier 1
+
+**Decision:** Before regex extraction, inspect `frontmatter` fields: if `is_a`, `works_at`,
+or `founded` keys are present, insert them as typed triples directly (no regex needed).
+These are trusted because they are explicitly authored.
+
+**Rationale:** Frontmatter is structured data. A field `is_a: researcher` is unambiguously
+an assertion. This path should be fast and noise-free.
+
+### 3. Minimum object-length guard
+
+**Decision:** Discard any regex-extracted triple whose `object` field is shorter than
+6 characters or contains fewer than 1 whitespace-bounded word after trimming. Applied after
+extraction, before insert.
+
+**Rationale:** Noise matches like `is_a: it`, `is_a: the` slip through the current regex
+and create trivially-false contradictions. The guard is simple and cheap.
+
+### 4. No `[[is_a: X]]` inline syntax in this lane
+
+**Decision:** Inline wikilink-style assertion syntax is out of scope. Deferred to a future
+change (`inline-assertion-syntax`).
+
+**Rationale:** The scope needed to fix the false-positive problem is narrow. Inline syntax
+requires parser changes, documentation, and community discussion around the format. The
+`## Assertions` section approach solves the immediate problem without that investment.
+
+### 5. No migration for existing pages
+
+**Decision:** No automatic re-extraction on upgrade. Existing pages that relied on prose
+extraction will show zero agent assertions after this change. Users re-import or add explicit
+`## Assertions` sections.
+
+**Rationale:** A migration would require scanning all pages, re-extracting, and re-running
+check — risky for large vaults. The change moves the system from "too noisy" to "too quiet"
+which is a safer default. Users can restore precision by adding structured sections.

--- a/openspec/changes/assertion-extraction-tightening/proposal.md
+++ b/openspec/changes/assertion-extraction-tightening/proposal.md
@@ -1,0 +1,87 @@
+---
+id: assertion-extraction-tightening
+title: "check --all: tighten assertion extraction to eliminate false-positive contradictions"
+status: proposed
+type: bug
+owner: professor
+reviewers: [leela, nibbler]
+created: 2026-04-19
+depends_on: p3-skills-benchmarks
+closes: ["#38"]
+---
+
+# check --all: tighten assertion extraction to eliminate false-positive contradictions
+
+## Why
+
+`gbrain check --all` produces a flood of false-positive contradiction reports on real vaults.
+The root cause is in `src/core/assertions.rs`: `extract_from_content` runs broad regex patterns
+(is_a, works_at, founded) across the full `compiled_truth` section of every page. Any prose
+sentence that happens to match — analysis text, summaries, quoted sources — becomes an
+`is_a` or `works_at` assertion and gets compared against assertions from every other page.
+
+Beta tester doug-aillm (issue #38) reproduced this with a 789-page Obsidian vault:
+`check --all` produced 10+ false conflicts all tracing back to a single research-notes page
+whose prose happened to match the is_a pattern in many different ways. The output was
+completely unusable.
+
+The fix is structural: only extract assertions from explicitly-structured content, not arbitrary
+body prose.
+
+## What Changes
+
+### 1. `src/core/assertions.rs` — scope extraction to structured zones only
+
+Assertion extraction moves from "scan all of `compiled_truth`" to "scan only content inside
+an explicit `## Assertions` section (if present) and structured frontmatter fields."
+
+Extraction rules (in priority order):
+
+1. **Frontmatter fields** (highest trust): `is_a: founder`, `works_at: Acme Corp`,
+   `founded: Brain Co` — parse as typed assertions without regex.
+2. **`## Assertions` section** (explicit opt-in): if the page's `compiled_truth` contains a
+   `## Assertions` heading, extract only from the content between that heading and the next
+   `##`-level heading. Regex patterns continue to apply within this scoped zone.
+3. **Inline syntax** (future): `[[is_a: X]]` wikilink-style markers — reserved for a
+   future change; do not implement in this lane.
+
+If neither frontmatter fields nor an `## Assertions` section is present, extract zero
+assertions. Do not fall back to scanning general body text.
+
+### 2. `src/core/assertions.rs` — minimum object-length guard
+
+Add a guard: any regex-extracted object (the `object` field of the triple) that is fewer than
+3 tokens (whitespace-split words) or shorter than 6 characters is discarded. This filters out
+single-word noise matches like `is_a: "it"` or `is_a: "the"`.
+
+### 3. `src/schema.sql` — no schema changes
+
+The `assertions` table schema is unchanged. The `asserted_by` column already distinguishes
+`'agent'` (heuristic) from `'user'` (manual). This fix only affects the `'agent'` extraction
+path; manual assertions are unaffected.
+
+### 4. Docs — document the Assertions section format
+
+- `docs/spec.md` or equivalent: add a "Structured Assertions" section documenting:
+  - The `## Assertions` heading convention.
+  - Supported frontmatter assertion fields (`is_a`, `works_at`, `founded`).
+  - The decision to not extract from general body text.
+- `README.md` or `gbrain check --help`: update the check command description to mention that
+  assertions are extracted from structured zones only.
+
+## Non-Goals
+
+- Adding new assertion predicates — this change only fixes extraction scoping.
+- Implementing `[[is_a: X]]` inline syntax — deferred to a future lane.
+- Changing contradiction-matching logic — only the extraction side is affected.
+- Re-extracting assertions for already-imported pages automatically — users will need to
+  re-run `gbrain check` or re-import; no migration script is required.
+
+## Impact
+
+- `src/core/assertions.rs`: new `extract_assertions_section` helper; modified
+  `extract_from_content` to call it instead of scanning full content; new minimum-length guard.
+- `docs/spec.md` (or equivalent): assertion format documentation added.
+- Existing vault users will see fewer contradictions reported after this change. Pages that
+  relied on prose extraction for assertions will need to add an explicit `## Assertions`
+  section to retain them.

--- a/openspec/changes/assertion-extraction-tightening/tasks.md
+++ b/openspec/changes/assertion-extraction-tightening/tasks.md
@@ -1,0 +1,61 @@
+# Assertion Extraction Tightening — Implementation Checklist
+
+**Scope:** Scope `extract_from_content` to `## Assertions` sections and frontmatter fields
+only; add minimum object-length guard; document the structured assertion format.
+Closes: #38
+
+---
+
+## Phase A — structured extraction in `src/core/assertions.rs`
+
+- [ ] A.1 Add `extract_assertions_section(content: &str) -> &str` helper: scan `content`
+  for a line matching `^## [Aa]ssertions` and return the substring from that heading to the
+  next `^##` heading (or end of string). Return an empty string if no such section exists.
+
+- [ ] A.2 Add `extract_from_frontmatter(frontmatter: &HashMap<String, String>) -> Vec<ExtractedAssertion>`
+  helper: for each key in `["is_a", "works_at", "founded"]`, if the key is present and the
+  value is non-empty, construct a Triple with the page's title/slug as subject (passed in),
+  the key as predicate, and the value as object. Insert these with `evidence_text = "frontmatter"`.
+
+- [ ] A.3 Modify `extract_from_content(content: &str) -> Vec<ExtractedAssertion>` to call
+  `extract_assertions_section(content)` and run regex patterns against that scoped text only.
+  Do not change the regex patterns themselves. If the section is empty, return an empty vec.
+
+- [ ] A.4 Update `extract_assertions(page: &Page, conn: &Connection)` to call both
+  `extract_from_frontmatter` and `extract_from_content`. The frontmatter map must be parsed
+  from `page`'s frontmatter JSON field (already available). Merge results before inserting.
+
+- [ ] A.5 Add minimum object-length guard in `collect_pattern_matches`: after constructing a
+  `Triple`, discard it if `triple.object.trim().len() < 6`. Apply before `seen.insert`.
+
+---
+
+## Phase B — documentation
+
+- [ ] B.1 Add a "Structured Assertions" section to `docs/spec.md` (or create
+  `docs/assertions.md` if the spec is too large): document the `## Assertions` heading
+  convention, the supported frontmatter fields (`is_a`, `works_at`, `founded`), and explain
+  that general body text is not scanned.
+
+- [ ] B.2 Update `gbrain check --help` text (in `src/commands/check.rs` or equivalent) to
+  mention that assertions are extracted from structured zones only.
+
+---
+
+## Phase C — tests
+
+- [ ] C.1 Add unit test: page with `## Assertions` section — verify correct triples extracted.
+- [ ] C.2 Add unit test: page with no `## Assertions` section — verify zero triples extracted
+  (the current false-positive case).
+- [ ] C.3 Add unit test: page with frontmatter `is_a: researcher` — verify triple inserted
+  via frontmatter path, not regex.
+- [ ] C.4 Add unit test: object shorter than 6 chars (e.g., `is_a: it`) — verify discarded.
+
+---
+
+## Phase D — verification
+
+- [ ] D.1 Import the 789-page PARA test vault (or a representative subset) and run
+  `gbrain check --all`. Confirm zero false-positive contradictions from prose text.
+- [ ] D.2 Add a page with a proper `## Assertions` section and run `gbrain check --all`.
+  Confirm the assertion is detected and participates in contradiction checking correctly.

--- a/openspec/changes/import-type-inference/design.md
+++ b/openspec/changes/import-type-inference/design.md
@@ -1,0 +1,78 @@
+## Context
+
+`src/core/migrate.rs` `parse_file()` derives a page's `type` from frontmatter:
+
+```rust
+let page_type = frontmatter
+    .get("type")
+    .cloned()
+    .unwrap_or_else(|| "concept".to_string());
+```
+
+When `type:` is absent from frontmatter, the type is unconditionally `"concept"`.
+The relative file path (used to derive the slug) is available in `parse_file` as
+`file_path` and `root`, but is currently only used for slug derivation.
+
+PARA vault folder naming conventions: Obsidian users commonly name their top-level
+folders with numeric prefixes (`1. Projects`, `2. Areas`, etc.) or without (`Projects`,
+`Areas`). Both forms must be handled.
+
+---
+
+## Decisions
+
+### 1. Two-tier fallback: frontmatter first, then folder inference
+
+**Decision:** The existing frontmatter read is unchanged and remains tier 1. Folder-based
+inference is tier 2, only applied when `frontmatter["type"]` is absent. The final fallback
+remains `"concept"`.
+
+**Rationale:** Frontmatter is explicit author intent and must always win. Folder inference
+is a convention-based heuristic; if the author has set a `type:` field, their intent is clear.
+
+### 2. Case-insensitive, numeric-prefix-stripped matching
+
+**Decision:** Normalize the first path component by:
+1. Stripping a leading `[0-9]+\.\s*` prefix (Obsidian PARA numbering).
+2. Converting to lowercase.
+3. Matching against a fixed table of known folder names.
+
+**Rationale:** Beta tester's vault used `1. Projects`, `2. Areas` etc. Hardcoding without
+normalization would require separate entries for every numeric variant. Case-insensitive
+matching is table-stakes for user-facing path matching.
+
+### 3. Supported folder → type mappings (initial set)
+
+The initial mapping covers the PARA structure and the two most common named wings:
+
+| Normalized folder  | Type       |
+|--------------------|------------|
+| `projects`         | `project`  |
+| `areas`            | `area`     |
+| `resources`        | `resource` |
+| `archives`         | `archive`  |
+| `journal`          | `journal`  |
+| `journals`         | `journal`  |
+| `people`           | `person`   |
+| `companies`        | `company`  |
+| `orgs`             | `company`  |
+
+Anything not in the table falls through to `"concept"`.
+
+### 4. Log inferred type only when tier 2 was used
+
+**Decision:** The import progress output notes `(inferred type: X)` only when the type was
+inferred from the folder, not when it came from frontmatter or when the fallback `"concept"`
+was used unchanged.
+
+**Rationale:** Logging every type assignment would be too verbose for large vaults. Users
+need to see when the heuristic fired, not when frontmatter was honored as expected.
+
+### 5. No config-file mapping in this lane
+
+**Decision:** The folder-to-type table is hardcoded in this change. A user-configurable
+mapping file is deferred.
+
+**Rationale:** The PARA mapping covers the target user base. A config format adds surface
+area and documentation burden. The hardcoded table can be extended in a follow-on change
+without breaking any interface.

--- a/openspec/changes/import-type-inference/proposal.md
+++ b/openspec/changes/import-type-inference/proposal.md
@@ -1,0 +1,90 @@
+---
+id: import-type-inference
+title: "import: respect frontmatter type and infer from PARA folder structure"
+status: proposed
+type: enhancement
+owner: fry
+reviewers: [leela]
+created: 2026-04-19
+closes: ["#40"]
+---
+
+# import: respect frontmatter type and infer from PARA folder structure
+
+## Why
+
+`gbrain import` assigns every page the type `concept` unless the page's frontmatter contains
+an explicit `type:` field. For the dominant Obsidian PKM structure — PARA (Projects, Areas,
+Resources, Archives) — this means ~99% of pages land as `concept`, making type-filtered
+queries useless and the stats output misleading.
+
+Beta tester doug-aillm (issue #40) reproduced this: after importing a 789-page PARA vault,
+stats showed 784/789 pages as `concept`. The target user base is the Obsidian/PARA community;
+ignoring folder structure is a first-run blocker for this cohort.
+
+The code already reads the frontmatter `type:` field. The gap is the fallback: when `type:` is
+absent, the code hard-codes `"concept"` without consulting the file's path.
+
+## What Changes
+
+### 1. `src/core/migrate.rs` — tiered type inference in `parse_file`
+
+Replace the single-fallback `"concept"` default with a two-tier fallback:
+
+**Tier 1 — frontmatter field (existing, unchanged):**
+If `frontmatter["type"]` is present and non-empty, use it verbatim.
+
+**Tier 2 — top-level folder inference (new):**
+If `frontmatter["type"]` is absent, inspect the first path component of the relative file
+path (the top-level folder) and map it to a type:
+
+| Folder (case-insensitive prefix match) | Inferred type |
+|----------------------------------------|---------------|
+| `projects` / `1. projects`             | `project`     |
+| `areas`    / `2. areas`                | `area`        |
+| `resources`/ `3. resources`            | `resource`    |
+| `archives` / `4. archives`             | `archive`     |
+| `journal`  / `journals`                | `journal`     |
+| `people`                               | `person`      |
+| `companies`/ `orgs`                    | `company`     |
+| anything else                          | `concept`     |
+
+The matching is case-insensitive and strips leading numeric prefixes (`1. `, `2. `, etc.) to
+handle Obsidian PARA numbered folder naming conventions.
+
+**Tier 3 — final fallback (unchanged):**
+`"concept"` if no folder mapping matches.
+
+### 2. `src/core/migrate.rs` — expose inferred type in import output
+
+The import command's progress output already logs the slug. Extend it to log the inferred type
+when it differs from the frontmatter value (i.e., when tier 2 was used), so users can verify
+the inference is correct:
+
+```
+Imported people/alice (inferred type: person)
+```
+
+### 3. Docs — document type inference rules
+
+- `docs/getting-started.md`: add a "Page types and PARA structure" section documenting the
+  folder-to-type mapping and how to override it with a frontmatter `type:` field.
+- `gbrain import --help` text: add a note that types are inferred from folder structure when
+  not set in frontmatter.
+
+## Non-Goals
+
+- Inferring types from page content or body text — folder structure and frontmatter only.
+- Supporting arbitrary custom folder-to-type mappings via config file — deferred; the built-in
+  PARA mapping covers the majority of users.
+- Changing how types are stored in the database — the `type` column is unchanged.
+- Retroactively re-typing already-imported pages — users who want updated types must
+  re-import or use `gbrain put` to update individual pages.
+
+## Impact
+
+- `src/core/migrate.rs`: new `infer_type_from_path` function; modified `parse_file` to call it
+  as fallback when frontmatter `type:` is absent.
+- `docs/getting-started.md`: new "Page types and PARA structure" section.
+- Import behavior change: PARA-structured vaults will now yield meaningful type distributions
+  on first import without any frontmatter changes.

--- a/openspec/changes/import-type-inference/tasks.md
+++ b/openspec/changes/import-type-inference/tasks.md
@@ -1,0 +1,78 @@
+# Import Type Inference — Implementation Checklist
+
+**Scope:** Add folder-based type inference as tier-2 fallback in `gbrain import`;
+document the type inference rules.
+Closes: #40
+
+---
+
+## Phase A — type inference in `src/core/migrate.rs`
+
+- [ ] A.1 Add `infer_type_from_path(file_path: &Path, root: &Path) -> Option<String>` function:
+  - Compute the relative path from `root`.
+  - Extract the first path component (top-level folder name).
+  - Strip leading `[0-9]+\.\s*` prefix (regex or manual char scan).
+  - Convert to lowercase.
+  - Match against the following table and return `Some(type_str)` on a hit, `None` on miss:
+    - `projects` → `"project"`
+    - `areas` → `"area"`
+    - `resources` → `"resource"`
+    - `archives` → `"archive"`
+    - `journal` | `journals` → `"journal"`
+    - `people` → `"person"`
+    - `companies` | `orgs` → `"company"`
+
+- [ ] A.2 Modify `parse_file` to use a two-tier lookup:
+  ```rust
+  let (page_type, type_inferred) = if let Some(t) = frontmatter.get("type") {
+      (t.clone(), false)
+  } else if let Some(t) = infer_type_from_path(file_path, root) {
+      (t, true)
+  } else {
+      ("concept".to_string(), false)
+  };
+  ```
+  Thread `type_inferred` through `ParsedEntry` or log it locally.
+
+- [ ] A.3 Log inferred type in the import progress output when `type_inferred == true`:
+  `Imported <slug> (inferred type: <type>)` — only when tier 2 fired. Use the existing
+  progress printer; do not add a new logging mechanism.
+
+---
+
+## Phase B — documentation
+
+- [ ] B.1 Add a "Page types and PARA structure" section to `docs/getting-started.md`:
+  - List the supported folder → type mappings in a table.
+  - Explain that `type:` in frontmatter always overrides folder inference.
+  - Note that the fallback for unrecognized folders is `concept`.
+  - Show an example: importing `2. Areas/Health/exercise.md` yields type `area`.
+
+- [ ] B.2 Update `gbrain import --help` text (in `src/commands/import.rs` or equivalent) to
+  note that page types are inferred from top-level folder name when not set in frontmatter.
+
+---
+
+## Phase C — tests
+
+- [ ] C.1 Unit tests for `infer_type_from_path`:
+  - `1. Projects/foo/bar.md` → `project`
+  - `2. Areas/health.md` → `area`
+  - `Resources/book.md` → `resource`
+  - `Journal/2024-01-01.md` → `journal`
+  - `people/alice.md` → `person`
+  - `random/note.md` → `None` (falls through)
+
+- [ ] C.2 Integration test: import a minimal PARA-structured directory with no `type:`
+  frontmatter fields. Verify stats show correct type distribution.
+
+- [ ] C.3 Test that explicit frontmatter `type:` always wins over folder inference:
+  a file at `Projects/note.md` with `type: concept` in frontmatter must be typed `concept`.
+
+---
+
+## Phase D — verification
+
+- [ ] D.1 Import the beta tester's vault structure (or representative subset). Run
+  `gbrain stats`. Confirm `concept` count drops to near-zero for PARA-structured content
+  and project/area/resource/archive counts are proportional to folder sizes.

--- a/openspec/changes/install-profile-flow/design.md
+++ b/openspec/changes/install-profile-flow/design.md
@@ -1,0 +1,47 @@
+## Context
+
+`scripts/install.sh` is a POSIX-compatible shell script that installs the `gbrain` binary
+from GitHub Releases. As of `v0.9.1` it supports dual channels (airgapped/online),
+checksums, and smoke-tests the binary. It does not touch shell profiles.
+
+---
+
+## Decisions
+
+### 1. Auto-write is the default; opt-out is explicit
+
+**Decision:** The installer writes to the shell profile by default. The user opts out with
+`GBRAIN_NO_PROFILE=1` (env var, works with pipe-to-sh) or `--no-profile` (flag, works with
+two-step download-then-run).
+
+**Rationale:** The primary failure mode is silent: user installs, binary works in session,
+then is unreachable on restart. Defaulting to profile writes eliminates the failure mode.
+Opt-out is needed for CI environments that manage `$PATH` separately.
+
+### 2. Detect profile via `$SHELL`, not fixed path
+
+**Decision:** Use `$SHELL` to determine the preferred profile:
+- `*/zsh` → `~/.zshrc`
+- `*/bash` → `~/.bashrc` (Linux) or `~/.bash_profile` (Darwin, because `~/.bash_profile`
+  is sourced by login shells on macOS)
+- anything else → `~/.profile`
+
+**Rationale:** Hardcoding `~/.zshrc` fails on bash users and vice versa. `$SHELL` is set
+on all supported platforms and is more reliable than reading `/etc/shells`.
+
+### 3. Idempotent writes — check before appending
+
+**Decision:** Before appending a line, grep the target profile file for the exported
+variable name (`PATH` / `GBRAIN_DB`). Skip the append if already present.
+
+**Rationale:** Repeated installs (version upgrades) must not produce duplicate export lines.
+
+### 4. Two-step install as a documented alternative, not default
+
+**Decision:** The piped install (`curl ... | sh`) remains the primary recommended path.
+The two-step pattern (`-o gbrain-install.sh && sh gbrain-install.sh`) is documented as
+an explicit alternative for sandboxed environments. No default behavior change.
+
+**Rationale:** Changing the primary path would break existing documentation and bookmarks.
+The two-step workaround is narrowly useful; exposing it in the success output and docs is
+sufficient.

--- a/openspec/changes/install-profile-flow/proposal.md
+++ b/openspec/changes/install-profile-flow/proposal.md
@@ -1,0 +1,79 @@
+---
+id: install-profile-flow
+title: "Install: auto-write PATH and GBRAIN_DB to shell profile"
+status: proposed
+type: enhancement
+owner: fry
+reviewers: [leela]
+created: 2026-04-19
+depends_on: simplified-install
+closes: ["#36", "#41"]
+---
+
+# Install: auto-write PATH and GBRAIN_DB to shell profile
+
+## Why
+
+After a successful install, `scripts/install.sh` prints PATH and GBRAIN_DB hints but makes no
+changes to the user's shell profile. For human users this is easy to miss; for agent users
+(OpenClaw, CI) it is a silent failure — the binary installs correctly but is unreachable after
+the session ends because `~/.local/bin` is not in `$PATH` and `GBRAIN_DB` is never set.
+
+Issue #36 (filed by beta tester doug-aillm) named this as an adoption blocker for agent users.
+Issue #41 is a duplicate that adds a second requirement: document a two-step install for
+sandboxed environments where piping a remote script directly to `sh` is blocked.
+
+## What Changes
+
+### 1. `scripts/install.sh` — automatic profile write
+
+After a successful install, the script:
+
+1. Detects the user's preferred shell profile (`~/.zshrc` for zsh, `~/.bashrc` for bash,
+   `~/.profile` as fallback), based on `$SHELL` and file existence.
+2. Appends the `PATH` export line if `$INSTALL_DIR` is not already present in the profile.
+3. Appends the `GBRAIN_DB` export line if it is not already present in the profile.
+4. Prints a confirmation: `Added PATH and GBRAIN_DB to ~/.zshrc. Run: source ~/.zshrc`
+5. Respects a `--no-profile` flag (or `GBRAIN_NO_PROFILE=1` env var) to skip all profile
+   writes entirely.
+
+Idempotency: the script checks for the presence of each line before appending, so
+repeated installs do not duplicate entries.
+
+### 2. `scripts/install.sh` — two-step install documentation block
+
+After the success message, the script prints a two-step alternative for sandboxed environments:
+
+```
+For sandboxed environments (agents, restricted shells):
+  curl -fsSL https://raw.githubusercontent.com/macro88/gigabrain/main/scripts/install.sh \
+    -o gbrain-install.sh && sh gbrain-install.sh
+```
+
+### 3. `packages/gbrain-npm/scripts/postinstall.js` — matching GBRAIN_DB tip
+
+The npm postinstall already prints a GBRAIN_DB tip. Update the message to match the new
+shell installer wording for consistency.
+
+### 4. Docs — README Quick Start and install guide
+
+- README.md Quick Start: add a note that the installer writes to the shell profile automatically
+  and document `--no-profile` / `GBRAIN_NO_PROFILE` opt-out.
+- `website/src/content/docs/guides/install.md`: add a "Sandboxed / agent environments" section
+  with the two-step install pattern and the `GBRAIN_NO_PROFILE=1` env var.
+- `docs/getting-started.md`: update install walkthrough to reflect automatic profile setup.
+
+## Non-Goals
+
+- Windows support (separate proposal when Windows is a supported target).
+- Fish shell support — fish uses a different config format. Document as unsupported; fall through
+  to `~/.profile` for fish users.
+- Modifying any profile other than the one detected — no multi-profile writes.
+
+## Impact
+
+- `scripts/install.sh`: new `write_profile` and `detect_profile` shell functions; new
+  `--no-profile` flag parsing; updated post-install output.
+- `packages/gbrain-npm/scripts/postinstall.js`: minor wording update to GBRAIN_DB tip.
+- `README.md`, `website/src/content/docs/guides/install.md`, `docs/getting-started.md`:
+  documentation updates.

--- a/openspec/changes/install-profile-flow/tasks.md
+++ b/openspec/changes/install-profile-flow/tasks.md
@@ -1,0 +1,74 @@
+# Install Profile Flow — Implementation Checklist
+
+**Scope:** Auto-write PATH and GBRAIN_DB to shell profile after successful install;
+document two-step install for sandboxed environments; match npm postinstall wording.
+Closes: #36, #41
+
+---
+
+## Phase A — shell installer profile writes (`scripts/install.sh`)
+
+- [ ] A.1 Add `detect_profile` function: inspect `$SHELL` to choose profile file:
+  - `*/zsh` → `$HOME/.zshrc`
+  - `*/bash` on Darwin → `$HOME/.bash_profile`; on Linux → `$HOME/.bashrc`
+  - fallback → `$HOME/.profile`
+  Create the file if it does not exist.
+
+- [ ] A.2 Add `write_profile_line` helper: takes `(profile, marker_pattern, line_to_append)`.
+  Greps `$profile` for `$marker_pattern`; appends `$line_to_append` only if not present.
+  Prints `  Added <line> to <profile>` when it appends; silently skips when already present.
+
+- [ ] A.3 Add `write_profile` function: calls `write_profile_line` twice:
+  - PATH: marker `$INSTALL_DIR`, line `export PATH="$INSTALL_DIR:$PATH"`
+  - GBRAIN_DB: marker `GBRAIN_DB`, line `export GBRAIN_DB="$HOME/brain.db"`
+  Prints a final summary line: `Profile updated. Run: source <profile>`
+
+- [ ] A.4 Add `--no-profile` flag parsing to the script's argument loop. Set
+  `GBRAIN_NO_PROFILE=1` when the flag is present. Respect existing `GBRAIN_NO_PROFILE` env var.
+
+- [ ] A.5 Call `write_profile` (or skip if `GBRAIN_NO_PROFILE=1`) after the smoke test
+  succeeds. Replace the existing `print_path_hint` and `print_gbrain_db_tip` calls: when
+  profile writes are enabled, the new summary line replaces both; when writes are disabled
+  (`--no-profile`), print the existing hint block as fallback.
+
+- [ ] A.6 Add the two-step install block to the end of the success output (always printed):
+  ```
+  For sandboxed/agent environments: download first, then run:
+    curl -fsSL .../install.sh -o gbrain-install.sh && sh gbrain-install.sh
+  ```
+
+---
+
+## Phase B — npm postinstall wording
+
+- [ ] B.1 Update `packages/gbrain-npm/scripts/postinstall.js`: replace the GBRAIN_DB tip
+  wording to match the new shell installer language exactly. No logic change.
+
+---
+
+## Phase C — docs
+
+- [ ] C.1 Update `README.md` Quick Start install section: note that the installer writes
+  PATH and GBRAIN_DB to the shell profile automatically and document `GBRAIN_NO_PROFILE=1`
+  for CI/agent users.
+
+- [ ] C.2 Update `website/src/content/docs/guides/install.md`: add "Sandboxed / agent
+  environments" subsection with two-step install pattern and `GBRAIN_NO_PROFILE=1`.
+
+- [ ] C.3 Update `docs/getting-started.md`: reflect automatic profile setup in the
+  post-install walkthrough steps.
+
+---
+
+## Phase D — verification
+
+- [ ] D.1 Run `install.sh` in a fresh shell with no existing profile writes. Confirm
+  `~/.zshrc` (or appropriate profile) receives both export lines exactly once.
+
+- [ ] D.2 Run `install.sh` a second time (upgrade scenario). Confirm no duplicate lines
+  are appended to the profile.
+
+- [ ] D.3 Run `GBRAIN_NO_PROFILE=1 sh install.sh`. Confirm no profile writes occur and
+  the hint block is printed instead.
+
+- [ ] D.4 Run `sh install.sh --no-profile`. Same as D.3.


### PR DESCRIPTION
## Summary

Planning and proposal work for three beta feedback lanes from doug-aillm.

**No implementation in this PR** — this is the OpenSpec proposal layer for team review and routing.

---

## Lanes

### 1. `install-profile-flow` — closes #36, #41
- Auto-write PATH and GBRAIN_DB to shell profile after successful install
- `--no-profile` / `GBRAIN_NO_PROFILE=1` opt-out for CI/agent environments  
- Two-step install documented for sandboxed environments
- **Owner: Fry** | Low risk | Ready to implement

### 2. `assertion-extraction-tightening` — closes #38
- Scope `extract_from_content` to `## Assertions` sections only (eliminates false-positive cascade from prose text)
- Add frontmatter field extraction as tier-1
- Add minimum object-length guard
- **Owner: Professor** | High risk — changes runtime behavior for all vaults | **Nibbler review gated**

### 3. `import-type-inference` — closes #40
- Add PARA folder-based type inference as tier-2 fallback in `gbrain import`
- Mapping: Projects→project, Areas→area, Resources→resource, Archives→archive, Journal→journal, People→person, Companies→company
- Handles Obsidian numeric prefix naming (`1. Projects`, `2. Areas`)
- **Owner: Fry** | Low risk | Ready to implement

---

## Routing decision

Fry's two lanes (install + import) are independent and can be executed in parallel.
Professor's assertion lane requires Nibbler adversarial review before merge — this is the only inter-team dependency.

Issue #41 confirmed as duplicate of #36; captured in install lane.