### PR TITLE
fix: 404s on quaid.app + README rewrite

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,6 +25,8 @@ jobs:
           node-version: "22"
       - run: cd website && npm ci --no-audit --no-fund
       - run: cd website && npm run build
+        env:
+          CUSTOM_DOMAIN: quaid.app
       - if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v3
         with:

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -5,10 +5,13 @@ import starlight from "@astrojs/starlight";
 const repo = process.env.GITHUB_REPOSITORY?.split("/")?.[1] ?? "quaid";
 const owner = process.env.GITHUB_REPOSITORY_OWNER ?? "quaid-app";
 const isGitHubActions = process.env.GITHUB_ACTIONS === "true";
+const customDomain = process.env.CUSTOM_DOMAIN ?? "quaid.app";
 
 export default defineConfig({
-  site: isGitHubActions ? `https://${owner}.github.io` : undefined,
-  base: isGitHubActions ? `/${repo}` : "/",
+  site: isGitHubActions
+    ? (customDomain ? `https://${customDomain}` : `https://${owner}.github.io`)
+    : undefined,
+  base: isGitHubActions && !customDomain ? `/${repo}` : "/",
   trailingSlash: "always",
   integrations: [
     starlight({

--- a/website/public/CNAME
+++ b/website/public/CNAME
@@ -1,0 +1,1 @@
+quaid.app


### PR DESCRIPTION
Two related improvements in one PR:

## 1. Fix 404s on quaid.app custom domain

**Bug:** All CSS/JS assets returning 404 on quaid.app

**Root cause:** Astro was building with `base='/quaid'` (GitHub Pages subdirectory path). When served at `quaid.app` (root `/`), assets at `/quaid/_astro/...` all 404.

**Fixes:**
- `website/public/CNAME` — adds `quaid.app` so GitHub Pages preserves custom domain between deploys (was missing)
- `astro.config.mjs` — use `base='/'` and `site='https://quaid.app'` when `CUSTOM_DOMAIN` is set
- `.github/workflows/docs.yml` — set `CUSTOM_DOMAIN=quaid.app` in build step

## 2. README.md rewrite (dev-marketing structure)

Applied devmarketing-skills framework to the main repo README:
- Hero statement + value prop
- Badges: CI, release, DAB score (193/215 90%), license  
- Quick start in <5 lines (install → init → add collection → embed → search)
- MCP setup section prominent (primary use case for most users)
- Why Quaid? with concrete differentiators
- Benchmark table linking to quaid-evals live results
- 52% shorter than original (8,900 vs 18,000 chars) — all essential info kept