### PR TITLE
docs: add OpenClaw harness guide for v0.9.6 (collections + live sync)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -77,13 +77,22 @@ gbrain init ~/brain.db
 
 This creates a new `brain.db` file with the full v5 schema — pages, embeddings, links, assertions, knowledge-gaps table, and (in `v0.9.6`) collections, file_state, and raw_imports tables.
 
-### 2. Import an existing markdown directory
+### 2. Import or attach an existing markdown directory
 
 ```bash
 gbrain import /path/to/notes/ --db ~/brain.db
 ```
 
 GigaBrain ingests each markdown file, parses frontmatter, splits compiled-truth from timeline, generates embeddings, and writes to the database. Ingest is idempotent — re-running the same file is safe.
+
+> **`v0.9.6` note:** Use collections for ongoing vault sync. The old workflow was `gbrain import <path>`. The new workflow is `gbrain collection add <name> <path>` and then `gbrain serve`, which starts the live watcher automatically on macOS/Linux.
+>
+> ```bash
+> gbrain collection add notes /path/to/notes
+> gbrain serve
+> ```
+>
+> Use `gbrain import` for one-shot bulk ingest. Use collections when you want GigaBrain to stay in sync with a markdown or Obsidian vault. For an OpenClaw setup, see [openclaw-harness.md](openclaw-harness.md).
 
 ### 3. Search
 
@@ -163,6 +172,8 @@ gbrain serve
 > **Unix only in `v0.9.6`.** `gbrain serve` now owns the vault-sync runtime, so macOS/Linux are the supported hosts for MCP on this release line. On Windows it returns `UnsupportedPlatformError`; use the portable CLI commands (`search`, `query`, `get`, `list`, etc.) there until a safe non-Unix serve contract lands.
 
 The MCP server exposes tools over stdio JSON-RPC 2.0.
+
+> For OpenClaw, put the same server definition under `mcp.servers` in `openclaw.json`. See [openclaw-harness.md](openclaw-harness.md) for the full harness setup, collections-based vault sync, and `brain_collections` health checks.
 
 **Phase 1 tools (core read/write):** `brain_get`, `brain_put`, `brain_query`, `brain_search`, `brain_list`
 

--- a/docs/openclaw-harness.md
+++ b/docs/openclaw-harness.md
@@ -1,0 +1,187 @@
+# Using GigaBrain v0.9.6 as an OpenClaw Harness
+
+GigaBrain `v0.9.6` works well as the memory and knowledge layer for agents running on OpenClaw. OpenClaw talks to GigaBrain over MCP, while GigaBrain keeps a local SQLite brain synchronized with one or more markdown collections.
+
+This release changes the recommended setup:
+
+- Old one-shot ingest: `gbrain import <path>`
+- New live-sync workflow: `gbrain collection add <name> <path>` then `gbrain serve`
+
+When `gbrain serve` starts on macOS/Linux, it starts the MCP server and the live watcher for active collections. There is no separate sync daemon to run.
+
+## Prerequisites
+
+- macOS or Linux host for `gbrain serve`
+- `gbrain` `v0.9.6`
+- An initialized brain database
+- An OpenClaw install that supports MCP server configuration
+
+Initialize the database once:
+
+```bash
+gbrain init ~/brain.db
+```
+
+## Attach a vault as a collection
+
+For ongoing sync with Obsidian or any markdown vault, attach the directory as a collection instead of using `gbrain import`.
+
+```bash
+gbrain collection add notes ~/Documents/Obsidian
+```
+
+This creates the collection metadata in the v5 schema and performs the initial reconcile. In `v0.9.6`, the benchmark on a 350-page vault is about 5 seconds for `collection add`.
+
+Collections are backed by the new schema tables introduced in `v0.9.6`:
+
+- `collections`
+- `file_state`
+- `embedding_jobs`
+- `raw_imports`
+- `collection_owners`
+
+Use `.gbrainignore` at the vault root to exclude files or patterns from sync:
+
+```gitignore
+.obsidian/
+Templates/
+Daily/*.tmp.md
+archive/**
+```
+
+## Configure OpenClaw
+
+OpenClaw should launch `gbrain serve` as an MCP server. Put the GigaBrain block in `openclaw.json` under `mcp.servers`.
+
+Recommended `openclaw.json` snippet:
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "gbrain": {
+        "command": "gbrain",
+        "args": ["serve"],
+        "env": {
+          "GBRAIN_DB": "/Users/alice/brain.db"
+        }
+      }
+    }
+  }
+}
+```
+
+The important part is `GBRAIN_DB`: it must point at the `brain.db` file that OpenClaw agents should use.
+
+If you want to test the server outside OpenClaw first:
+
+```bash
+GBRAIN_DB=~/brain.db gbrain serve
+```
+
+## Live sync workflow
+
+The normal OpenClaw workflow is:
+
+1. Initialize the database with `gbrain init`.
+2. Attach one or more vaults with `gbrain collection add`.
+3. Configure OpenClaw to spawn `gbrain serve`.
+4. Start OpenClaw.
+5. Edit markdown files in the vault. The watcher started by `gbrain serve` reconciles changes into `brain.db` automatically.
+
+On `v0.9.6`, `gbrain serve` owns the watcher lifecycle on Unix/macOS. File edits, creates, and deletes are picked up automatically after the server starts.
+
+Deleted pages are not hard-deleted immediately. `v0.9.6` adds a quarantine lifecycle so pages with preserved DB-side state can be reviewed and restored instead of being dropped blindly.
+
+## MCP usage patterns
+
+OpenClaw agents should treat the GigaBrain MCP tools as the durable memory interface. `v0.9.6` exposes 17 tools, including the new `brain_collections` status tool.
+
+### `brain_query` vs `brain_search`
+
+Use `brain_query` for:
+
+- natural-language questions
+- synthesis across multiple pages
+- semantic retrieval when wording may not match exactly
+
+Use `brain_search` for:
+
+- exact keywords
+- names, titles, tags, or phrases likely to appear verbatim
+- fast recall when you know the text you want
+
+Benchmarks from the `v0.9.6` 350-page DAB run:
+
+- `collection add`: 5s
+- FTS query: 26ms
+- semantic query: 93ms
+- all checks: passed
+
+### When to use `brain_put`
+
+Use `brain_put` when the agent is intentionally creating or updating durable knowledge in the brain, not for temporary scratch work.
+
+For updates to an existing page:
+
+1. Call `brain_get` first.
+2. Read the current `version`.
+3. Send `brain_put` with `expected_version`.
+
+That preserves optimistic concurrency and avoids blind overwrites.
+
+### Use `brain_collections` for health checks
+
+`brain_collections` is the right first check when OpenClaw can query the MCP server but results look stale or writes are blocked.
+
+It returns a JSON array of collection status records. Check these fields first:
+
+- `state`
+- `page_count`
+- `last_sync_at`
+- `embedding_queue_depth`
+- `ignore_parse_errors`
+- `needs_full_sync`
+- `recovery_in_progress`
+- `integrity_blocked`
+- `restore_in_progress`
+
+Example request:
+
+```json
+{}
+```
+
+Example response:
+
+```json
+[
+  {
+    "name": "notes",
+    "root_path": "/Users/alice/Documents/Obsidian",
+    "state": "active",
+    "writable": true,
+    "is_write_target": true,
+    "page_count": 350,
+    "last_sync_at": "2026-04-25T09:01:00Z",
+    "embedding_queue_depth": 0,
+    "ignore_parse_errors": null,
+    "needs_full_sync": false,
+    "recovery_in_progress": false,
+    "integrity_blocked": null,
+    "restore_in_progress": false
+  }
+]
+```
+
+If `ignore_parse_errors` is non-null, fix the `.gbrainignore` file. If `needs_full_sync` is `true` or `state` is not `active`, treat the collection as unhealthy until reconcile or restore finishes.
+
+## Recommended operating model
+
+- Use `gbrain collection add` for vault-backed knowledge sources.
+- Keep `gbrain import` for one-shot bulk ingest, not live vault sync.
+- Let OpenClaw spawn `gbrain serve`; that keeps MCP and watcher lifecycle in one process.
+- Run `brain_query` first for agent reasoning, then fall back to `brain_search` for exact recall.
+- Use `brain_put` only for durable page updates.
+- Poll `brain_collections` during startup or incident diagnosis.
+


### PR DESCRIPTION
## Summary

Adds `docs/openclaw-harness.md` — a guide for using GigaBrain v0.9.6 as the memory/knowledge layer for agents running on OpenClaw. Also updates `docs/getting-started.md` with a v0.9.6 collections callout.

## What's in the new guide

- **Collections setup**: `gbrain collection add` instead of `gbrain import` for ongoing vault sync
- **OpenClaw config**: exact `openclaw.json` snippet with GBRAIN_DB env var
- **Live sync workflow**: `gbrain serve` starts the watcher automatically on Unix/macOS
- **MCP usage patterns**: `brain_query` vs `brain_search`, `brain_put` best practices, `brain_collections` health checks
- **`.gbrainignore` examples**
- **Quarantine behavior** (v0.9.6 soft-delete)

## DAB benchmark context (v0.9.6, 350 pages)

| Metric | Value |
|--------|-------|
| collection add | 5s |
| FTS query | 26ms |
| Semantic query | 93ms |
| Data integrity | All checks passed |
| PARA type classification | Fixed (archive=88, area=41, project=35, resource=96, journal=75) |

## macOS build note

v0.9.6 requires a one-line patch on macOS: `stat.st_mode as u32` in `src/core/fs_safety.rs` (macOS has `u16`, Linux has `u32`). Filed separately.

## Files changed

- `docs/openclaw-harness.md` (new, 187 lines)
- `docs/getting-started.md` (updated with v0.9.6 collections callout + link to new guide)