### PR TITLE
Fix serve watcher startup for empty collection roots

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,7 +210,7 @@ jobs:
             cargo build --release --no-default-features --features bundled,online-model
             ```
 
-            This release preserves the current vault-sync surface while fixing the macOS release build and enforcing one canonical public release-asset contract across the installer, workflow, and release checks. The `online` build still supports configurable BGE models via `GBRAIN_MODEL` / `--model`; `airgapped` embeds BGE-small-en-v1.5. npm installs the `online` channel; the shell installer defaults to `airgapped`.
+            This patch release preserves the current vault-sync surface and fixes Issue #81: `gbrain serve` now normalizes legacy active collections with blank root paths to `detached` before watcher registration, so empty-root bootstrap rows no longer break watcher startup. The `online` build still supports configurable BGE models via `GBRAIN_MODEL` / `--model`; `airgapped` embeds BGE-small-en-v1.5. npm installs the `online` channel; the shell installer defaults to `airgapped`.
 
             ---
           draft: false

--- a/.squad/agents/fry/history.md
+++ b/.squad/agents/fry/history.md
@@ -840,3 +840,8 @@ Ready for implementation and landing.
 - `src/core/vault_sync.rs` is the right regression seam for serve-only watcher bootstrapping: normalize invalid collection rows there and keep the proof close to watcher selection.
 - Cross-platform proof should target the deterministic normalization helper (`detach_active_collections_with_empty_root_path`), while the Unix-only watcher test can stay narrow and just prove the active watcher set excludes blank-root rows.
 - The default collection bootstrap is `root_path=''` plus `state='detached'` in `src/core/db.rs`; tests that want the old broken state must opt into it explicitly with `UPDATE collections SET state='active', root_path='' WHERE id = 1`.
+
+### 2026-04-25 11:35:00 - Issue #81 release-ready patch lane
+
+- When a hotfix PR is the next shippable patch, bump every public version truth that users can copy from (`Cargo.toml`, npm package metadata, runtime user agent, README/docs install snippets) in the same change or the release surface drifts immediately.
+- GitHub release body text is part of the product contract: keep install commands stable, but rewrite the explanatory paragraph so it names the actual hotfix instead of inheriting stale notes from the prior patch lane.

--- a/.squad/agents/fry/history.md
+++ b/.squad/agents/fry/history.md
@@ -834,3 +834,9 @@ Ready for implementation and landing.
 
 - When a platform gate sits at the public command boundary (`gbrain serve`), the docs need to describe the command as gated even if some lower-level helpers compile on other platforms. Reviewer feedback will keep coming back if the docs talk about an internal seam instead of the user-visible one.
 - Restore notes have to distinguish between “no implementation” and “narrow landed seam.” For quarantine restore, the honest wording was “Unix-only, no-replace target, pre-existing parent dirs, online handshake still deferred,” not “not yet implemented.”
+
+### 2026-04-25 10:45:00 - Issue #81 watcher empty-root repair
+
+- `src/core/vault_sync.rs` is the right regression seam for serve-only watcher bootstrapping: normalize invalid collection rows there and keep the proof close to watcher selection.
+- Cross-platform proof should target the deterministic normalization helper (`detach_active_collections_with_empty_root_path`), while the Unix-only watcher test can stay narrow and just prove the active watcher set excludes blank-root rows.
+- The default collection bootstrap is `root_path=''` plus `state='detached'` in `src/core/db.rs`; tests that want the old broken state must opt into it explicitly with `UPDATE collections SET state='active', root_path='' WHERE id = 1`.

--- a/.squad/decisions/inbox/fry-issue81-release-ready.md
+++ b/.squad/decisions/inbox/fry-issue81-release-ready.md
@@ -1,0 +1,6 @@
+# Fry — Issue #81 release-ready decision
+
+- **Date:** 2026-04-25
+- **Decision:** Ship PR #84 as patch release `v0.9.8`, and rewrite the GitHub release body to describe the empty-root watcher hotfix instead of reusing the prior `v0.9.7` macOS release-contract notes.
+- **Why:** The code fix in PR #84 is already the next patch candidate, so leaving product/version surfaces at `0.9.7` would mislabel the release and stale release-note prose would describe the wrong user-visible repair.
+- **Scope touched:** `Cargo.toml`, `Cargo.lock`, `packages/gbrain-npm/package.json`, `src/core/inference.rs`, `README.md`, `docs/getting-started.md`, `website/src/content/docs/guides/install.mdx`, `.github/workflows/release.yml`.

--- a/.squad/decisions/inbox/fry-issue81.md
+++ b/.squad/decisions/inbox/fry-issue81.md
@@ -1,0 +1,5 @@
+# Fry — Issue #81 watcher empty-root decision
+
+- Decision: treat any `collections` row with `state='active'` and blank `root_path` as invalid legacy state during serve watcher bootstrap, and normalize it to `state='detached'` before watcher registration.
+- Why: the crash surface happens before any filesystem work worth preserving; demoting the row is safer than attempting to watch an empty path or silently keeping an impossible active root around.
+- Implementation seam: `src/core/vault_sync.rs::detach_active_collections_with_empty_root_path()` runs from watcher sync, logs `WARN: serve_detached_empty_root ...`, and leaves watcher selection gated on `trim(root_path) != ''`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "gbrain"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gbrain"
-version = "0.9.7"
+version = "0.9.8"
 edition = "2021"
 description = "Personal knowledge brain. SQLite + FTS5 + local vector embeddings. One static binary."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Open-source personal knowledge brain. SQLite + FTS5 + vector embeddings in one file. Thin CLI harness, fat skill files. MCP-ready from day one. Runs anywhere. No API keys, no Docker. Airgapped + online release channels with configurable BGE models in the online build.
 
-**Status:** `v0.9.7` (release candidate) — current vault-sync surface plus the macOS release-build fix and a canonical release-asset contract shared across installer, workflow, docs, and release checks. [See the roadmap →](#roadmap)
+**Status:** `v0.9.8` (release candidate) — current vault-sync surface plus the Issue #81 watcher-startup hotfix for legacy active collections with blank root paths. [See the roadmap →](#roadmap)
 
 ---
 
@@ -79,18 +79,18 @@ Every knowledge page is a markdown file with this structure. GigaBrain stores th
 
 ## Quick start
 
-> `v0.9.7` keeps the current vault-sync surface and hardens release delivery: macOS release preflight now checks both channels and the public asset contract is centralized around `gbrain-<platform>-<channel>`.
+> `v0.9.8` keeps the current vault-sync surface and fixes Issue #81: `gbrain serve` now normalizes legacy active collections with blank root paths before watcher registration.
 
 ### Install options
 
 | Method | Status |
 | ------ | ------ |
 | Build from source (`cargo build --release`) | ✅ Available now — airgapped default |
-| GitHub Release binary (macOS ARM/x86, Linux x86_64/ARM64) | ✅ Available — `v0.9.7` airgapped + online assets |
+| GitHub Release binary (macOS ARM/x86, Linux x86_64/ARM64) | ✅ Available — `v0.9.8` airgapped + online assets |
 | `npm install -g gbrain` | 🚧 Staged — online channel by default once published |
 | One-command curl installer | ✅ Available — airgapped by default; set `GBRAIN_CHANNEL=online` for the online asset |
 
-**Build from source** defaults to the airgapped channel. **GitHub Releases** and the **shell installer** expose both channels for `v0.9.7` using the canonical `gbrain-<platform>-<channel>` asset names. The npm package remains a single wrapper package and targets the `online` channel by default.
+**Build from source** defaults to the airgapped channel. **GitHub Releases** and the **shell installer** expose both channels for `v0.9.8` using the canonical `gbrain-<platform>-<channel>` asset names. The npm package remains a single wrapper package and targets the `online` channel by default.
 
 Install with the shell script:
 
@@ -125,7 +125,7 @@ curl -fsSL https://raw.githubusercontent.com/macro88/gigabrain/main/scripts/inst
 Download a pre-built binary from GitHub Releases:
 
 ```bash
-VERSION="v0.9.7"
+VERSION="v0.9.8"
 PLATFORM="darwin-arm64"   # darwin-arm64 | darwin-x86_64 | linux-x86_64 | linux-aarch64
 ASSET="gbrain-${PLATFORM}-airgapped"   # or: gbrain-${PLATFORM}-online
 curl -fsSL "https://github.com/macro88/gigabrain/releases/download/${VERSION}/${ASSET}" -o "${ASSET}"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started with GigaBrain
 
-> GigaBrain is a local-first personal knowledge brain: SQLite + FTS5 + local vector embeddings in one file. `v0.9.7` keeps the current vault-sync release surface and adds the macOS release-build fix plus a canonical release-asset contract.
+> GigaBrain is a local-first personal knowledge brain: SQLite + FTS5 + local vector embeddings in one file. `v0.9.8` keeps the current vault-sync release surface and adds the Issue #81 watcher-startup hotfix for legacy blank-root collections.
 
 ## What it does
 
@@ -15,7 +15,7 @@ You search it with full-text keywords and semantic queries. Any MCP-compatible A
 
 ## Status
 
-> **Phase 3 is complete, and the first vault-sync slice is shipped.** The current release is `v0.9.7`: it preserves the current vault-sync surface, fixes the macOS release build, and keeps `airgapped` + `online` assets on one canonical `gbrain-<platform>-<channel>` contract.
+> **Phase 3 is complete, and the first vault-sync slice is shipped.** The current release is `v0.9.8`: it preserves the current vault-sync surface and fixes `gbrain serve` startup when legacy active collections still carry blank root paths.
 >
 > See [roadmap.md](roadmap.md) for the full delivery plan.
 
@@ -26,7 +26,7 @@ You search it with full-text keywords and semantic queries. Any MCP-compatible A
 | Method | Status |
 | ------ | ------ |
 | Build from source (`cargo build --release`) | ✅ Available now — airgapped default |
-| GitHub Release binary (macOS ARM/x86, Linux x86_64/ARM64) | ✅ Available — `v0.9.7` airgapped + online assets |
+| GitHub Release binary (macOS ARM/x86, Linux x86_64/ARM64) | ✅ Available — `v0.9.8` airgapped + online assets |
 | `npm install -g gbrain` | 🚧 Staged — online channel by default once published |
 | One-command curl installer | ✅ Available — airgapped by default; set `GBRAIN_CHANNEL=online` for online |
 

--- a/openspec/changes/vault-sync-engine/tasks.md
+++ b/openspec/changes/vault-sync-engine/tasks.md
@@ -125,6 +125,8 @@
 - [x] 6.1 Add `notify` crate (with `macos_fsevents` feature).
   > **Complete (watcher core slice):** Added `notify` with the real crate feature name `macos_fsevent` (singular; task wording used the conceptual plural) and wired it into the serve-only watcher path.
 - [x] 6.2 Per-collection watcher task: one `notify` recommended watcher per collection, events pushed into a bounded `tokio::mpsc` channel tagged with `CollectionId`.
+- [x] 6.2a `gbrain serve` normalizes any `state='active'` collection whose `root_path` is blank before watcher registration so invalid legacy rows do not crash startup.
+  > **Complete (Issue #81 repair):** serve now demotes blank-root active collections to `detached`, logs a WARN, and watcher selection keeps using `trim(root_path) != ''`. Regression coverage includes the collection-normalization seam plus a Unix watcher-selection proof.
 - [x] 6.3 Per-collection debounce buffer; default `GBRAIN_WATCH_DEBOUNCE_MS=1500` coalesces Obsidian bulk saves.
 - [x] 6.4 Batch processor drains the debounce buffer, runs stat-diff, commits updates.
 - [ ] 6.5 Create/Modify handler: re-ingest bytes; never self-write UUID on observed external edits.

--- a/openspec/changes/watcher-empty-root-hotfix/proposal.md
+++ b/openspec/changes/watcher-empty-root-hotfix/proposal.md
@@ -1,0 +1,51 @@
+# Watcher Empty-Root Hotfix
+
+**Status:** complete  
+**Issue:** #81 (beta feedback — watcher crash on empty root_path)  
+**Branch:** fry/issue-81-empty-root-watcher  
+**Lane:** hotfix — no new capability, pure correctness fix
+
+## Problem
+
+`gbrain serve` crashes with `InvariantViolationError: failed to watch root` when any
+collection is in `state='active'` with an empty `root_path`.
+
+Root cause: `ensure_default_collection` in `db.rs` inserts the default collection with
+`state='active'` and `root_path=''`. On first `gbrain init`, before the user runs
+`collection add`, this is the initial state of the brain. `sync_collection_watchers`
+queries all `state='active'` collections and calls `watcher.watch("")`, which fails.
+
+This is an invariant violation in the schema: the codebase uses
+`CASE WHEN root_path = '' THEN 'detached' ELSE 'active' END` in three places to
+maintain this invariant, but the bootstrap insert violated it.
+
+## Fix
+
+Three changes:
+
+1. **`src/core/db.rs`** — `ensure_default_collection` now inserts with `state='detached'`
+   instead of `state='active'` when `root_path=''`. This is correct because a collection
+   with no root path is by definition detached (not watching anything).
+
+2. **`src/core/vault_sync.rs`** — `detach_active_collections_with_empty_root_path()` now
+   demotes any legacy `state='active' AND trim(root_path) = ''` rows to `detached`
+   before watcher registration. This repairs already-initialized brains without a
+   migration and makes the behavior explicit in logs.
+
+3. **`src/core/vault_sync.rs`** — `sync_collection_watchers` SQL adds
+   `AND trim(root_path) != ''` as a defensive guard so watcher selection itself
+   stays fail-closed even if another invalid row appears.
+
+## Non-goals
+
+- No schema migration required (the guard handles the old bad state in existing DBs).
+- No change to the `default` collection's role as the catch-all for legacy pages.
+- No change to the vault-sync-engine change scope — this is a bootstrap bug, not a
+  watcher-core behavioral gap.
+
+## Test
+
+- `detach_active_collections_with_empty_root_path_normalizes_default_collection`
+  in `src/core/vault_sync.rs`
+- `sync_collection_watchers_skips_active_collection_with_empty_root_path` in
+  `src/core/vault_sync.rs` (unix-only, matches the unix gate on the watcher)

--- a/packages/gbrain-npm/package.json
+++ b/packages/gbrain-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gbrain",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "GigaBrain personal knowledge brain CLI (online BGE-small channel)",
   "bin": {
     "gbrain": "bin/gbrain"

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -339,7 +339,7 @@ fn ensure_default_collection(conn: &Connection) -> Result<(), DbError> {
     conn.execute_batch(
         "INSERT OR IGNORE INTO collections \
              (id, name, root_path, state, writable, is_write_target) \
-         VALUES (1, 'default', '', 'active', 1, 1);",
+         VALUES (1, 'default', '', 'detached', 1, 1);",
     )?;
     Ok(())
 }

--- a/src/core/inference.rs
+++ b/src/core/inference.rs
@@ -638,7 +638,7 @@ fn download_model_files(model: &ModelConfig) -> Result<(PathBuf, PathBuf, PathBu
 
     let client = reqwest::blocking::Client::builder()
         .timeout(std::time::Duration::from_secs(300))
-        .user_agent("gigabrain-runtime/0.9.7")
+        .user_agent("gigabrain-runtime/0.9.8")
         .build()
         .map_err(|e| format!("build download client: {e}"))?;
 

--- a/src/core/vault_sync.rs
+++ b/src/core/vault_sync.rs
@@ -2072,11 +2072,12 @@ fn sync_collection_watchers(
     db_path: &str,
     watchers: &mut HashMap<i64, CollectionWatcherState>,
 ) -> Result<(), VaultSyncError> {
+    let _ = detach_active_collections_with_empty_root_path(conn)?;
     let mut active = HashMap::new();
     let mut stmt = conn.prepare(
         "SELECT id, root_path, reload_generation
          FROM collections
-         WHERE state = 'active'",
+         WHERE state = 'active' AND trim(root_path) != ''",
     )?;
     let rows = stmt
         .query_map([], |row| {
@@ -2106,6 +2107,41 @@ fn sync_collection_watchers(
         watchers.insert(collection_id, state);
     }
     Ok(())
+}
+
+#[cfg(any(test, unix))]
+fn detach_active_collections_with_empty_root_path(
+    conn: &Connection,
+) -> Result<Vec<i64>, VaultSyncError> {
+    let mut stmt = conn.prepare(
+        "SELECT id, name
+         FROM collections
+         WHERE state = 'active' AND trim(root_path) = ''",
+    )?;
+    let collections = stmt
+        .query_map([], |row| {
+            Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+    if !collections.is_empty() {
+        conn.execute(
+            "UPDATE collections
+             SET state = 'detached',
+                  updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+              WHERE state = 'active' AND trim(root_path) = ''",
+            [],
+        )?;
+        for (collection_id, name) in &collections {
+            eprintln!(
+                "WARN: serve_detached_empty_root collection={} collection_id={}",
+                name, collection_id
+            );
+        }
+    }
+    Ok(collections
+        .into_iter()
+        .map(|(collection_id, _)| collection_id)
+        .collect())
 }
 
 #[cfg(unix)]
@@ -4622,6 +4658,10 @@ mod tests {
         let snippet = &source[start..end];
 
         assert!(
+            snippet.contains("detach_active_collections_with_empty_root_path(conn)?;"),
+            "watcher sync must normalize empty root paths before watching: {snippet}"
+        );
+        assert!(
             snippet.contains("WHERE state = 'active'"),
             "watcher sync must only enumerate active collections: {snippet}"
         );
@@ -4638,6 +4678,66 @@ mod tests {
             snippet.contains("state.generation = generation;"),
             "replacement watchers must inherit the new reload_generation: {snippet}"
         );
+    }
+
+    #[test]
+    fn detach_active_collections_with_empty_root_path_normalizes_default_collection() {
+        let (_dir, _db_path, conn) = open_test_db_file();
+        let root = tempfile::TempDir::new().unwrap();
+        let work_id = insert_collection(&conn, "work", root.path());
+        conn.execute(
+            "UPDATE collections SET state = 'active', root_path = '' WHERE id = 1",
+            [],
+        )
+        .unwrap();
+
+        let detached = detach_active_collections_with_empty_root_path(&conn).unwrap();
+        assert_eq!(detached, vec![1]);
+
+        let active_ids = conn
+            .prepare("SELECT id FROM collections WHERE state = 'active' ORDER BY id")
+            .unwrap()
+            .query_map([], |row| row.get::<_, i64>(0))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(active_ids, vec![work_id]);
+
+        let default_state: String = conn
+            .query_row("SELECT state FROM collections WHERE id = 1", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(default_state, "detached");
+    }
+
+    /// Regression test for issue #81.
+    ///
+    /// `gbrain serve` must not attempt to watch an empty collection root.
+    #[cfg(unix)]
+    #[test]
+    fn sync_collection_watchers_skips_active_collection_with_empty_root_path() {
+        let (_dir, db_path, conn) = open_test_db_file();
+        let root = tempfile::TempDir::new().unwrap();
+        let work_id = insert_collection(&conn, "work", root.path());
+        conn.execute(
+            "UPDATE collections SET state = 'active', root_path = '' WHERE id = 1",
+            [],
+        )
+        .unwrap();
+
+        let mut watchers = HashMap::new();
+        sync_collection_watchers(&conn, &db_path, &mut watchers).unwrap();
+
+        assert!(watchers.contains_key(&work_id));
+        assert!(!watchers.contains_key(&1));
+
+        let default_state: String = conn
+            .query_row("SELECT state FROM collections WHERE id = 1", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(default_state, "detached");
     }
 
     #[test]

--- a/website/src/content/docs/guides/install.mdx
+++ b/website/src/content/docs/guides/install.mdx
@@ -116,7 +116,7 @@ cross build --release --target aarch64-unknown-linux-musl`}
 
 <CodePanel
   label={"GitHub Releases"}
-  code={`VERSION='v0.9.7'
+  code={`VERSION='v0.9.8'
 PLATFORM='linux-x86_64'   # linux-x86_64 | linux-aarch64 | darwin-arm64 | darwin-x86_64
 ASSET='gbrain-\${PLATFORM}-airgapped'   # or: gbrain-\${PLATFORM}-online
 curl -fsSL 'https://github.com/macro88/gigabrain/releases/download/\${VERSION}/\${ASSET}' -o '\${ASSET}'
@@ -150,13 +150,13 @@ sudo install -m 755 '\${ASSET}' /usr/local/bin/gbrain`}
   code={`curl -fsSL https://raw.githubusercontent.com/macro88/gigabrain/main/scripts/install.sh | sh
 
 curl -fsSL https://raw.githubusercontent.com/macro88/gigabrain/main/scripts/install.sh \
- | GBRAIN_VERSION=v0.9.7 sh
+ | GBRAIN_VERSION=v0.9.8 sh
 
 curl -fsSL https://raw.githubusercontent.com/macro88/gigabrain/main/scripts/install.sh \
- | GBRAIN_VERSION=v0.9.7 GBRAIN_CHANNEL=online sh
+ | GBRAIN_VERSION=v0.9.8 GBRAIN_CHANNEL=online sh
 
 curl -fsSL https://raw.githubusercontent.com/macro88/gigabrain/main/scripts/install.sh \
- | GBRAIN_VERSION=v0.9.7 GBRAIN_INSTALL_DIR="$HOME/.local/bin" sh`}
+ | GBRAIN_VERSION=v0.9.8 GBRAIN_INSTALL_DIR="$HOME/.local/bin" sh`}
 />
 
 <div class="gb-guide-note">


### PR DESCRIPTION
## Summary
- normalize active collections with blank root paths to detached before watcher registration
- add regression coverage for the normalization seam and watcher-selection invariant
- prepare the release surfaces for `v0.9.8` and rewrite the release workflow body for the Issue #81 hotfix lane

## Testing
- cargo metadata --format-version 1 --no-deps
- node -e "JSON.parse(require('fs').readFileSync('packages\\gbrain-npm\\package.json','utf8'))"
- cargo test detach_active_collections_with_empty_root_path_normalizes_default_collection --lib
- cargo test sync_collection_watchers_production_logic_stays_active_only_and_generation_aware --lib
- cargo test vault_sync --lib

Closes #81