### PR TITLE
feat: auto-write PATH and GBRAIN_DB to shell profile on install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,9 @@ jobs:
       - name: Run tests (online channel)
         run: cargo test --verbose --no-default-features --features bundled,online-model
 
+      - name: Run installer profile tests
+        run: sh tests/install_profile.sh
+
   benchmarks:
     name: Offline Benchmarks
     runs-on: ubuntu-latest

--- a/.squad/decisions/inbox/bender-last-46.md
+++ b/.squad/decisions/inbox/bender-last-46.md
@@ -1,0 +1,41 @@
+### PR #46 Final Validation — Bender
+
+**Date:** 2026-04-17
+**By:** Bender (Tester)
+**Verdict:** ✅ APPROVE
+
+**Scope:** Final test/validation review of Scruffy's revision (1da8443) — the last claimed seam removal.
+
+---
+
+**The fake seam is gone.**
+
+Old T19 overrode `detect_profile()` with a canned stub that returned 1 and printed a hardcoded warning. The failure was synthetic — it never exercised the production `detect_profile` code path through `main()`.
+
+New T19 (Scruffy, 1da8443):
+- Re-sources `install.sh` at line 371, restoring ALL production functions including `detect_profile`.
+- Creates a real unwritable directory (`chmod 500`) and sets `HOME` to it.
+- Calls `main()` — the real entry path.
+- Production `detect_profile` runs, hits the real filesystem constraint, and fails genuinely.
+- `write_profile` propagates the failure to `main()`, which exits non-zero with recovery output.
+
+**Only network I/O is stubbed** (curl, resolve_version, resolve_platform, resolve_channel, verify_checksum, need_cmd). These are the correct stubs for deterministic testing. No profile/write functions are faked.
+
+**Assertions verified (T19/T19b/T19c):**
+1. `main()` exits non-zero ✓
+2. stderr contains real `detect_profile` warning: `Cannot create shell profile <path>/.zshrc` ✓
+3. stderr contains `main()` failure message: `gbrain was installed, but PATH/GBRAIN_DB were not persisted automatically.` ✓
+4. stderr contains manual recovery hints (PATH, GBRAIN_DB exports) ✓
+5. stderr contains sandboxed/two-step install hint ✓
+6. stdout still reports `Installed gbrain to` (binary was installed before profile failed) ✓
+7. Profile file was NOT created in the unwritable directory ✓
+
+**Validation evidence:**
+- Local run: 25/25 tests pass, 0 failures.
+- CI (commit 1da8443): All 12 check runs green — Check, Test (including `sh tests/install_profile.sh`), Coverage, Benchmarks.
+- Codecov: 86.98%, no coverage regression.
+
+**Non-blocking note:**
+- `openspec/changes/simplified-install/proposal.md` still says "does not modify any shell files." Stale after this PR. Not a code defect — OpenSpec doc nit for Hermes.
+
+**Outcome:** The installer failure-path contract is proven end-to-end through the real `main()` function with real filesystem constraints. No remaining test seams bypass production code. Cleared for merge.

--- a/.squad/decisions/inbox/bender-rererevise-46.md
+++ b/.squad/decisions/inbox/bender-rererevise-46.md
@@ -1,0 +1,35 @@
+---
+date: 2026-04-19
+by: Bender (Tester)
+scope: PR #46 — install profile flow
+type: revision
+---
+
+# Bender re-re-revision of PR #46
+
+## What was wrong
+
+Three categories of defect remained after Fry, Leela, and Mom's revisions:
+
+1. **T10–T13 tested a copied function body.** The `detect_profile()` function was pasted into the test file instead of re-sourcing `install.sh`. If production code changed, tests would silently pass against stale logic.
+
+2. **No end-to-end `GBRAIN_NO_PROFILE=1` → `main()` coverage.** T16 verified the env-var-to-variable propagation, and T14 verified `--no-profile` flag through `main()`, but no test actually ran `main()` with the env var set and verified the profile was untouched. The documented pipe flow (`curl ... | GBRAIN_NO_PROFILE=1 sh`) was unproven.
+
+3. **Env vars on the wrong side of `curl ... | sh`.** Five copy-paste examples and two recovery hints in `install.sh` placed `GBRAIN_VERSION`, `GBRAIN_CHANNEL`, or `GBRAIN_INSTALL_DIR` on the `curl` side of the pipe, where they apply to `curl` (which ignores them) rather than `sh` (which reads them). Users copying these examples would get default behavior silently.
+
+## What was fixed
+
+1. T10–T13 now re-source `install.sh` to restore production `detect_profile`.
+2. New T17 re-sources `install.sh` with `GBRAIN_NO_PROFILE=1`, re-applies stubs, calls `main()`, and asserts the profile is empty.
+3. All six `curl | sh` examples moved env vars to the `sh` side: `curl ... | VAR=val sh`. The two `install.sh` recovery hints were corrected the same way.
+4. OpenSpec tasks.md A.2/A.3/A.4 aligned with actual `write_profile_line(profile, line)` signature.
+
+## Verification
+
+- 21/21 shell tests pass (was 20, +1 new T17)
+- All cargo tests pass
+- No remaining `GBRAIN_*` env vars on the `curl` side of any executable example
+
+## Decision
+
+This revision is scoped to test fidelity and doc correctness. No production logic was changed.

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ Install with the shell script:
 curl -fsSL https://raw.githubusercontent.com/macro88/gigabrain/main/scripts/install.sh | sh
 
 # Online channel instead of the default airgapped channel
-GBRAIN_CHANNEL=online \
-  curl -fsSL https://raw.githubusercontent.com/macro88/gigabrain/main/scripts/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/macro88/gigabrain/main/scripts/install.sh \
+  | GBRAIN_CHANNEL=online sh
 ```
 
 > The installer automatically writes `PATH` and `GBRAIN_DB` exports to your shell profile

--- a/README.md
+++ b/README.md
@@ -97,6 +97,18 @@ GBRAIN_CHANNEL=online \
   curl -fsSL https://raw.githubusercontent.com/macro88/gigabrain/main/scripts/install.sh | sh
 ```
 
+> The installer automatically writes `PATH` and `GBRAIN_DB` exports to your shell profile
+> (`~/.zshrc`, `~/.bashrc`, or `~/.profile`) so gbrain works immediately in new sessions.
+> To skip profile writes (e.g. in CI), set `GBRAIN_NO_PROFILE=1` or pass `--no-profile`.
+
+**Sandboxed / agent environments** — if your security sandbox blocks piping remote scripts
+directly to `sh`, download first, then run:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/macro88/gigabrain/main/scripts/install.sh \
+  -o gbrain-install.sh && sh gbrain-install.sh
+```
+
 Download a pre-built binary from GitHub Releases:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -98,8 +98,16 @@ GBRAIN_CHANNEL=online \
 ```
 
 > The installer automatically writes `PATH` and `GBRAIN_DB` exports to your shell profile
-> (`~/.zshrc`, `~/.bashrc`, or `~/.profile`) so gbrain works immediately in new sessions.
-> To skip profile writes (e.g. in CI), set `GBRAIN_NO_PROFILE=1` or pass `--no-profile`.
+> (`~/.zshrc`, `~/.bash_profile` on macOS / `~/.bashrc` on Linux, or `~/.profile`) so gbrain
+> works immediately in new sessions.
+> To skip profile writes (e.g. in CI), pipe with `GBRAIN_NO_PROFILE=1 sh` or pass `--no-profile`
+> with the two-step method:
+> ```bash
+> curl -fsSL https://raw.githubusercontent.com/macro88/gigabrain/main/scripts/install.sh | GBRAIN_NO_PROFILE=1 sh
+> # two-step (download first, then run with flag):
+> curl -fsSL https://raw.githubusercontent.com/macro88/gigabrain/main/scripts/install.sh \
+>   -o gbrain-install.sh && sh gbrain-install.sh --no-profile
+> ```
 
 **Sandboxed / agent environments** — if your security sandbox blocks piping remote scripts
 directly to `sh`, download first, then run:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -62,6 +62,13 @@ cross build --release --target aarch64-unknown-linux-musl     # Linux ARM64 (ful
 
 > **Phase 1 commands** are implemented. **Phase 2 commands** (graph, check, gaps) are implemented. **Phase 3 commands** (validate, call, pipe, skills) are implemented. Build from source to use all features now; see [Status](#status) and [Install options](#install-options) above.
 
+> **Post-install note:** The shell installer (`scripts/install.sh`) automatically adds `PATH` and `GBRAIN_DB` to your shell profile. If you built from source or used the manual GitHub Releases download, add these to your profile yourself:
+> ```bash
+> export PATH="$HOME/.local/bin:$PATH"
+> export GBRAIN_DB="$HOME/brain.db"
+> ```
+> For CI/agent environments that manage PATH externally, skip profile writes with `GBRAIN_NO_PROFILE=1`.
+
 ### 1. Initialize
 
 ```bash
@@ -202,6 +209,7 @@ The `original` type is for your own thinking — distinct from compiled external
 | Variable | Default | Purpose |
 | -------- | ------- | ------- |
 | `GBRAIN_DB` | `./brain.db` | Path to the active brain database |
+| `GBRAIN_NO_PROFILE` | `0` | Set to `1` to skip shell profile writes during install |
 
 ---
 

--- a/openspec/changes/install-profile-flow/design.md
+++ b/openspec/changes/install-profile-flow/design.md
@@ -1,0 +1,47 @@
+## Context
+
+`scripts/install.sh` is a POSIX-compatible shell script that installs the `gbrain` binary
+from GitHub Releases. As of `v0.9.1` it supports dual channels (airgapped/online),
+checksums, and smoke-tests the binary. It does not touch shell profiles.
+
+---
+
+## Decisions
+
+### 1. Auto-write is the default; opt-out is explicit
+
+**Decision:** The installer writes to the shell profile by default. The user opts out with
+`GBRAIN_NO_PROFILE=1` (env var, works with pipe-to-sh) or `--no-profile` (flag, works with
+two-step download-then-run).
+
+**Rationale:** The primary failure mode is silent: user installs, binary works in session,
+then is unreachable on restart. Defaulting to profile writes eliminates the failure mode.
+Opt-out is needed for CI environments that manage `$PATH` separately.
+
+### 2. Detect profile via `$SHELL`, not fixed path
+
+**Decision:** Use `$SHELL` to determine the preferred profile:
+- `*/zsh` → `~/.zshrc`
+- `*/bash` → `~/.bashrc` (Linux) or `~/.bash_profile` (Darwin, because `~/.bash_profile`
+  is sourced by login shells on macOS)
+- anything else → `~/.profile`
+
+**Rationale:** Hardcoding `~/.zshrc` fails on bash users and vice versa. `$SHELL` is set
+on all supported platforms and is more reliable than reading `/etc/shells`.
+
+### 3. Idempotent writes — check before appending
+
+**Decision:** Before appending a line, grep the target profile file for the exported
+variable name (`PATH` / `GBRAIN_DB`). Skip the append if already present.
+
+**Rationale:** Repeated installs (version upgrades) must not produce duplicate export lines.
+
+### 4. Two-step install as a documented alternative, not default
+
+**Decision:** The piped install (`curl ... | sh`) remains the primary recommended path.
+The two-step pattern (`-o gbrain-install.sh && sh gbrain-install.sh`) is documented as
+an explicit alternative for sandboxed environments. No default behavior change.
+
+**Rationale:** Changing the primary path would break existing documentation and bookmarks.
+The two-step workaround is narrowly useful; exposing it in the success output and docs is
+sufficient.

--- a/openspec/changes/install-profile-flow/design.md
+++ b/openspec/changes/install-profile-flow/design.md
@@ -31,10 +31,15 @@ on all supported platforms and is more reliable than reading `/etc/shells`.
 
 ### 3. Idempotent writes — check before appending
 
-**Decision:** Before appending a line, grep the target profile file for the exported
-variable name (`PATH` / `GBRAIN_DB`). Skip the append if already present.
+**Decision:** Before appending a line, grep the target profile file for the exact export
+line to be appended (e.g. `export PATH="$INSTALL_DIR:$PATH"` / `export GBRAIN_DB="$HOME/brain.db"`).
+Use fixed-string matching (`grep -F`) to avoid false positives from regex metacharacters in
+paths. Skip the append if the exact line is already present.
 
 **Rationale:** Repeated installs (version upgrades) must not produce duplicate export lines.
+Using the exact export line as the idempotency key is precise: matching only the variable name
+`PATH` would falsely trigger on every profile (PATH is always present), while matching the
+full line is accurate and handles paths with shell-special characters safely.
 
 ### 4. Two-step install as a documented alternative, not default
 

--- a/openspec/changes/install-profile-flow/proposal.md
+++ b/openspec/changes/install-profile-flow/proposal.md
@@ -1,0 +1,79 @@
+---
+id: install-profile-flow
+title: "Install: auto-write PATH and GBRAIN_DB to shell profile"
+status: implemented
+type: enhancement
+owner: fry
+reviewers: [leela]
+created: 2026-04-19
+depends_on: simplified-install
+closes: ["#36", "#41"]
+---
+
+# Install: auto-write PATH and GBRAIN_DB to shell profile
+
+## Why
+
+After a successful install, `scripts/install.sh` prints PATH and GBRAIN_DB hints but makes no
+changes to the user's shell profile. For human users this is easy to miss; for agent users
+(OpenClaw, CI) it is a silent failure — the binary installs correctly but is unreachable after
+the session ends because `~/.local/bin` is not in `$PATH` and `GBRAIN_DB` is never set.
+
+Issue #36 (filed by beta tester doug-aillm) named this as an adoption blocker for agent users.
+Issue #41 is a duplicate that adds a second requirement: document a two-step install for
+sandboxed environments where piping a remote script directly to `sh` is blocked.
+
+## What Changes
+
+### 1. `scripts/install.sh` — automatic profile write
+
+After a successful install, the script:
+
+1. Detects the user's preferred shell profile (`~/.zshrc` for zsh, `~/.bashrc` for bash,
+   `~/.profile` as fallback), based on `$SHELL` and file existence.
+2. Appends the `PATH` export line if `$INSTALL_DIR` is not already present in the profile.
+3. Appends the `GBRAIN_DB` export line if it is not already present in the profile.
+4. Prints a confirmation: `Added PATH and GBRAIN_DB to ~/.zshrc. Run: source ~/.zshrc`
+5. Respects a `--no-profile` flag (or `GBRAIN_NO_PROFILE=1` env var) to skip all profile
+   writes entirely.
+
+Idempotency: the script checks for the presence of each line before appending, so
+repeated installs do not duplicate entries.
+
+### 2. `scripts/install.sh` — two-step install documentation block
+
+After the success message, the script prints a two-step alternative for sandboxed environments:
+
+```
+For sandboxed environments (agents, restricted shells):
+  curl -fsSL https://raw.githubusercontent.com/macro88/gigabrain/main/scripts/install.sh \
+    -o gbrain-install.sh && sh gbrain-install.sh
+```
+
+### 3. `packages/gbrain-npm/scripts/postinstall.js` — matching GBRAIN_DB tip
+
+The npm postinstall already prints a GBRAIN_DB tip. Update the message to match the new
+shell installer wording for consistency.
+
+### 4. Docs — README Quick Start and install guide
+
+- README.md Quick Start: add a note that the installer writes to the shell profile automatically
+  and document `--no-profile` / `GBRAIN_NO_PROFILE` opt-out.
+- `website/src/content/docs/guides/install.md`: add a "Sandboxed / agent environments" section
+  with the two-step install pattern and the `GBRAIN_NO_PROFILE=1` env var.
+- `docs/getting-started.md`: update install walkthrough to reflect automatic profile setup.
+
+## Non-Goals
+
+- Windows support (separate proposal when Windows is a supported target).
+- Fish shell support — fish uses a different config format. Document as unsupported; fall through
+  to `~/.profile` for fish users.
+- Modifying any profile other than the one detected — no multi-profile writes.
+
+## Impact
+
+- `scripts/install.sh`: new `write_profile` and `detect_profile` shell functions; new
+  `--no-profile` flag parsing; updated post-install output.
+- `packages/gbrain-npm/scripts/postinstall.js`: minor wording update to GBRAIN_DB tip.
+- `README.md`, `website/src/content/docs/guides/install.md`, `docs/getting-started.md`:
+  documentation updates.

--- a/openspec/changes/install-profile-flow/tasks.md
+++ b/openspec/changes/install-profile-flow/tasks.md
@@ -1,0 +1,74 @@
+# Install Profile Flow — Implementation Checklist
+
+**Scope:** Auto-write PATH and GBRAIN_DB to shell profile after successful install;
+document two-step install for sandboxed environments; match npm postinstall wording.
+Closes: #36, #41
+
+---
+
+## Phase A — shell installer profile writes (`scripts/install.sh`)
+
+- [x] A.1 Add `detect_profile` function: inspect `$SHELL` to choose profile file:
+  - `*/zsh` → `$HOME/.zshrc`
+  - `*/bash` on Darwin → `$HOME/.bash_profile`; on Linux → `$HOME/.bashrc`
+  - fallback → `$HOME/.profile`
+  Create the file if it does not exist.
+
+- [x] A.2 Add `write_profile_line` helper: takes `(profile, marker_pattern, line_to_append)`.
+  Greps `$profile` for `$marker_pattern`; appends `$line_to_append` only if not present.
+  Prints `  Added <line> to <profile>` when it appends; silently skips when already present.
+
+- [x] A.3 Add `write_profile` function: calls `write_profile_line` twice:
+  - PATH: marker `$INSTALL_DIR`, line `export PATH="$INSTALL_DIR:$PATH"`
+  - GBRAIN_DB: marker `GBRAIN_DB`, line `export GBRAIN_DB="$HOME/brain.db"`
+  Prints a final summary line: `Profile updated. Run: source <profile>`
+
+- [x] A.4 Add `--no-profile` flag parsing to the script's argument loop. Set
+  `GBRAIN_NO_PROFILE=1` when the flag is present. Respect existing `GBRAIN_NO_PROFILE` env var.
+
+- [x] A.5 Call `write_profile` (or skip if `GBRAIN_NO_PROFILE=1`) after the smoke test
+  succeeds. Replace the existing `print_path_hint` and `print_gbrain_db_tip` calls: when
+  profile writes are enabled, the new summary line replaces both; when writes are disabled
+  (`--no-profile`), print the existing hint block as fallback.
+
+- [x] A.6 Add the two-step install block to the end of the success output (always printed):
+  ```
+  For sandboxed/agent environments: download first, then run:
+    curl -fsSL .../install.sh -o gbrain-install.sh && sh gbrain-install.sh
+  ```
+
+---
+
+## Phase B — npm postinstall wording
+
+- [x] B.1 Update `packages/gbrain-npm/scripts/postinstall.js`: replace the GBRAIN_DB tip
+  wording to match the new shell installer language exactly. No logic change.
+
+---
+
+## Phase C — docs
+
+- [x] C.1 Update `README.md` Quick Start install section: note that the installer writes
+  PATH and GBRAIN_DB to the shell profile automatically and document `GBRAIN_NO_PROFILE=1`
+  for CI/agent users.
+
+- [x] C.2 Update `website/src/content/docs/guides/install.md`: add "Sandboxed / agent
+  environments" subsection with two-step install pattern and `GBRAIN_NO_PROFILE=1`.
+
+- [x] C.3 Update `docs/getting-started.md`: reflect automatic profile setup in the
+  post-install walkthrough steps.
+
+---
+
+## Phase D — verification
+
+- [x] D.1 Run `install.sh` in a fresh shell with no existing profile writes. Confirm
+  `~/.zshrc` (or appropriate profile) receives both export lines exactly once.
+
+- [x] D.2 Run `install.sh` a second time (upgrade scenario). Confirm no duplicate lines
+  are appended to the profile.
+
+- [x] D.3 Run `GBRAIN_NO_PROFILE=1 sh install.sh`. Confirm no profile writes occur and
+  the hint block is printed instead.
+
+- [x] D.4 Run `sh install.sh --no-profile`. Same as D.3.

--- a/openspec/changes/install-profile-flow/tasks.md
+++ b/openspec/changes/install-profile-flow/tasks.md
@@ -14,17 +14,19 @@ Closes: #36, #41
   - fallback → `$HOME/.profile`
   Create the file if it does not exist.
 
-- [x] A.2 Add `write_profile_line` helper: takes `(profile, marker_pattern, line_to_append)`.
-  Greps `$profile` for `$marker_pattern`; appends `$line_to_append` only if not present.
-  Prints `  Added <line> to <profile>` when it appends; silently skips when already present.
+- [x] A.2 Add `write_profile_line` helper: takes `(profile, line_to_append)`.
+  Checks whether `$profile` already contains the exact `$line_to_append` (using
+  `grep -F` fixed-string match); appends it only if not present. Prints
+  `  Added <line> to <profile>` when it appends; returns non-zero when already present.
 
 - [x] A.3 Add `write_profile` function: calls `write_profile_line` twice:
-  - PATH: marker `$INSTALL_DIR`, line `export PATH="$INSTALL_DIR:$PATH"`
-  - GBRAIN_DB: marker `GBRAIN_DB`, line `export GBRAIN_DB="$HOME/brain.db"`
+  - PATH line: `export PATH="$INSTALL_DIR:$PATH"`
+  - GBRAIN_DB line: `export GBRAIN_DB="$HOME/brain.db"`
   Prints a final summary line: `Profile updated. Run: source <profile>`
 
-- [x] A.4 Add `--no-profile` flag parsing to the script's argument loop. Set
-  `GBRAIN_NO_PROFILE=1` when the flag is present. Respect existing `GBRAIN_NO_PROFILE` env var.
+- [x] A.4 Add `--no-profile` flag parsing to the script's argument loop. Treat the
+  flag as enabling no-profile mode for that run. Respect existing `GBRAIN_NO_PROFILE`
+  env var.
 
 - [x] A.5 Call `write_profile` (or skip if `GBRAIN_NO_PROFILE=1`) after the smoke test
   succeeds. Replace the existing `print_path_hint` and `print_gbrain_db_tip` calls: when

--- a/openspec/changes/simplified-install/proposal.md
+++ b/openspec/changes/simplified-install/proposal.md
@@ -57,8 +57,8 @@ curl -fsSL https://raw.githubusercontent.com/macro88/gigabrain/main/scripts/inst
 Or with version and directory overrides:
 
 ```sh
-GBRAIN_VERSION=v0.9.0 GBRAIN_INSTALL_DIR="$HOME/.local/bin" \
-  curl -fsSL https://raw.githubusercontent.com/macro88/gigabrain/main/scripts/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/macro88/gigabrain/main/scripts/install.sh \
+  | GBRAIN_VERSION=v0.9.0 GBRAIN_INSTALL_DIR="$HOME/.local/bin" sh
 ```
 
 After installing, the script prints a tip suggesting the user set `GBRAIN_DB` in their

--- a/packages/gbrain-npm/scripts/postinstall.js
+++ b/packages/gbrain-npm/scripts/postinstall.js
@@ -132,8 +132,11 @@ async function sha256(filePath) {
 function printDbTip() {
   console.log("");
   console.log("Tip: Set GBRAIN_DB in your shell profile to avoid passing --db on every command:");
-  console.log("  echo 'export GBRAIN_DB=\"$HOME/brain.db\"' >> ~/.zshrc");
-  console.log("  echo 'export GBRAIN_DB=\"$HOME/brain.db\"' >> ~/.bashrc");
+  console.log('  export GBRAIN_DB="$HOME/brain.db"');
+  console.log("");
+  console.log("The shell installer (scripts/install.sh) writes PATH and GBRAIN_DB to your");
+  console.log("shell profile automatically. If you installed via npm, add the line above to");
+  console.log("your ~/.zshrc, ~/.bashrc, or ~/.profile manually.");
 }
 
 async function main() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -213,14 +213,14 @@ main() {
   if [ -d "$INSTALL_DIR" ] && [ ! -w "$INSTALL_DIR" ]; then
     fail "Install directory is not writable: ${INSTALL_DIR}
   Either use the default (~/.local/bin) or re-run with appropriate privileges:
-    GBRAIN_INSTALL_DIR=\"\$HOME/.local/bin\" curl -fsSL ... | sh
+    curl -fsSL ... | GBRAIN_INSTALL_DIR=\"\$HOME/.local/bin\" sh
     sudo sh -c 'GBRAIN_INSTALL_DIR=/usr/local/bin sh' < install.sh"
   fi
 
   if ! mkdir -p "$INSTALL_DIR" 2>/dev/null; then
     fail "Cannot create install directory: ${INSTALL_DIR}
   Try a user-writable path or run with appropriate privileges:
-    GBRAIN_INSTALL_DIR=\"\$HOME/.local/bin\" curl -fsSL ... | sh"
+    curl -fsSL ... | GBRAIN_INSTALL_DIR=\"\$HOME/.local/bin\" sh"
   fi
 
   install_path="${INSTALL_DIR}/gbrain"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,6 +6,7 @@ REPO="macro88/gigabrain"
 API_URL="${GBRAIN_RELEASE_API_URL:-https://api.github.com/repos/${REPO}/releases/latest}"
 RELEASE_BASE="${GBRAIN_RELEASE_BASE_URL:-https://github.com/${REPO}/releases/download}"
 INSTALL_DIR="${GBRAIN_INSTALL_DIR:-$HOME/.local/bin}"
+NO_PROFILE="${GBRAIN_NO_PROFILE:-0}"
 
 tmp_dir=""
 
@@ -94,29 +95,107 @@ verify_checksum() {
   [ -f "$tmp_dir/$asset_name" ] || fail "Checksum verification did not preserve downloaded binary"
 }
 
-print_path_hint() {
+# --- Profile detection and writing (A.1–A.3) ---
+
+detect_profile() {
+  shell_name="$(basename "${SHELL:-/bin/sh}" 2>/dev/null || echo "sh")"
+  case "$shell_name" in
+    zsh)
+      PROFILE_FILE="$HOME/.zshrc"
+      ;;
+    bash)
+      case "$(uname -s 2>/dev/null || true)" in
+        Darwin) PROFILE_FILE="$HOME/.bash_profile" ;;
+        *)      PROFILE_FILE="$HOME/.bashrc" ;;
+      esac
+      ;;
+    *)
+      PROFILE_FILE="$HOME/.profile"
+      ;;
+  esac
+
+  # Create the profile file if it does not exist
+  if [ ! -f "$PROFILE_FILE" ]; then
+    touch "$PROFILE_FILE" 2>/dev/null || true
+  fi
+}
+
+write_profile_line() {
+  profile="$1"
+  marker_pattern="$2"
+  line_to_append="$3"
+
+  if [ ! -f "$profile" ]; then
+    return
+  fi
+
+  if grep -q "$marker_pattern" "$profile" 2>/dev/null; then
+    return
+  fi
+
+  printf '\n%s\n' "$line_to_append" >> "$profile"
+  printf '  Added: %s → %s\n' "$line_to_append" "$profile"
+}
+
+write_profile() {
+  detect_profile
+
+  path_line="export PATH=\"${INSTALL_DIR}:\$PATH\""
+  db_line="export GBRAIN_DB=\"\$HOME/brain.db\""
+
+  wrote_something=0
+
+  # Only write PATH if install dir is not already in PATH
   case ":${PATH:-}:" in
     *:"$INSTALL_DIR":*) ;;
     *)
-      printf '%s\n' ""
-      printf '%s\n' "Add this directory to your PATH to run gbrain from anywhere:"
+      write_profile_line "$PROFILE_FILE" "$INSTALL_DIR" "$path_line"
+      wrote_something=1
+      ;;
+  esac
+
+  write_profile_line "$PROFILE_FILE" "GBRAIN_DB" "$db_line"
+  wrote_something=1
+
+  if [ "$wrote_something" = "1" ]; then
+    printf '\n  Profile updated: %s\n' "$PROFILE_FILE"
+    printf '  Run: source %s\n' "$PROFILE_FILE"
+  fi
+}
+
+print_manual_hints() {
+  printf '%s\n' ""
+  printf '%s\n' "Complete setup by adding these to your shell profile:"
+  case ":${PATH:-}:" in
+    *:"$INSTALL_DIR":*) ;;
+    *)
       printf '  export PATH="%s:$PATH"\n' "$INSTALL_DIR"
       ;;
   esac
+  printf '  export GBRAIN_DB="$HOME/brain.db"\n'
 }
 
-print_gbrain_db_tip() {
+print_sandboxed_hint() {
   printf '%s\n' ""
-  printf '%s\n' "Tip: Set GBRAIN_DB in your shell profile to avoid passing --db on every command:"
-  printf '%s\n' "  echo 'export GBRAIN_DB=\"\$HOME/brain.db\"' >> ~/.zshrc"
-  printf '%s\n' "  echo 'export GBRAIN_DB=\"\$HOME/brain.db\"' >> ~/.bashrc"
+  printf '%s\n' "For sandboxed/agent environments: download first, then run:"
+  printf '  curl -fsSL https://raw.githubusercontent.com/%s/main/scripts/install.sh \\\n' "$REPO"
+  printf '    -o gbrain-install.sh && sh gbrain-install.sh\n'
 }
+
+# --- Argument parsing ---
+
+for arg in "$@"; do
+  case "$arg" in
+    --no-profile) NO_PROFILE=1 ;;
+  esac
+done
 
 need_cmd curl
 need_cmd mkdir
 need_cmd chmod
 need_cmd mv
 need_cmd mktemp
+need_cmd grep
 
 trap cleanup EXIT INT HUP TERM
 
@@ -165,5 +244,11 @@ fi
 
 printf '%s\n' ""
 printf 'Installed gbrain to %s\n' "$install_path"
-print_path_hint
-print_gbrain_db_tip
+
+if [ "$NO_PROFILE" = "1" ]; then
+  print_manual_hints
+else
+  write_profile
+fi
+
+print_sandboxed_hint

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -122,19 +122,17 @@ detect_profile() {
 
 write_profile_line() {
   profile="$1"
-  marker_pattern="$2"
-  line_to_append="$3"
+  line_to_append="$2"
 
-  if [ ! -f "$profile" ]; then
-    return
-  fi
+  [ -f "$profile" ] || return 1
 
-  if grep -q "$marker_pattern" "$profile" 2>/dev/null; then
-    return
+  if grep -Fq "$line_to_append" "$profile" 2>/dev/null; then
+    return 1
   fi
 
   printf '\n%s\n' "$line_to_append" >> "$profile"
-  printf '  Added: %s → %s\n' "$line_to_append" "$profile"
+  printf '  Added to %s: %s\n' "$profile" "$line_to_append"
+  return 0
 }
 
 write_profile() {
@@ -145,17 +143,13 @@ write_profile() {
 
   wrote_something=0
 
-  # Only write PATH if install dir is not already in PATH
-  case ":${PATH:-}:" in
-    *:"$INSTALL_DIR":*) ;;
-    *)
-      write_profile_line "$PROFILE_FILE" "$INSTALL_DIR" "$path_line"
-      wrote_something=1
-      ;;
-  esac
+  if write_profile_line "$PROFILE_FILE" "$path_line"; then
+    wrote_something=1
+  fi
 
-  write_profile_line "$PROFILE_FILE" "GBRAIN_DB" "$db_line"
-  wrote_something=1
+  if write_profile_line "$PROFILE_FILE" "$db_line"; then
+    wrote_something=1
+  fi
 
   if [ "$wrote_something" = "1" ]; then
     printf '\n  Profile updated: %s\n' "$PROFILE_FILE"
@@ -166,12 +160,7 @@ write_profile() {
 print_manual_hints() {
   printf '%s\n' ""
   printf '%s\n' "Complete setup by adding these to your shell profile:"
-  case ":${PATH:-}:" in
-    *:"$INSTALL_DIR":*) ;;
-    *)
-      printf '  export PATH="%s:$PATH"\n' "$INSTALL_DIR"
-      ;;
-  esac
+  printf '  export PATH="%s:$PATH"\n' "$INSTALL_DIR"
   printf '  export GBRAIN_DB="$HOME/brain.db"\n'
 }
 
@@ -182,73 +171,79 @@ print_sandboxed_hint() {
   printf '    -o gbrain-install.sh && sh gbrain-install.sh\n'
 }
 
-# --- Argument parsing ---
+# --- Main execution ---
 
-for arg in "$@"; do
-  case "$arg" in
-    --no-profile) NO_PROFILE=1 ;;
+main() {
+  for arg in "$@"; do
+    case "$arg" in
+      --no-profile) NO_PROFILE=1 ;;
+    esac
+  done
+
+  need_cmd curl
+  need_cmd mkdir
+  need_cmd chmod
+  need_cmd mv
+  need_cmd mktemp
+  need_cmd grep
+
+  trap cleanup EXIT INT HUP TERM
+
+  resolve_platform
+  resolve_channel
+  resolve_version
+
+  case "$CHANNEL" in
+    airgapped|online) asset_name="gbrain-${PLATFORM}-${CHANNEL}" ;;
   esac
-done
+  checksum_name="${asset_name}.sha256"
+  binary_url="${RELEASE_BASE}/${VERSION}/${asset_name}"
+  checksum_url="${RELEASE_BASE}/${VERSION}/${checksum_name}"
 
-need_cmd curl
-need_cmd mkdir
-need_cmd chmod
-need_cmd mv
-need_cmd mktemp
-need_cmd grep
+  tmp_dir="$(mktemp -d 2>/dev/null || mktemp -d -t gbrain-install)" || fail "Cannot create temporary directory with mktemp"
 
-trap cleanup EXIT INT HUP TERM
+  printf '%s\n' "Installing gbrain ${VERSION} for ${PLATFORM} (${CHANNEL})..."
+  curl -fsSL "$binary_url" -o "$tmp_dir/$asset_name" || fail "Failed to download ${binary_url}"
+  curl -fsSL "$checksum_url" -o "$tmp_dir/$checksum_name" || fail "Failed to download ${checksum_url}"
 
-resolve_platform
-resolve_channel
-resolve_version
+  if ! verify_checksum "$checksum_name" "$asset_name"; then
+    fail "SHA-256 verification failed for ${asset_name}"
+  fi
 
-case "$CHANNEL" in
-  airgapped|online) asset_name="gbrain-${PLATFORM}-${CHANNEL}" ;;
-esac
-checksum_name="${asset_name}.sha256"
-binary_url="${RELEASE_BASE}/${VERSION}/${asset_name}"
-checksum_url="${RELEASE_BASE}/${VERSION}/${checksum_name}"
-
-tmp_dir="$(mktemp -d 2>/dev/null || mktemp -d -t gbrain-install)" || fail "Cannot create temporary directory with mktemp"
-
-printf '%s\n' "Installing gbrain ${VERSION} for ${PLATFORM} (${CHANNEL})..."
-curl -fsSL "$binary_url" -o "$tmp_dir/$asset_name" || fail "Failed to download ${binary_url}"
-curl -fsSL "$checksum_url" -o "$tmp_dir/$checksum_name" || fail "Failed to download ${checksum_url}"
-
-if ! verify_checksum "$checksum_name" "$asset_name"; then
-  fail "SHA-256 verification failed for ${asset_name}"
-fi
-
-if [ -d "$INSTALL_DIR" ] && [ ! -w "$INSTALL_DIR" ]; then
-  fail "Install directory is not writable: ${INSTALL_DIR}
+  if [ -d "$INSTALL_DIR" ] && [ ! -w "$INSTALL_DIR" ]; then
+    fail "Install directory is not writable: ${INSTALL_DIR}
   Either use the default (~/.local/bin) or re-run with appropriate privileges:
     GBRAIN_INSTALL_DIR=\"\$HOME/.local/bin\" curl -fsSL ... | sh
     sudo sh -c 'GBRAIN_INSTALL_DIR=/usr/local/bin sh' < install.sh"
-fi
+  fi
 
-if ! mkdir -p "$INSTALL_DIR" 2>/dev/null; then
-  fail "Cannot create install directory: ${INSTALL_DIR}
+  if ! mkdir -p "$INSTALL_DIR" 2>/dev/null; then
+    fail "Cannot create install directory: ${INSTALL_DIR}
   Try a user-writable path or run with appropriate privileges:
     GBRAIN_INSTALL_DIR=\"\$HOME/.local/bin\" curl -fsSL ... | sh"
+  fi
+
+  install_path="${INSTALL_DIR}/gbrain"
+  mv "$tmp_dir/$asset_name" "$install_path" || fail "Cannot write to ${install_path} — is the directory writable?"
+  chmod +x "$install_path"
+
+  if ! "$install_path" version; then
+    rm -f "$install_path"
+    fail "Smoke test failed: ${install_path} version"
+  fi
+
+  printf '%s\n' ""
+  printf 'Installed gbrain to %s\n' "$install_path"
+
+  if [ "$NO_PROFILE" = "1" ]; then
+    print_manual_hints
+  else
+    write_profile
+  fi
+
+  print_sandboxed_hint
+}
+
+if [ "${GBRAIN_TEST_MODE:-0}" != "1" ]; then
+  main "$@"
 fi
-
-install_path="${INSTALL_DIR}/gbrain"
-mv "$tmp_dir/$asset_name" "$install_path" || fail "Cannot write to ${install_path} — is the directory writable?"
-chmod +x "$install_path"
-
-if ! "$install_path" version; then
-  rm -f "$install_path"
-  fail "Smoke test failed: ${install_path} version"
-fi
-
-printf '%s\n' ""
-printf 'Installed gbrain to %s\n' "$install_path"
-
-if [ "$NO_PROFILE" = "1" ]; then
-  print_manual_hints
-else
-  write_profile
-fi
-
-print_sandboxed_hint

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -114,29 +114,54 @@ detect_profile() {
       ;;
   esac
 
+  profile_dir="$(dirname "$PROFILE_FILE")"
+
   # Create the profile file if it does not exist
   if [ ! -f "$PROFILE_FILE" ]; then
-    touch "$PROFILE_FILE" 2>/dev/null || true
+    if [ ! -d "$profile_dir" ] || [ ! -w "$profile_dir" ]; then
+      printf '%s\n' "Warning: Cannot create shell profile ${PROFILE_FILE}; ${profile_dir} is not writable." >&2
+      return 1
+    fi
+
+    if ! touch "$PROFILE_FILE" 2>/dev/null; then
+      printf '%s\n' "Warning: Failed to create shell profile ${PROFILE_FILE}." >&2
+      return 1
+    fi
   fi
+
+  if [ ! -w "$PROFILE_FILE" ]; then
+    printf '%s\n' "Warning: Shell profile ${PROFILE_FILE} is not writable." >&2
+    return 1
+  fi
+
+  return 0
 }
 
 write_profile_line() {
   profile="$1"
   line_to_append="$2"
 
-  [ -f "$profile" ] || return 1
+  if [ ! -f "$profile" ]; then
+    return 2
+  fi
 
   if grep -Fq "$line_to_append" "$profile" 2>/dev/null; then
     return 1
   fi
 
-  printf '\n%s\n' "$line_to_append" >> "$profile"
+  if ! printf '\n%s\n' "$line_to_append" >> "$profile" 2>/dev/null; then
+    printf '%s\n' "Warning: Failed to append to shell profile ${profile}." >&2
+    return 2
+  fi
+
   printf '  Added to %s: %s\n' "$profile" "$line_to_append"
   return 0
 }
 
 write_profile() {
-  detect_profile
+  if ! detect_profile; then
+    return 1
+  fi
 
   path_line="export PATH=\"${INSTALL_DIR}:\$PATH\""
   db_line="export GBRAIN_DB=\"\$HOME/brain.db\""
@@ -145,16 +170,30 @@ write_profile() {
 
   if write_profile_line "$PROFILE_FILE" "$path_line"; then
     wrote_something=1
+  else
+    status=$?
+    if [ "$status" -gt 1 ]; then
+      return 1
+    fi
   fi
 
   if write_profile_line "$PROFILE_FILE" "$db_line"; then
     wrote_something=1
+  else
+    status=$?
+    if [ "$status" -gt 1 ]; then
+      return 1
+    fi
   fi
 
   if [ "$wrote_something" = "1" ]; then
     printf '\n  Profile updated: %s\n' "$PROFILE_FILE"
     printf '  Run: source %s\n' "$PROFILE_FILE"
+  else
+    printf '\n  Profile already configured: %s\n' "$PROFILE_FILE"
   fi
+
+  return 0
 }
 
 print_manual_hints() {
@@ -238,7 +277,13 @@ main() {
   if [ "$NO_PROFILE" = "1" ]; then
     print_manual_hints
   else
-    write_profile
+    if ! write_profile; then
+      printf '%s\n' "" >&2
+      printf '%s\n' "Warning: gbrain was installed, but PATH/GBRAIN_DB were not persisted automatically." >&2
+      print_manual_hints >&2
+      print_sandboxed_hint >&2
+      return 1
+    fi
   fi
 
   print_sandboxed_hint

--- a/tests/install_profile.sh
+++ b/tests/install_profile.sh
@@ -201,29 +201,12 @@ GBRAIN_NO_PROFILE=0
 # ---------------------------------------------------------------
 # detect_profile — branch coverage (T10–T13)
 # ---------------------------------------------------------------
-# Restore detect_profile to its installer-defined implementation.
-# Earlier tests (T8) override it; re-source the function so T10–T13
-# exercise the real branching logic, not a test stub.
-detect_profile() {
-  shell_name="$(basename "${SHELL:-/bin/sh}" 2>/dev/null || echo "sh")"
-  case "$shell_name" in
-    zsh)
-      PROFILE_FILE="$HOME/.zshrc"
-      ;;
-    bash)
-      case "$(uname -s 2>/dev/null || true)" in
-        Darwin) PROFILE_FILE="$HOME/.bash_profile" ;;
-        *)      PROFILE_FILE="$HOME/.bashrc" ;;
-      esac
-      ;;
-    *)
-      PROFILE_FILE="$HOME/.profile"
-      ;;
-  esac
-  if [ ! -f "$PROFILE_FILE" ]; then
-    touch "$PROFILE_FILE" 2>/dev/null || true
-  fi
-}
+# Restore detect_profile to the PRODUCTION implementation by re-sourcing
+# install.sh.  Earlier tests (T5-T8) override detect_profile with test
+# stubs; re-sourcing is the only reliable way to recover the real function
+# without copy-pasting its body (which would silently diverge if the
+# production code changed).
+. "$INSTALL_SH"
 
 # T10: zsh → ~/.zshrc (any OS)
 SHELL=/usr/bin/zsh detect_profile
@@ -336,6 +319,35 @@ if [ "$t16_result" = "1" ]; then
 else
   not_ok "T16: GBRAIN_NO_PROFILE=1 did not set NO_PROFILE=1 (got: '$t16_result')"
 fi
+
+# T17: main() with GBRAIN_NO_PROFILE=1 env var — full end-to-end opt-out
+# Exercises the real pipe-flow semantics: env var → top-level NO_PROFILE init → main() skip.
+# Re-source install.sh so the top-level NO_PROFILE="${GBRAIN_NO_PROFILE:-0}" re-executes
+# with GBRAIN_NO_PROFILE=1, then call main() and verify no profile write occurred.
+GBRAIN_NO_PROFILE=1
+. "$INSTALL_SH"
+# Re-apply function stubs (re-source replaced them with production versions)
+resolve_version()  { VERSION="v0.0.0-test"; }
+resolve_platform() { PLATFORM="linux-x86_64"; }
+resolve_channel()  { CHANNEL="airgapped"; }
+verify_checksum()  { return 0; }
+need_cmd()         { return 0; }
+PATH="$TEST_STUBS:$PATH"
+T17_PROFILE="$TEST_HOME/.t17_profile"
+printf '' > "$T17_PROFILE"
+detect_profile() { PROFILE_FILE="$T17_PROFILE"; }
+if main >/dev/null 2>&1; then
+  if [ ! -s "$T17_PROFILE" ]; then
+    ok "T17: main() with GBRAIN_NO_PROFILE=1 skips profile write end-to-end"
+  else
+    not_ok "T17: main() with GBRAIN_NO_PROFILE=1 wrote to profile (file non-empty)"
+  fi
+else
+  not_ok "T17: main() with GBRAIN_NO_PROFILE=1 exited non-zero"
+fi
+GBRAIN_NO_PROFILE=0
+tmp_dir=""
+PATH="$SAVED_PATH_STUBS"
 
 # ---------------------------------------------------------------
 # Summary

--- a/tests/install_profile.sh
+++ b/tests/install_profile.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env sh
+# tests/install_profile.sh — deterministic tests for the installer's profile-write logic.
+#
+# Sources scripts/install.sh in GBRAIN_TEST_MODE=1 to isolate profile functions without
+# running the download/install path. Tests cover: fresh write, idempotency, opt-out
+# (--no-profile / GBRAIN_NO_PROFILE=1), and regex-metacharacter safety.
+#
+# Usage:
+#   sh tests/install_profile.sh
+#
+# Exit code: 0 = all pass, 1 = one or more failures.
+
+set -e
+
+PASS=0
+FAIL=0
+
+ok() {
+  printf '  ok: %s\n' "$1"
+  PASS=$((PASS + 1))
+}
+
+not_ok() {
+  printf '  FAIL: %s\n' "$1"
+  FAIL=$((FAIL + 1))
+}
+
+# Locate project root relative to this script
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+INSTALL_SH="$SCRIPT_DIR/scripts/install.sh"
+
+# Isolated home dir written under target/ so it is gitignored and cleaned by cargo clean
+TEST_HOME="$SCRIPT_DIR/target/test-home-install-profile"
+rm -rf "$TEST_HOME"
+mkdir -p "$TEST_HOME"
+
+# Required variables install.sh reads at top level before any function executes
+GBRAIN_TEST_MODE=1
+GBRAIN_RELEASE_API_URL="https://example.invalid"
+GBRAIN_RELEASE_BASE_URL="https://example.invalid"
+GBRAIN_INSTALL_DIR="$TEST_HOME/bin"
+GBRAIN_NO_PROFILE=0
+GBRAIN_CHANNEL="airgapped"
+GBRAIN_VERSION="v0.0.0-test"
+HOME="$TEST_HOME"
+mkdir -p "$GBRAIN_INSTALL_DIR"
+
+# Source the installer in test mode — function definitions load, main() does not run
+# shellcheck source=../scripts/install.sh
+. "$INSTALL_SH"
+
+printf '\nRunning install profile tests...\n\n'
+
+# ---------------------------------------------------------------
+# write_profile_line
+# ---------------------------------------------------------------
+
+PROFILE="$TEST_HOME/.zshrc_test"
+LINE='export PATH="/test/.local/bin:$PATH"'
+
+# T1: appends to a fresh (empty) file
+printf '' > "$PROFILE"
+if write_profile_line "$PROFILE" "$LINE"; then
+  if grep -Fq "$LINE" "$PROFILE"; then
+    ok "T1: write_profile_line appends to fresh file"
+  else
+    not_ok "T1: write_profile_line appends to fresh file — line missing after append"
+  fi
+else
+  not_ok "T1: write_profile_line appends to fresh file — returned non-zero"
+fi
+
+# T2a: idempotent — second call returns non-zero (nothing to write)
+if write_profile_line "$PROFILE" "$LINE"; then
+  not_ok "T2a: write_profile_line returns non-zero when line already present"
+else
+  ok "T2a: write_profile_line returns non-zero when line already present"
+fi
+
+# T2b: idempotent — no duplicate written
+count=$(grep -cF "$LINE" "$PROFILE")
+if [ "$count" = "1" ]; then
+  ok "T2b: write_profile_line does not duplicate an existing line"
+else
+  not_ok "T2b: write_profile_line duplicated line: found $count copies"
+fi
+
+# T3: missing profile file — returns non-zero, does not create file
+MISSING="$TEST_HOME/.no_such_profile"
+rm -f "$MISSING"
+if write_profile_line "$MISSING" "$LINE"; then
+  not_ok "T3: write_profile_line returns non-zero for missing file"
+else
+  ok "T3: write_profile_line returns non-zero for missing file"
+fi
+if [ -f "$MISSING" ]; then
+  not_ok "T3b: write_profile_line must not create missing profile"
+else
+  ok "T3b: write_profile_line does not create missing profile"
+fi
+
+# T4: fixed-string matching — regex metacharacters in path are handled correctly
+REGEX_PROFILE="$TEST_HOME/.profile_regex"
+REGEX_LINE='export PATH="/test/.local/bin[x]:$PATH"'
+printf '' > "$REGEX_PROFILE"
+if write_profile_line "$REGEX_PROFILE" "$REGEX_LINE"; then
+  ok "T4: write_profile_line handles regex metacharacters in path (first write)"
+else
+  not_ok "T4: write_profile_line failed with metacharacters in path"
+fi
+# Second write must still be idempotent
+if write_profile_line "$REGEX_PROFILE" "$REGEX_LINE"; then
+  not_ok "T4b: idempotent check failed with metacharacters in path"
+else
+  ok "T4b: idempotent check works with metacharacters in path"
+fi
+count2=$(grep -cF "$REGEX_LINE" "$REGEX_PROFILE")
+if [ "$count2" = "1" ]; then
+  ok "T4c: no duplicate for metacharacter path"
+else
+  not_ok "T4c: found $count2 copies for metacharacter path"
+fi
+
+# ---------------------------------------------------------------
+# write_profile
+# ---------------------------------------------------------------
+
+WP_PROFILE="$TEST_HOME/.wp_zshrc"
+printf '' > "$WP_PROFILE"
+
+# Override detect_profile so write_profile uses our test file
+detect_profile() { PROFILE_FILE="$WP_PROFILE"; }
+
+# T5: write_profile writes both exports to a fresh profile
+write_profile
+if grep -Fq "export PATH=" "$WP_PROFILE" && grep -Fq "export GBRAIN_DB=" "$WP_PROFILE"; then
+  ok "T5: write_profile writes both PATH and GBRAIN_DB exports"
+else
+  not_ok "T5: write_profile did not write expected exports"
+fi
+
+# T6: write_profile is idempotent on re-run
+write_profile
+path_count=$(grep -c "export PATH=" "$WP_PROFILE")
+db_count=$(grep -c "export GBRAIN_DB=" "$WP_PROFILE")
+if [ "$path_count" = "1" ] && [ "$db_count" = "1" ]; then
+  ok "T6: write_profile is idempotent (no duplicates on re-run)"
+else
+  not_ok "T6: write_profile duplicated lines: PATH×${path_count} GBRAIN_DB×${db_count}"
+fi
+
+# T7: profile does not key off current PATH — write_profile always checks the file
+# Even if INSTALL_DIR happens to appear in the current session PATH, write_profile
+# must defer to the profile file for idempotency, not the live environment.
+OLD_PATH="$PATH"
+# Temporarily add INSTALL_DIR to the session PATH to simulate an already-active session
+PATH="${INSTALL_DIR}:${PATH}"
+WP_PROFILE2="$TEST_HOME/.wp_fresh"
+printf '' > "$WP_PROFILE2"
+detect_profile() { PROFILE_FILE="$WP_PROFILE2"; }
+write_profile
+if grep -Fq "export PATH=" "$WP_PROFILE2"; then
+  ok "T7: write_profile writes to profile regardless of current session PATH"
+else
+  not_ok "T7: write_profile skipped PATH write because INSTALL_DIR was already in session PATH"
+fi
+PATH="$OLD_PATH"
+
+# ---------------------------------------------------------------
+# --no-profile / GBRAIN_NO_PROFILE=1 opt-out
+# ---------------------------------------------------------------
+
+# T8: NO_PROFILE=1 branch — profile file must not be touched
+WP_PROFILE3="$TEST_HOME/.optout_test"
+printf '' > "$WP_PROFILE3"
+detect_profile() { PROFILE_FILE="$WP_PROFILE3"; }
+NO_PROFILE=1
+# Simulate the main() branch: --no-profile calls print_manual_hints, not write_profile
+if [ "$NO_PROFILE" = "1" ]; then
+  print_manual_hints > /dev/null 2>&1
+fi
+if [ -s "$WP_PROFILE3" ]; then
+  not_ok "T8: NO_PROFILE=1 must not write to profile"
+else
+  ok "T8: NO_PROFILE=1 leaves profile untouched"
+fi
+NO_PROFILE=0
+
+# T9: GBRAIN_NO_PROFILE=1 env var is read at startup into NO_PROFILE
+# The script initializes: NO_PROFILE="${GBRAIN_NO_PROFILE:-0}"
+# We verify that behavior by checking the value directly.
+GBRAIN_NO_PROFILE=1
+_computed_no_profile="${GBRAIN_NO_PROFILE:-0}"
+if [ "$_computed_no_profile" = "1" ]; then
+  ok "T9: GBRAIN_NO_PROFILE=1 env var propagates to NO_PROFILE at startup"
+else
+  not_ok "T9: GBRAIN_NO_PROFILE=1 did not propagate"
+fi
+GBRAIN_NO_PROFILE=0
+
+# ---------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/install_profile.sh
+++ b/tests/install_profile.sh
@@ -249,8 +249,26 @@ else
   not_ok "T13: detect_profile — unknown shell → ~/.profile (got: $PROFILE_FILE)"
 fi
 
+# T14: detect_profile fails with a warning when the profile cannot be created
+UNWRITABLE_HOME="$TEST_HOME/unwritable_home"
+mkdir -p "$UNWRITABLE_HOME"
+chmod 500 "$UNWRITABLE_HOME"
+OLD_HOME_T14="$HOME"
+HOME="$UNWRITABLE_HOME"
+if SHELL=/usr/bin/zsh detect_profile >"$TEST_HOME/t14_detect.out" 2>"$TEST_HOME/t14_detect.err"; then
+  not_ok "T14: detect_profile should fail when profile directory is not writable"
+else
+  if grep -Fq "Cannot create shell profile" "$TEST_HOME/t14_detect.err"; then
+    ok "T14: detect_profile warns when profile creation fails"
+  else
+    not_ok "T14: detect_profile did not explain profile creation failure"
+  fi
+fi
+HOME="$OLD_HOME_T14"
+chmod 700 "$UNWRITABLE_HOME"
+
 # ---------------------------------------------------------------
-# main() integration tests — T14–T16
+# main() integration tests — T15–T18
 # Exercises the real entry path with stubbed network/system functions.
 # ---------------------------------------------------------------
 
@@ -271,56 +289,56 @@ need_cmd()         { return 0; }
 SAVED_PATH_STUBS="$PATH"
 PATH="$TEST_STUBS:$PATH"
 
-# T14: main() --no-profile parses the flag and skips profile write
-T14_PROFILE="$TEST_HOME/.t14_profile"
-printf '' > "$T14_PROFILE"
-detect_profile() { PROFILE_FILE="$T14_PROFILE"; }
-NO_PROFILE=0
-if main --no-profile >/dev/null 2>&1; then
-  if [ ! -s "$T14_PROFILE" ]; then
-    ok "T14: main() --no-profile parses flag and leaves profile untouched"
-  else
-    not_ok "T14: main() --no-profile wrote to profile (file non-empty)"
-  fi
-else
-  not_ok "T14: main() --no-profile exited non-zero"
-fi
-tmp_dir=""
-
-# T15: main() default path writes both exports through the real write_profile call
+# T15: main() --no-profile parses the flag and skips profile write
 T15_PROFILE="$TEST_HOME/.t15_profile"
 printf '' > "$T15_PROFILE"
 detect_profile() { PROFILE_FILE="$T15_PROFILE"; }
 NO_PROFILE=0
-GBRAIN_NO_PROFILE=0
-if main >/dev/null 2>&1; then
-  if grep -Fq "export PATH=" "$T15_PROFILE" && grep -Fq "export GBRAIN_DB=" "$T15_PROFILE"; then
-    ok "T15: main() default path writes PATH and GBRAIN_DB to profile"
+if main --no-profile >/dev/null 2>&1; then
+  if [ ! -s "$T15_PROFILE" ]; then
+    ok "T15: main() --no-profile parses flag and leaves profile untouched"
   else
-    not_ok "T15: main() default path did not write expected exports"
+    not_ok "T15: main() --no-profile wrote to profile (file non-empty)"
   fi
 else
-  not_ok "T15: main() default path exited non-zero"
+  not_ok "T15: main() --no-profile exited non-zero"
+fi
+tmp_dir=""
+
+# T16: main() default path writes both exports through the real write_profile call
+T16_PROFILE="$TEST_HOME/.t16_profile"
+printf '' > "$T16_PROFILE"
+detect_profile() { PROFILE_FILE="$T16_PROFILE"; }
+NO_PROFILE=0
+GBRAIN_NO_PROFILE=0
+if main >/dev/null 2>&1; then
+  if grep -Fq "export PATH=" "$T16_PROFILE" && grep -Fq "export GBRAIN_DB=" "$T16_PROFILE"; then
+    ok "T16: main() default path writes PATH and GBRAIN_DB to profile"
+  else
+    not_ok "T16: main() default path did not write expected exports"
+  fi
+else
+  not_ok "T16: main() default path exited non-zero"
 fi
 tmp_dir=""
 
 PATH="$SAVED_PATH_STUBS"
 
-# T16: GBRAIN_NO_PROFILE=1 env var is captured at script source time → NO_PROFILE=1
+# T17: GBRAIN_NO_PROFILE=1 env var is captured at script source time → NO_PROFILE=1
 # Run the installer in a fresh subprocess (GBRAIN_TEST_MODE=1 prevents main() from firing
 # but the top-level assignment  NO_PROFILE="${GBRAIN_NO_PROFILE:-0}"  still executes).
-t16_result=$(GBRAIN_TEST_MODE=1 \
+t17_result=$(GBRAIN_TEST_MODE=1 \
   GBRAIN_NO_PROFILE=1 \
   GBRAIN_INSTALL_DIR="$TEST_HOME/bin" \
   HOME="$TEST_HOME" \
   sh -c ". \"$INSTALL_SH\" && printf '%s' \"\$NO_PROFILE\"" 2>/dev/null)
-if [ "$t16_result" = "1" ]; then
-  ok "T16: GBRAIN_NO_PROFILE=1 env var sets NO_PROFILE=1 at script startup"
+if [ "$t17_result" = "1" ]; then
+  ok "T17: GBRAIN_NO_PROFILE=1 env var sets NO_PROFILE=1 at script startup"
 else
-  not_ok "T16: GBRAIN_NO_PROFILE=1 did not set NO_PROFILE=1 (got: '$t16_result')"
+  not_ok "T17: GBRAIN_NO_PROFILE=1 did not set NO_PROFILE=1 (got: '$t17_result')"
 fi
 
-# T17: main() with GBRAIN_NO_PROFILE=1 env var — full end-to-end opt-out
+# T18: main() with GBRAIN_NO_PROFILE=1 env var — full end-to-end opt-out
 # Exercises the real pipe-flow semantics: env var → top-level NO_PROFILE init → main() skip.
 # Re-source install.sh so the top-level NO_PROFILE="${GBRAIN_NO_PROFILE:-0}" re-executes
 # with GBRAIN_NO_PROFILE=1, then call main() and verify no profile write occurred.
@@ -333,19 +351,56 @@ resolve_channel()  { CHANNEL="airgapped"; }
 verify_checksum()  { return 0; }
 need_cmd()         { return 0; }
 PATH="$TEST_STUBS:$PATH"
-T17_PROFILE="$TEST_HOME/.t17_profile"
-printf '' > "$T17_PROFILE"
-detect_profile() { PROFILE_FILE="$T17_PROFILE"; }
+T18_PROFILE="$TEST_HOME/.t18_profile"
+printf '' > "$T18_PROFILE"
+detect_profile() { PROFILE_FILE="$T18_PROFILE"; }
 if main >/dev/null 2>&1; then
-  if [ ! -s "$T17_PROFILE" ]; then
-    ok "T17: main() with GBRAIN_NO_PROFILE=1 skips profile write end-to-end"
+  if [ ! -s "$T18_PROFILE" ]; then
+    ok "T18: main() with GBRAIN_NO_PROFILE=1 skips profile write end-to-end"
   else
-    not_ok "T17: main() with GBRAIN_NO_PROFILE=1 wrote to profile (file non-empty)"
+    not_ok "T18: main() with GBRAIN_NO_PROFILE=1 wrote to profile (file non-empty)"
   fi
 else
-  not_ok "T17: main() with GBRAIN_NO_PROFILE=1 exited non-zero"
+  not_ok "T18: main() with GBRAIN_NO_PROFILE=1 exited non-zero"
 fi
 GBRAIN_NO_PROFILE=0
+tmp_dir=""
+PATH="$SAVED_PATH_STUBS"
+
+# T19: main() fails loudly and prints manual recovery when profile persistence fails
+. "$INSTALL_SH"
+resolve_version()  { VERSION="v0.0.0-test"; }
+resolve_platform() { PLATFORM="linux-x86_64"; }
+resolve_channel()  { CHANNEL="airgapped"; }
+verify_checksum()  { return 0; }
+need_cmd()         { return 0; }
+PATH="$TEST_STUBS:$PATH"
+T19_PROFILE="$TEST_HOME/.t19_profile"
+rm -f "$T19_PROFILE"
+NO_PROFILE=0
+GBRAIN_NO_PROFILE=0
+detect_profile() {
+  PROFILE_FILE="$T19_PROFILE"
+  printf '%s\n' "Warning: Shell profile $PROFILE_FILE is not writable." >&2
+  return 1
+}
+if main >"$TEST_HOME/t19_main.out" 2>"$TEST_HOME/t19_main.err"; then
+  not_ok "T19: main() should exit non-zero when profile persistence fails"
+else
+  if grep -Fq 'gbrain was installed, but PATH/GBRAIN_DB were not persisted automatically.' "$TEST_HOME/t19_main.err" &&
+     grep -Fq 'Complete setup by adding these to your shell profile:' "$TEST_HOME/t19_main.err" &&
+     grep -Fq 'export PATH="' "$TEST_HOME/t19_main.err" &&
+     grep -Fq 'export GBRAIN_DB="$HOME/brain.db"' "$TEST_HOME/t19_main.err"; then
+    ok "T19: main() prints manual recovery steps when profile persistence fails"
+  else
+    not_ok "T19: main() did not print the expected recovery guidance on profile failure"
+  fi
+fi
+if grep -Fq "Installed gbrain to" "$TEST_HOME/t19_main.out"; then
+  ok "T19b: main() still reports where the binary was installed before failing"
+else
+  not_ok "T19b: main() should report the installed binary path on profile failure"
+fi
 tmp_dir=""
 PATH="$SAVED_PATH_STUBS"
 

--- a/tests/install_profile.sh
+++ b/tests/install_profile.sh
@@ -199,6 +199,145 @@ fi
 GBRAIN_NO_PROFILE=0
 
 # ---------------------------------------------------------------
+# detect_profile — branch coverage (T10–T13)
+# ---------------------------------------------------------------
+# Restore detect_profile to its installer-defined implementation.
+# Earlier tests (T8) override it; re-source the function so T10–T13
+# exercise the real branching logic, not a test stub.
+detect_profile() {
+  shell_name="$(basename "${SHELL:-/bin/sh}" 2>/dev/null || echo "sh")"
+  case "$shell_name" in
+    zsh)
+      PROFILE_FILE="$HOME/.zshrc"
+      ;;
+    bash)
+      case "$(uname -s 2>/dev/null || true)" in
+        Darwin) PROFILE_FILE="$HOME/.bash_profile" ;;
+        *)      PROFILE_FILE="$HOME/.bashrc" ;;
+      esac
+      ;;
+    *)
+      PROFILE_FILE="$HOME/.profile"
+      ;;
+  esac
+  if [ ! -f "$PROFILE_FILE" ]; then
+    touch "$PROFILE_FILE" 2>/dev/null || true
+  fi
+}
+
+# T10: zsh → ~/.zshrc (any OS)
+SHELL=/usr/bin/zsh detect_profile
+if [ "$PROFILE_FILE" = "$HOME/.zshrc" ]; then
+  ok "T10: detect_profile — zsh → ~/.zshrc"
+else
+  not_ok "T10: detect_profile — zsh → ~/.zshrc (got: $PROFILE_FILE)"
+fi
+
+# T11: Darwin bash → ~/.bash_profile
+# Inject a fake uname into PATH that reports Darwin for 'uname -s'
+DARWIN_STUBS="$TEST_HOME/darwin_stubs"
+mkdir -p "$DARWIN_STUBS"
+printf '#!/usr/bin/env sh\n[ "$1" = "-s" ] && { printf "Darwin\\n"; exit 0; }; exec /usr/bin/uname "$@"\n' \
+  > "$DARWIN_STUBS/uname"
+chmod +x "$DARWIN_STUBS/uname"
+OLD_PATH_T11="$PATH"
+PATH="$DARWIN_STUBS:$PATH"
+SHELL=/bin/bash detect_profile
+PATH="$OLD_PATH_T11"
+if [ "$PROFILE_FILE" = "$HOME/.bash_profile" ]; then
+  ok "T11: detect_profile — Darwin bash → ~/.bash_profile"
+else
+  not_ok "T11: detect_profile — Darwin bash → ~/.bash_profile (got: $PROFILE_FILE)"
+fi
+
+# T12: Linux bash → ~/.bashrc  (CI runs on Linux; real uname returns Linux)
+SHELL=/bin/bash detect_profile
+if [ "$PROFILE_FILE" = "$HOME/.bashrc" ]; then
+  ok "T12: detect_profile — Linux bash → ~/.bashrc"
+else
+  not_ok "T12: detect_profile — Linux bash → ~/.bashrc (got: $PROFILE_FILE)"
+fi
+
+# T13: unknown shell → ~/.profile
+SHELL=/usr/bin/fish detect_profile
+if [ "$PROFILE_FILE" = "$HOME/.profile" ]; then
+  ok "T13: detect_profile — unknown shell → ~/.profile"
+else
+  not_ok "T13: detect_profile — unknown shell → ~/.profile (got: $PROFILE_FILE)"
+fi
+
+# ---------------------------------------------------------------
+# main() integration tests — T14–T16
+# Exercises the real entry path with stubbed network/system functions.
+# ---------------------------------------------------------------
+
+# Build a fake 'curl' that writes a minimal sh script to any '-o FILE' target.
+TEST_STUBS="$TEST_HOME/stubs"
+mkdir -p "$TEST_STUBS"
+printf '#!/usr/bin/env sh\noutfile=""\nwhile [ "$#" -gt 0 ]; do\n  case "$1" in\n    -o) outfile="$2"; shift 2 ;;\n    *)  shift ;;\n  esac\ndone\n[ -n "$outfile" ] && printf "#!/usr/bin/env sh\\nexit 0\\n" > "$outfile"\nexit 0\n' \
+  > "$TEST_STUBS/curl"
+chmod +x "$TEST_STUBS/curl"
+
+# Override network/platform functions to avoid real I/O
+resolve_version()  { VERSION="v0.0.0-test"; }
+resolve_platform() { PLATFORM="linux-x86_64"; }
+resolve_channel()  { CHANNEL="airgapped"; }
+verify_checksum()  { return 0; }
+need_cmd()         { return 0; }
+
+SAVED_PATH_STUBS="$PATH"
+PATH="$TEST_STUBS:$PATH"
+
+# T14: main() --no-profile parses the flag and skips profile write
+T14_PROFILE="$TEST_HOME/.t14_profile"
+printf '' > "$T14_PROFILE"
+detect_profile() { PROFILE_FILE="$T14_PROFILE"; }
+NO_PROFILE=0
+if main --no-profile >/dev/null 2>&1; then
+  if [ ! -s "$T14_PROFILE" ]; then
+    ok "T14: main() --no-profile parses flag and leaves profile untouched"
+  else
+    not_ok "T14: main() --no-profile wrote to profile (file non-empty)"
+  fi
+else
+  not_ok "T14: main() --no-profile exited non-zero"
+fi
+tmp_dir=""
+
+# T15: main() default path writes both exports through the real write_profile call
+T15_PROFILE="$TEST_HOME/.t15_profile"
+printf '' > "$T15_PROFILE"
+detect_profile() { PROFILE_FILE="$T15_PROFILE"; }
+NO_PROFILE=0
+GBRAIN_NO_PROFILE=0
+if main >/dev/null 2>&1; then
+  if grep -Fq "export PATH=" "$T15_PROFILE" && grep -Fq "export GBRAIN_DB=" "$T15_PROFILE"; then
+    ok "T15: main() default path writes PATH and GBRAIN_DB to profile"
+  else
+    not_ok "T15: main() default path did not write expected exports"
+  fi
+else
+  not_ok "T15: main() default path exited non-zero"
+fi
+tmp_dir=""
+
+PATH="$SAVED_PATH_STUBS"
+
+# T16: GBRAIN_NO_PROFILE=1 env var is captured at script source time → NO_PROFILE=1
+# Run the installer in a fresh subprocess (GBRAIN_TEST_MODE=1 prevents main() from firing
+# but the top-level assignment  NO_PROFILE="${GBRAIN_NO_PROFILE:-0}"  still executes).
+t16_result=$(GBRAIN_TEST_MODE=1 \
+  GBRAIN_NO_PROFILE=1 \
+  GBRAIN_INSTALL_DIR="$TEST_HOME/bin" \
+  HOME="$TEST_HOME" \
+  sh -c ". \"$INSTALL_SH\" && printf '%s' \"\$NO_PROFILE\"" 2>/dev/null)
+if [ "$t16_result" = "1" ]; then
+  ok "T16: GBRAIN_NO_PROFILE=1 env var sets NO_PROFILE=1 at script startup"
+else
+  not_ok "T16: GBRAIN_NO_PROFILE=1 did not set NO_PROFILE=1 (got: '$t16_result')"
+fi
+
+# ---------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"

--- a/tests/install_profile.sh
+++ b/tests/install_profile.sh
@@ -375,25 +375,27 @@ resolve_channel()  { CHANNEL="airgapped"; }
 verify_checksum()  { return 0; }
 need_cmd()         { return 0; }
 PATH="$TEST_STUBS:$PATH"
-T19_PROFILE="$TEST_HOME/.t19_profile"
-rm -f "$T19_PROFILE"
 NO_PROFILE=0
 GBRAIN_NO_PROFILE=0
-detect_profile() {
-  PROFILE_FILE="$T19_PROFILE"
-  printf '%s\n' "Warning: Shell profile $PROFILE_FILE is not writable." >&2
-  return 1
-}
+T19_HOME="$TEST_HOME/unwritable_home_t19"
+mkdir -p "$T19_HOME"
+chmod 500 "$T19_HOME"
+OLD_HOME_T19="$HOME"
+OLD_SHELL_T19="${SHELL:-}"
+HOME="$T19_HOME"
+SHELL=/usr/bin/zsh
 if main >"$TEST_HOME/t19_main.out" 2>"$TEST_HOME/t19_main.err"; then
   not_ok "T19: main() should exit non-zero when profile persistence fails"
 else
-  if grep -Fq 'gbrain was installed, but PATH/GBRAIN_DB were not persisted automatically.' "$TEST_HOME/t19_main.err" &&
+  if grep -Fq "Cannot create shell profile ${T19_HOME}/.zshrc" "$TEST_HOME/t19_main.err" &&
+     grep -Fq 'gbrain was installed, but PATH/GBRAIN_DB were not persisted automatically.' "$TEST_HOME/t19_main.err" &&
      grep -Fq 'Complete setup by adding these to your shell profile:' "$TEST_HOME/t19_main.err" &&
      grep -Fq 'export PATH="' "$TEST_HOME/t19_main.err" &&
-     grep -Fq 'export GBRAIN_DB="$HOME/brain.db"' "$TEST_HOME/t19_main.err"; then
-    ok "T19: main() prints manual recovery steps when profile persistence fails"
+     grep -Fq 'export GBRAIN_DB="$HOME/brain.db"' "$TEST_HOME/t19_main.err" &&
+     grep -Fq 'download first, then run:' "$TEST_HOME/t19_main.err"; then
+    ok "T19: main() drives the real detect_profile failure and prints recovery guidance"
   else
-    not_ok "T19: main() did not print the expected recovery guidance on profile failure"
+    not_ok "T19: main() did not print the expected real failure and recovery output"
   fi
 fi
 if grep -Fq "Installed gbrain to" "$TEST_HOME/t19_main.out"; then
@@ -401,6 +403,14 @@ if grep -Fq "Installed gbrain to" "$TEST_HOME/t19_main.out"; then
 else
   not_ok "T19b: main() should report the installed binary path on profile failure"
 fi
+if [ ! -e "$T19_HOME/.zshrc" ]; then
+  ok "T19c: main() leaves the failed profile path untouched"
+else
+  not_ok "T19c: main() unexpectedly created the unwritable profile file"
+fi
+HOME="$OLD_HOME_T19"
+SHELL="$OLD_SHELL_T19"
+chmod 700 "$T19_HOME"
 tmp_dir=""
 PATH="$SAVED_PATH_STUBS"
 

--- a/website/src/content/docs/guides/install.md
+++ b/website/src/content/docs/guides/install.md
@@ -81,14 +81,14 @@ curl -fsSL https://raw.githubusercontent.com/macro88/gigabrain/main/scripts/inst
 You can pin a version, switch to the online channel, or change the install directory:
 
 ```bash
-GBRAIN_VERSION=v0.9.1 \
-  curl -fsSL https://raw.githubusercontent.com/macro88/gigabrain/main/scripts/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/macro88/gigabrain/main/scripts/install.sh \
+  | GBRAIN_VERSION=v0.9.1 sh
 
-GBRAIN_VERSION=v0.9.1 GBRAIN_CHANNEL=online \
-  curl -fsSL https://raw.githubusercontent.com/macro88/gigabrain/main/scripts/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/macro88/gigabrain/main/scripts/install.sh \
+  | GBRAIN_VERSION=v0.9.1 GBRAIN_CHANNEL=online sh
 
-GBRAIN_VERSION=v0.9.1 GBRAIN_INSTALL_DIR="$HOME/.local/bin" \
-  curl -fsSL https://raw.githubusercontent.com/macro88/gigabrain/main/scripts/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/macro88/gigabrain/main/scripts/install.sh \
+  | GBRAIN_VERSION=v0.9.1 GBRAIN_INSTALL_DIR="$HOME/.local/bin" sh
 ```
 
 > **Note:** The default install directory is `~/.local/bin`. System-wide paths like `/usr/local/bin`

--- a/website/src/content/docs/guides/install.md
+++ b/website/src/content/docs/guides/install.md
@@ -95,8 +95,29 @@ GBRAIN_VERSION=v0.9.1 GBRAIN_INSTALL_DIR="$HOME/.local/bin" \
 > require `sudo` — the installer does not escalate privileges automatically.
 
 The installer auto-detects your platform, chooses the airgapped or online release asset based on
-`GBRAIN_CHANNEL`, verifies the SHA-256 checksum, runs `gbrain version`, and prints a `GBRAIN_DB`
-shell-profile tip.
+`GBRAIN_CHANNEL`, verifies the SHA-256 checksum, runs `gbrain version`, and automatically writes
+`PATH` and `GBRAIN_DB` to your shell profile (`~/.zshrc`, `~/.bashrc`, or `~/.profile`).
+
+To skip automatic profile writes (e.g. in CI or agent environments that manage `$PATH` externally):
+
+```bash
+GBRAIN_NO_PROFILE=1 curl -fsSL https://raw.githubusercontent.com/macro88/gigabrain/main/scripts/install.sh | sh
+# or with the two-step method:
+sh gbrain-install.sh --no-profile
+```
+
+#### Sandboxed / agent environments
+
+If your security sandbox blocks piping remote scripts directly to `sh`, download first, then run:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/macro88/gigabrain/main/scripts/install.sh \
+  -o gbrain-install.sh && sh gbrain-install.sh
+```
+
+This two-step pattern works in restricted shells and agent environments (e.g. OpenClaw) where
+the one-liner `curl | sh` is blocked. The installer's profile-write behavior is identical in
+both modes — `GBRAIN_NO_PROFILE=1` or `--no-profile` opts out.
 
 ### npm global install (staged)
 

--- a/website/src/content/docs/guides/install.md
+++ b/website/src/content/docs/guides/install.md
@@ -101,9 +101,10 @@ The installer auto-detects your platform, chooses the airgapped or online releas
 To skip automatic profile writes (e.g. in CI or agent environments that manage `$PATH` externally):
 
 ```bash
-GBRAIN_NO_PROFILE=1 curl -fsSL https://raw.githubusercontent.com/macro88/gigabrain/main/scripts/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/macro88/gigabrain/main/scripts/install.sh | GBRAIN_NO_PROFILE=1 sh
 # or with the two-step method:
-sh gbrain-install.sh --no-profile
+curl -fsSL https://raw.githubusercontent.com/macro88/gigabrain/main/scripts/install.sh \
+  -o gbrain-install.sh && sh gbrain-install.sh --no-profile
 ```
 
 #### Sandboxed / agent environments

--- a/website/src/content/docs/guides/install.md
+++ b/website/src/content/docs/guides/install.md
@@ -96,7 +96,7 @@ GBRAIN_VERSION=v0.9.1 GBRAIN_INSTALL_DIR="$HOME/.local/bin" \
 
 The installer auto-detects your platform, chooses the airgapped or online release asset based on
 `GBRAIN_CHANNEL`, verifies the SHA-256 checksum, runs `gbrain version`, and automatically writes
-`PATH` and `GBRAIN_DB` to your shell profile (`~/.zshrc`, `~/.bashrc`, or `~/.profile`).
+`PATH` and `GBRAIN_DB` to your shell profile (`~/.zshrc`, `~/.bash_profile` on macOS / `~/.bashrc` on Linux, or `~/.profile`).
 
 To skip automatic profile writes (e.g. in CI or agent environments that manage `$PATH` externally):
 


### PR DESCRIPTION
## Summary

The shell installer now **automatically writes** `PATH` and `GBRAIN_DB` exports to the user's shell profile after a successful install. This eliminates the silent failure where gbrain installs correctly but is unreachable after session restart.

### What changed

| File | Change |
|------|--------|
| `scripts/install.sh` | `detect_profile`, `write_profile_line`, `write_profile` functions; `--no-profile` flag; `GBRAIN_NO_PROFILE` env var; two-step install hint |
| `packages/gbrain-npm/scripts/postinstall.js` | Updated GBRAIN_DB tip wording to match shell installer |
| `README.md` | Profile auto-write note + `--no-profile` in Quick Start |
| `docs/getting-started.md` | Post-install profile setup note; added `GBRAIN_NO_PROFILE` to env table |
| `website/.../install.md` | Sandboxed environments section with two-step install pattern |
| `openspec/changes/install-profile-flow/` | Full proposal, design, and tasks (all complete) |

### Behavior

- **Default:** writes `export PATH` and `export GBRAIN_DB` to `~/.zshrc`, `~/.bashrc`, or `~/.profile` (detected via `$SHELL`)
- **Idempotent:** greps before appending — re-runs never duplicate lines
- **Opt-out:** `GBRAIN_NO_PROFILE=1` (env var, works with pipe-to-sh) or `--no-profile` (flag)
- **Sandboxed environments:** two-step `curl -o ... && sh` pattern documented for agent/restricted shells

### Verification

- Fresh profile write: ✓ both lines written exactly once
- Idempotent re-run: ✓ no duplicates
- `--no-profile` flag: ✓ skips writes, prints manual hints
- `GBRAIN_NO_PROFILE=1` env var: ✓ same as flag
- `cargo test`: ✓ all tests pass

Closes #36
Closes #41