### PR TITLE
docs: add install one-liner to hero

### DIFF
--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -16,7 +16,19 @@ hero:
       variant: secondary
 ---
 
-import { CardGrid, Card } from "@astrojs/starlight/components";
+import { Code, CardGrid, Card } from "@astrojs/starlight/components";
+
+## Install
+
+<Code code={`curl -fsSL https://raw.githubusercontent.com/macro88/gigabrain/main/scripts/install.sh | sh`} lang="bash" title="Install GigaBrain (macOS / Linux)" />
+
+Then import your notes and connect to Claude Code:
+
+<Code code={`gbrain import ~/docs --db ~/brain.db\ngbrain serve --db ~/brain.db`} lang="bash" />
+
+**Three commands. No API keys. No cloud.** [Full install options →](/guides/install/)
+
+---
 
 ## Architecture for Privacy
 


### PR DESCRIPTION
## Problem

The homepage has no visible install command. Visitors who land on [macro88.github.io/gigabrain](https://macro88.github.io/gigabrain/) see a hero with 'Get Started' and 'View Source' buttons but have to click through to find the actual install command.

## Solution

- Add `curl | sh` one-liner prominently to the homepage hero section
- Add Quick Install section at the top of the install guide
- Update quick-start to ensure install is step 0
- Sharper tagline: 'MCP-ready in 30 seconds'

## Reference patterns

- brew.sh: entire homepage IS the install command
- cli.github.com: install in hero above the fold
- garrytan/gstack: install command in first paragraph of README

No functional changes - docs only.