### PR TITLE
docs: add proposal to enable flexible model resoltion

### DIFF
--- a/openspec/changes/flexible-model-resolution/.openspec.yaml
+++ b/openspec/changes/flexible-model-resolution/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-18

--- a/openspec/changes/flexible-model-resolution/design.md
+++ b/openspec/changes/flexible-model-resolution/design.md
@@ -1,0 +1,67 @@
+## Context
+
+`resolve_model()` in `src/core/inference.rs` maps `--model` inputs to `ModelConfig` structs. Currently each known alias carries a pinned HuggingFace commit SHA (`revision`) and a `sha256_hashes` struct with expected file hashes. These values rotted — HF reorganised the large and m3 repos, causing 404s on download. Additionally, aliases `medium` and `max` appear in docs but are absent from the match table.
+
+The dimension-inference path (`hydrate_model_config`) already exists for custom model IDs and reads `embedding_dim` from `config.json` at download time, so the infrastructure for arbitrary model IDs is in place.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Remove all pinned revision SHAs and sha256_hashes from known-alias entries
+- Add `medium` → `base` and `max` → `m3` aliases to close the doc/code gap
+- Accept any `owner/repo` HF model ID without warnings
+- Add `gbrain model list` subcommand: static table of known aliases, their HF IDs, dims, and sizes
+- Update `--model` help text to mention `gbrain model list`
+
+**Non-Goals:**
+- Live HF API queries (rate limits, auth complexity, network dependency)
+- Integrity checking of downloaded model files (removed with the SHA tables)
+- Changing the DB `brain_config` schema or `model_id` storage format
+
+## Decisions
+
+### Remove all revision pinning and SHA verification for known aliases
+
+**Decision:** Drop `ModelFileHashes`, the four `*_HASHES` constants, and the `revision` field from `ModelConfig`. Known aliases resolve to `(model_id, embedding_dim, revision: None, sha256_hashes: None)`.
+
+**Alternatives considered:**
+- *Keep SHAs, update to current commits* — maintenance treadmill; same problem recurs on next HF repo reorg
+- *Pin to `"main"` branch* — avoids 404s but still requires manual updates if the branch is renamed or the model is restructured
+- *Warn-only on SHA mismatch* — half-measure; still requires maintaining hash tables
+
+**Rationale:** The meaningful reproducibility guarantee is the `model_id` string stored in `brain_config`, validated on every `brain open`. Commit SHAs offer a second layer whose maintenance cost exceeds its benefit for a personal, single-user tool.
+
+### Accept arbitrary HF model IDs silently (no warning)
+
+**Decision:** The `_` catch-all branch in `resolve_model()` currently prints a warning for "unpinned custom" models. Remove the warning — any `owner/repo` string is first-class.
+
+**Rationale:** Users passing full HF IDs (`sentence-transformers/all-MiniLM-L6-v2`) are doing exactly the right thing. The warning incorrectly signals that this is unsafe.
+
+### Add `medium` and `max` as documented aliases
+
+**Decision:** `medium` → `base` (BAAI/bge-base-en-v1.5, 768d), `max` → `m3` (BAAI/bge-m3, 1024d).
+
+**Rationale:** Closes issue #60. Cheaper than updating all docs. Aliases are obvious and consistent with size-based naming.
+
+### `gbrain model list` as a static informational command
+
+**Decision:** New `src/commands/model.rs` with a `list` subcommand. Prints a fixed table from a `KNOWN_MODELS` const slice. No network required.
+
+**Alternatives considered:**
+- *Live HF API query via `--remote` flag* — too much complexity (rate limits, pagination, auth tokens) for marginal benefit
+- *Include in `--help` text only* — harder to parse, can't pipe/grep
+
+## Risks / Trade-offs
+
+- [Removed SHA verification] downloaded files are no longer integrity-checked → Mitigation: HF CDN uses HTTPS; risk is low for a personal tool; can be re-added opt-in later
+- [Alias additions `medium`/`max`] users who already type `--model base` or `--model m3` are unaffected; new aliases are purely additive
+
+## Migration Plan
+
+No DB migration required. `brain_config` stores `model_id` (a string like `BAAI/bge-base-en-v1.5`), not the alias or revision. Existing brains open normally.
+
+Code-only change: update `inference.rs`, add `commands/model.rs`, wire into `main.rs` / `commands/mod.rs`.
+
+## Open Questions
+
+- Should `gbrain model list` output plain text (default) and optionally JSON (`--json`)? Recommend yes for scripting consistency with other commands.

--- a/openspec/changes/flexible-model-resolution/proposal.md
+++ b/openspec/changes/flexible-model-resolution/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Hardcoded HuggingFace commit SHAs in `resolve_model()` rot as HF reorganizes repos, causing download failures for `large` and `m3` models. At the same time, undocumented aliases (`medium`, `max`) referenced in docs don't exist in code. The fix is to remove pinned revisions and SHA tables entirely, accept arbitrary HF model IDs, and provide a `--model list` command so users can discover supported aliases without reading source.
+
+## What Changes
+
+- Remove all hardcoded `revision` commit SHAs and `sha256_hashes` from `ModelConfig` and the four `*_HASHES` constants
+- Simplify `resolve_model()`: known short aliases expand to HF IDs with no pinned revision; any `owner/repo` string is accepted as a custom model ID
+- Add `medium` and `max` as aliases (`medium` → `base`, `max` → `m3`) to match documented behaviour, or remove those mentions from docs
+- Add `gbrain --model list` (or `gbrain model list`) subcommand that prints a static table of known aliases, HF IDs, dimensions, and approximate sizes
+- Update CLI `--model` help text to reference `--model list`
+- **BREAKING**: `ModelConfig.revision` and `ModelConfig.sha256_hashes` fields removed (internal, no public API impact)
+
+## Capabilities
+
+### New Capabilities
+
+- `model-resolution`: How `--model` inputs are resolved to HF model IDs, including alias expansion, custom ID pass-through, and the `--model list` informational command
+
+### Modified Capabilities
+
+- (none — this is a new capability spec; existing behaviour was undocumented)
+
+## Impact
+
+- `src/core/inference.rs` — `resolve_model()`, `ModelConfig`, hash constants
+- `src/commands/` — any command accepting `--model` flag; add `list` subcommand
+- `CLAUDE.md`, `AGENTS.md`, docs — alias table references need updating
+- No DB schema changes; `model_id` string stored in `brain_config` is unaffected

--- a/openspec/changes/flexible-model-resolution/specs/model-resolution/spec.md
+++ b/openspec/changes/flexible-model-resolution/specs/model-resolution/spec.md
@@ -1,0 +1,51 @@
+## ADDED Requirements
+
+### Requirement: Known alias expansion
+The system SHALL resolve short alias strings to canonical HuggingFace model IDs without requiring pinned revision SHAs or file hash verification. Aliases SHALL include: `small`, `base`, `medium`, `large`, `m3`, `max`.
+
+#### Scenario: Small alias resolves correctly
+- **WHEN** user passes `--model small` (or omits `--model`)
+- **THEN** the system uses model ID `BAAI/bge-small-en-v1.5` with embedding dimension 384
+
+#### Scenario: Base alias resolves correctly
+- **WHEN** user passes `--model base`
+- **THEN** the system uses model ID `BAAI/bge-base-en-v1.5` with embedding dimension 768
+
+#### Scenario: Medium alias resolves as base
+- **WHEN** user passes `--model medium`
+- **THEN** the system uses model ID `BAAI/bge-base-en-v1.5` with embedding dimension 768
+
+#### Scenario: Large alias resolves correctly
+- **WHEN** user passes `--model large`
+- **THEN** the system uses model ID `BAAI/bge-large-en-v1.5` with embedding dimension 1024
+
+#### Scenario: M3 alias resolves correctly
+- **WHEN** user passes `--model m3`
+- **THEN** the system uses model ID `BAAI/bge-m3` with embedding dimension 1024
+
+#### Scenario: Max alias resolves as m3
+- **WHEN** user passes `--model max`
+- **THEN** the system uses model ID `BAAI/bge-m3` with embedding dimension 1024
+
+#### Scenario: Full HF model ID accepted silently
+- **WHEN** user passes a full HuggingFace model ID (e.g. `--model sentence-transformers/all-MiniLM-L6-v2`)
+- **THEN** the system accepts it without warnings and infers embedding dimension at load time
+
+#### Scenario: Full HF ID for known model normalises to alias
+- **WHEN** user passes `--model BAAI/bge-base-en-v1.5`
+- **THEN** the system resolves it identically to `--model base`
+
+### Requirement: Model list command
+The system SHALL provide a `gbrain model list` subcommand that prints a static table of known model aliases, their canonical HuggingFace IDs, embedding dimensions, and approximate download sizes. The command SHALL NOT require network access.
+
+#### Scenario: Plain text output
+- **WHEN** user runs `gbrain model list`
+- **THEN** a human-readable table is printed to stdout listing all known aliases
+
+#### Scenario: JSON output
+- **WHEN** user runs `gbrain model list --json`
+- **THEN** a JSON array is printed with fields: `alias`, `model_id`, `dim`, `size_mb`, `notes`
+
+#### Scenario: Help text references model list
+- **WHEN** user runs `gbrain --help` or `gbrain init --help`
+- **THEN** the `--model` flag description mentions `gbrain model list` for available options

--- a/openspec/changes/flexible-model-resolution/tasks.md
+++ b/openspec/changes/flexible-model-resolution/tasks.md
@@ -1,0 +1,33 @@
+## 1. Clean up ModelConfig and hash constants
+
+- [ ] 1.1 Remove `ModelFileHashes` struct and all four `*_HASHES` constants (`SMALL_HASHES`, `BASE_HASHES`, `LARGE_HASHES`, `M3_HASHES`) from `src/core/inference.rs`
+- [ ] 1.2 Remove `revision: Option<&'static str>` and `sha256_hashes: Option<ModelFileHashes>` fields from `ModelConfig`
+- [ ] 1.3 Remove any SHA verification logic in the download path that references `sha256_hashes`
+
+## 2. Simplify resolve_model()
+
+- [ ] 2.1 Rewrite `resolve_model()` match arms: known aliases return `ModelConfig` with no revision/hashes
+- [ ] 2.2 Add `"medium"` arm → `base` (BAAI/bge-base-en-v1.5, 768d)
+- [ ] 2.3 Add `"max"` arm → `m3` (BAAI/bge-m3, 1024d)
+- [ ] 2.4 Remove the warning `eprintln!` from the `_` catch-all arm; arbitrary HF IDs are accepted silently
+- [ ] 2.5 Ensure full HF IDs (e.g. `BAAI/bge-base-en-v1.5`) still normalise to their alias equivalents
+
+## 3. Add `gbrain model list` command
+
+- [ ] 3.1 Create `src/commands/model.rs` with a `KNOWN_MODELS` const slice (alias, model_id, dim, size_mb, notes)
+- [ ] 3.2 Implement plain-text table output for `gbrain model list`
+- [ ] 3.3 Implement `--json` flag outputting a JSON array
+- [ ] 3.4 Wire `model` subcommand into `src/commands/mod.rs` and `src/main.rs`
+
+## 4. Update help text and docs
+
+- [ ] 4.1 Update `--model` flag description in all commands to mention `gbrain model list`
+- [ ] 4.2 Update `CLAUDE.md` alias table: add `medium`, `max`; remove SHA/revision references
+- [ ] 4.3 Update `AGENTS.md` if it references model aliases or revision pinning
+
+## 5. Tests
+
+- [ ] 5.1 Add unit tests in `src/core/inference.rs` for `medium` and `max` aliases
+- [ ] 5.2 Add unit test that full HF IDs normalise to alias equivalents
+- [ ] 5.3 Add unit test that arbitrary `owner/repo` strings are accepted without error
+- [ ] 5.4 Verify `cargo test` passes


### PR DESCRIPTION
This pull request introduces a major overhaul of how model selection and resolution works in the project, focusing on simplifying the process, improving user experience, and reducing maintenance overhead. The main changes remove hardcoded HuggingFace commit SHAs and file hash checks, expand and clarify alias support, allow arbitrary HuggingFace model IDs, and add a discoverability command for available models. No database or public API changes are involved.

**Model Resolution and Alias Improvements**
* Removed all pinned revision SHAs and file hash verifications from `ModelConfig` and related constants, eliminating maintenance of these values and SHA checks. [[1]](diffhunk://#diff-d28eccd6ddfc1b79328a02058f2efafd6d5324c28a1d0b8d6601bd11dbfd033dR1-R67) [[2]](diffhunk://#diff-a152304289c94820213f4a96187055306e2d007e6ded3f47a75508749f8f95d6R1-R29) [[3]](diffhunk://#diff-c6149a32df52d8df9d7a4298b81b2c60aff53ee62cdc37f1896d26f3d75c8aacR1-R33)
* Added `medium` (alias for `base`) and `max` (alias for `m3`) to the supported model aliases, closing the gap between documentation and code. [[1]](diffhunk://#diff-d28eccd6ddfc1b79328a02058f2efafd6d5324c28a1d0b8d6601bd11dbfd033dR1-R67) [[2]](diffhunk://#diff-a152304289c94820213f4a96187055306e2d007e6ded3f47a75508749f8f95d6R1-R29) [[3]](diffhunk://#diff-7e3c7fe364c7a10673cc77922887c9fc51ed12a7dada6da5d4b4dc189c683d18R1-R51) [[4]](diffhunk://#diff-c6149a32df52d8df9d7a4298b81b2c60aff53ee62cdc37f1896d26f3d75c8aacR1-R33)
* Updated the model resolution logic to accept any HuggingFace `owner/repo` model ID without warning, treating custom IDs as first-class and normalizing known full IDs to their alias equivalents. [[1]](diffhunk://#diff-d28eccd6ddfc1b79328a02058f2efafd6d5324c28a1d0b8d6601bd11dbfd033dR1-R67) [[2]](diffhunk://#diff-7e3c7fe364c7a10673cc77922887c9fc51ed12a7dada6da5d4b4dc189c683d18R1-R51) [[3]](diffhunk://#diff-c6149a32df52d8df9d7a4298b81b2c60aff53ee62cdc37f1896d26f3d75c8aacR1-R33)

**User Interface and Discoverability**
* Added a new `gbrain model list` subcommand that prints a static table of known aliases, HuggingFace IDs, embedding dimensions, and sizes, with optional JSON output for scripting. [[1]](diffhunk://#diff-d28eccd6ddfc1b79328a02058f2efafd6d5324c28a1d0b8d6601bd11dbfd033dR1-R67) [[2]](diffhunk://#diff-7e3c7fe364c7a10673cc77922887c9fc51ed12a7dada6da5d4b4dc189c683d18R1-R51) [[3]](diffhunk://#diff-c6149a32df52d8df9d7a4298b81b2c60aff53ee62cdc37f1896d26f3d75c8aacR1-R33)
* Updated CLI help text for the `--model` flag to reference the new model list command, improving discoverability for users. [[1]](diffhunk://#diff-a152304289c94820213f4a96187055306e2d007e6ded3f47a75508749f8f95d6R1-R29) [[2]](diffhunk://#diff-7e3c7fe364c7a10673cc77922887c9fc51ed12a7dada6da5d4b4dc189c683d18R1-R51) [[3]](diffhunk://#diff-c6149a32df52d8df9d7a4298b81b2c60aff53ee62cdc37f1896d26f3d75c8aacR1-R33)

**Documentation and Testing**
* Updated documentation and design specs to reflect the new model aliasing and resolution behavior, and outlined tasks for code, docs, and tests to ensure robustness and clarity. [[1]](diffhunk://#diff-d28eccd6ddfc1b79328a02058f2efafd6d5324c28a1d0b8d6601bd11dbfd033dR1-R67) [[2]](diffhunk://#diff-a152304289c94820213f4a96187055306e2d007e6ded3f47a75508749f8f95d6R1-R29) [[3]](diffhunk://#diff-7e3c7fe364c7a10673cc77922887c9fc51ed12a7dada6da5d4b4dc189c683d18R1-R51) [[4]](diffhunk://#diff-c6149a32df52d8df9d7a4298b81b2c60aff53ee62cdc37f1896d26f3d75c8aacR1-R33)

These changes make model selection more robust, user-friendly, and maintainable, while removing unnecessary complexity from the codebase.