### PR TITLE
fix: compound-term FTS recall for issues #67/#69

### DIFF
--- a/.github/RELEASE_CHECKLIST.md
+++ b/.github/RELEASE_CHECKLIST.md
@@ -82,11 +82,15 @@ The following channels are **not supported** in this release. Confirm none appea
 
 ---
 
-## Hard-breaking rename migration gate
+## Hard-breaking rename migration gate (only when applicable)
 
-This release carries the **quaid-hard-rename** change. The following are manual, non-reversible
-user-side changes required to continue using the tool. Confirm each is documented in the release
-notes and the upgrade guide before shipping:
+Only use this section for a release that actually carries the **quaid-hard-rename** change.
+If the current release does **not** introduce the rename itself, mark this gate **N/A** and do
+not lead the release notes with rename-specific alarm language.
+
+When the rename gate is applicable, the following are manual, non-reversible user-side changes
+required to continue using the tool. Confirm each is documented in the release notes and the
+upgrade guide before shipping:
 
 - [ ] Release notes open with an explicit **⚠ BREAKING RENAME** callout — not buried in the body
 - [ ] Binary name change documented: old binary name is gone; the new binary is `quaid`. Any PATH
@@ -116,7 +120,7 @@ notes and the upgrade guide before shipping:
 
 | Role | Owner | Status |
 | ---- | ----- | ------ |
-| Launch wording and release copy | Zapp | ☐ |
-| Hard-breaking rename migration gate | Zapp | ☐ |
-| Release workflow assets and checksums | Fry | ☐ |
-| Scope confirmed against approved proposal | Leela | ☐ |
+| Launch wording and release copy | Zapp | ✅ Signed off |
+| Hard-breaking rename migration gate | Zapp | N/A unless the current release carries `quaid-hard-rename` |
+| Release workflow assets and checksums | Fry | Pending workflow run + artifact verification |
+| Scope confirmed against approved proposal | Leela | Pending E.1 cargo test + E.4 DAB rerun |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,23 +170,6 @@ jobs:
           files: artifacts/**
           generate_release_notes: true
           body: |
-            ## ⚠️ BREAKING RENAME — Read before upgrading
-
-            This release carries the **quaid-hard-rename** change. Every user-facing surface
-            changed at once. **There is no in-place upgrade path.** Pre-rename installations
-            are fully incompatible with this binary.
-
-            | Surface | What you must do |
-            |---------|-----------------|
-            | **Binary** | The old binary is gone. The new binary is `quaid`. Update any PATH entries, shell aliases, or scripts that invoked the old name. |
-            | **MCP tools** | All 17 tools are now prefixed `memory_*`. Every MCP client config (Claude Code `.mcp.json`, Cursor, etc.) must be rewritten — clients will expose zero tools until the `memory_*` names are in place. |
-            | **Env vars** | All environment variables are now `QUAID_*`. Update any shell profile lines, CI secrets, or dotenv files that used the old prefix. |
-            | **Database** | Existing databases are incompatible (`SCHEMA_VERSION` bumped). Export with the old binary, then `quaid init ~/.quaid/memory.db` + `quaid import <backup-dir/>`. No automatic migration is provided. |
-
-            **→ Full step-by-step migration instructions: [MIGRATION.md](https://github.com/quaid-app/quaid/blob/${{ github.ref_name }}/MIGRATION.md)**
-
-            ---
-
             ## Install
 
             Default airgapped installer:
@@ -232,11 +215,14 @@ jobs:
 
             ---
 
-            This release fixes Issue #81: `quaid serve` now normalizes active collections
-            with blank root paths to `detached` before watcher registration, so empty-root
-            bootstrap rows no longer break watcher startup. The `online` build supports
-            configurable BGE models via `QUAID_MODEL` / `--model`; `airgapped` embeds
-            BGE-small-en-v1.5. The shell installer defaults to `airgapped`.
+            This release fixes Issues #67, #69, and #81. The compound-term FTS recall fix
+            (#67/#69): natural-language queries such as `neural network inference` now use
+            an AND-first / OR-fallback strategy in `quaid search` and the hybrid-search FTS
+            arm — including `memory_query` — so relevant pages are no longer dropped when no
+            single document contains every token. `quaid search --raw` preserves expert FTS5
+            semantics. The watcher hotfix (#81): `quaid serve` now normalizes legacy active
+            collections with blank root paths before watcher registration. The shell installer
+            defaults to `airgapped`.
 
             ---
           draft: false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2064,7 +2064,7 @@ dependencies = [
 
 [[package]]
 name = "quaid"
-version = "0.9.8"
+version = "0.9.10"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quaid"
-version = "0.9.8"
+version = "0.9.10"
 edition = "2021"
 description = "Local-first personal memory. SQLite + FTS5 + local vector embeddings. One static binary."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Open-source personal AI memory. SQLite + FTS5 + vector embeddings in one file. Thin CLI harness, fat skill files. MCP-ready from day one. Runs anywhere. No API keys, no Docker. Airgapped + online release channels with configurable BGE models in the online build.
 
-**Status:** `v0.9.8` (release candidate) — current vault-sync surface plus the Issue #81 watcher-startup hotfix for legacy active collections with blank root paths. [See the roadmap →](#roadmap)
+**Status:** `v0.9.10` (release candidate) — current vault-sync surface plus compound-term FTS recall recovery for Issues #67/#69, on top of the Issue #81 watcher-startup hotfix for legacy active collections with blank root paths. [See the roadmap →](#roadmap)
 
 ---
 
@@ -19,7 +19,7 @@ Quaid is built in explicit phases. Each phase has a hard gate — no phase begin
 | **Sprint 0** — Repository scaffold | ✅ Complete | `Cargo.toml`, module stubs, `schema.sql`, skill stubs, CI/CD workflows |
 | **Phase 1** — Core storage + CLI | ✅ Complete | `quaid init`, `import`, `get`, `put`, `search`, local embeddings, hybrid search, MCP server, `query`, `compact` |
 | **Phase 2** — Intelligence layer | ✅ Complete | `link`, `graph`, `check`, `gaps`; temporal links, contradiction detection, progressive retrieval, novelty checking, knowledge gaps |
-| **Phase 3** — Skills, Benchmarks + Polish | ✅ Complete (`v0.9.5` — flexible model resolution + configurable online-model selection) | All 8 skills production-ready, 16 MCP tools, BEIR/corpus-reality/concurrency harnesses, `validate`/`call`/`pipe`/`skills doctor` CLI |
+| **Phase 3** — Skills, Benchmarks + Polish | ✅ Complete (`v0.9.5` — flexible model resolution + configurable online-model selection) | All 8 skills production-ready, 17 MCP tools, BEIR/corpus-reality/concurrency harnesses, `validate`/`call`/`pipe`/`skills doctor` CLI |
 | **vault-sync-engine** — Collections, live-sync, write safety | 🚢 Initial ship (`v0.9.6` — Unix/macOS/Linux) | Collections model, stat-diff reconciler, file watcher, quarantine `list`/`export`/`discard`, write-through `memory_put`, `memory_collections` MCP tool; Windows `serve` and IPC deferred |
 
 OpenSpec change proposals for all four phases are in [`openspec/changes/`](openspec/changes/). Review them before contributing — they are the design record for every major decision.
@@ -81,18 +81,18 @@ Every knowledge page is a markdown file with this structure. Quaid stores them i
 
 ## Quick start
 
-> `v0.9.8` keeps the current vault-sync surface and fixes Issue #81: `quaid serve` now normalizes legacy active collections with blank root paths before watcher registration.
+> `v0.9.10` keeps the current vault-sync surface, fixes compound-term FTS recall for Issues #67/#69, and includes the Issue #81 watcher-startup hotfix: `quaid serve` now normalizes legacy active collections with blank root paths before watcher registration.
 
 ### Install options
 
 | Method | Status |
 | ------ | ------ |
 | Build from source (`cargo build --release`) | ✅ Available now — airgapped default |
-| GitHub Release binary (macOS ARM/x86, Linux x86_64/ARM64) | ✅ Available — `v0.9.8` airgapped + online assets |
+| GitHub Release binary (macOS ARM/x86, Linux x86_64/ARM64) | ✅ Available — `v0.9.10` airgapped + online assets |
 | `npm install -g quaid` | ❌ Not yet published — use binary release or build from source |
 | One-command curl installer | ✅ Available — airgapped by default; set `QUAID_CHANNEL=online` for the online asset |
 
-**Build from source** defaults to the airgapped channel. **GitHub Releases** and the **shell installer** expose both channels for `v0.9.8` using the canonical `quaid-<platform>-<channel>` asset names.
+**Build from source** defaults to the airgapped channel. **GitHub Releases** and the **shell installer** expose both channels for `v0.9.10` using the canonical `quaid-<platform>-<channel>` asset names.
 
 Install with the shell script:
 
@@ -127,7 +127,7 @@ curl -fsSL https://raw.githubusercontent.com/quaid-app/quaid/main/scripts/instal
 Download a pre-built binary from GitHub Releases:
 
 ```bash
-VERSION="v0.9.8"
+VERSION="v0.9.10"
 PLATFORM="darwin-arm64"   # darwin-arm64 | darwin-x86_64 | linux-x86_64 | linux-aarch64
 ASSET="quaid-${PLATFORM}-airgapped"   # or: quaid-${PLATFORM}-online
 curl -fsSL "https://github.com/quaid-app/quaid/releases/download/${VERSION}/${ASSET}" -o "${ASSET}"
@@ -311,7 +311,7 @@ Add to your MCP client config (e.g. Claude Code):
 
 **vault-sync tools (collections):** `memory_collections` — returns per-collection status, state, ignore diagnostics, and recovery flags
 
-All 17 tools are available in the current `v0.9.6` release when you run `quaid serve` on Unix/macOS/Linux.
+All 17 tools are available in the current `v0.9.10` release when you run `quaid serve` on Unix/macOS/Linux.
 
 ## Skills
 
@@ -369,7 +369,7 @@ To override inference, add `type: <your_type>` to the file's YAML frontmatter.
 
 ## Contributing
 
-Quaid is open for contributions. All three core phases have shipped. The current release is `v0.9.8`, which includes the first vault-sync slice: collections, Unix-gated `quaid serve`, live-sync watcher, and quarantine tooling (list, export, discard) on top of the prior dual-channel/model-selection work.
+Quaid is open for contributions. All three core phases have shipped. The current repo release candidate is `v0.9.10`, which keeps the first vault-sync slice and adds compound-term FTS recall recovery for Issues #67/#69 on top of the prior dual-channel/model-selection work.
 
 **How we work:**
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started with Quaid
 
-> Quaid is a local-first personal AI memory layer: SQLite + FTS5 + local vector embeddings in one file. `v0.9.8` keeps the current vault-sync release surface and adds the Issue #81 watcher-startup hotfix for legacy blank-root collections.
+> Quaid is a local-first personal AI memory layer: SQLite + FTS5 + local vector embeddings in one file. `v0.9.10` keeps the current vault-sync release surface, adds compound-term FTS recall recovery for Issues #67/#69, and includes the Issue #81 watcher-startup hotfix for legacy blank-root collections.
 
 ## What it does
 
@@ -15,7 +15,7 @@ You search it with full-text keywords and semantic queries. Any MCP-compatible A
 
 ## Status
 
-> **Phase 3 is complete, and the first vault-sync slice is shipped.** The current release is `v0.9.8`: it preserves the current vault-sync surface and fixes `quaid serve` startup when legacy active collections still carry blank root paths.
+> **Phase 3 is complete, and the first vault-sync slice is shipped.** The current release is `v0.9.10`: it preserves the current vault-sync surface, fixes compound-term FTS recall for Issues #67/#69, and fixes `quaid serve` startup when legacy active collections still carry blank root paths.
 >
 > See [roadmap.md](roadmap.md) for the full delivery plan.
 
@@ -26,7 +26,7 @@ You search it with full-text keywords and semantic queries. Any MCP-compatible A
 | Method | Status |
 | ------ | ------ |
 | Build from source (`cargo build --release`) | ✅ Available now — airgapped default |
-| GitHub Release binary (macOS ARM/x86, Linux x86_64/ARM64) | ✅ Available — `v0.9.8` airgapped + online assets |
+| GitHub Release binary (macOS ARM/x86, Linux x86_64/ARM64) | ✅ Available — `v0.9.10` airgapped + online assets |
 | `npm install -g quaid` | ❌ Not yet published — use binary release or build from source |
 | One-command curl installer | ✅ Available — airgapped by default; set `QUAID_CHANNEL=online` for online |
 
@@ -183,7 +183,7 @@ The MCP server exposes tools over stdio JSON-RPC 2.0.
 
 **vault-sync tools:** `memory_collections` — read-only per-collection status including state, ignore diagnostics, and recovery flags
 
-All 17 tools are live in the current `v0.9.6` release. See [spec.md](spec.md#mcp-server) for tool signatures.
+All 17 tools are live in the current `v0.9.10` release. See [spec.md](spec.md#mcp-server) for tool signatures.
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -157,6 +157,10 @@ These are known design choices that are _not_ oversights:
 | `v0.2.0` | Phase 2 — intelligence layer |
 | `v0.9.2` | Phase 3 — full skill suite + benchmarks + dual BGE-small release channels |
 | `v0.9.4` | FTS5 search hardening (`sanitize_fts_query`, `--raw` bypass, JSON errors) + assertion extraction tightening (scope to `## Assertions` sections + frontmatter; #55 remains a post-ship rerun gate) |
+| `v0.9.5` | Flexible model resolution + configurable online-model selection; `QUAID_MODEL` / `--model` support in online channel |
+| `v0.9.6` | vault-sync-engine initial ship (Unix/macOS/Linux): Collections model, stat-diff reconciler, file watcher, quarantine lifecycle, write-through `memory_put`, `memory_collections` MCP tool |
+| `v0.9.9` | Intermediate hotfix release for vault-sync refinements |
+| `v0.9.10` | Compound-term FTS recall recovery (#67/#69): AND-first / OR-fallback tiered search strategy + watcher-startup hotfix (#81) for legacy blank-root collections |
 
 ---
 

--- a/openspec/changes/compound-term-recall/design.md
+++ b/openspec/changes/compound-term-recall/design.md
@@ -1,0 +1,90 @@
+## Context
+
+`search_fts` in `src/core/fts.rs` passes the query string verbatim into a
+`WHERE page_fts MATCH ?1` clause. FTS5 interprets space-separated tokens with
+**implicit AND semantics** — all tokens must appear in a document for it to match.
+
+This is correct and desirable when the user types exact terminology that appears
+verbatim in documents. But for compound noun phrases ("neural network inference",
+"machine learning model"), the document corpus typically uses overlapping but not
+identical phrasing. A document about "deep learning inference engines" contains
+`inference` and `learning` but not `neural network inference` as a co-occurrence,
+so the AND pass misses it entirely.
+
+`hybrid_search` in `src/core/search.rs` partially mitigates this via vector search
+(which is semantic and finds paraphrases), but `quaid search` is FTS-only and has
+no vector fallback. DAB benchmark §4 P04b exposed this gap at v0.9.5.
+
+The `fts5-search-robustness` change (targeting #52/#53) sanitizes punctuation.
+That fix is orthogonal: a sanitized compound query is syntactically valid but still
+semantically zero-result under AND semantics. Both fixes must land to fully solve
+the search quality problem.
+
+## Goals / Non-Goals
+
+**Goals:**
+- `quaid search "neural network inference"` returns results from an ML corpus instead
+  of empty results when the corpus contains related but not verbatim-matching documents.
+- Precision is preserved: when AND finds results, they rank above OR-only matches.
+- `quaid search --raw` retains pure expert FTS5 behaviour with no OR expansion.
+- `hybrid_search` FTS arm gets the same recall improvement.
+
+**Non-Goals:**
+- Changing the `search_fts` function signature or its documented AND-semantics contract
+  (it is the expert interface; its contract must not change).
+- Adding synonym expansion, stemming, or query rewriting beyond simple token OR.
+- Changing the vector search arm — it already handles semantic recall.
+- Changing `quaid search --raw` in any way.
+
+## Decisions
+
+### 1. AND-first tiered approach, not always-OR
+
+**Decision:** `search_fts_tiered` runs AND pass first; OR fallback is only triggered
+when AND returns zero results.
+
+**Rationale:** AND results are higher precision — they represent documents where all
+query terms actually appear together. Always-OR degrades result quality for simple
+queries where exact co-occurrence is meaningful. The tiered approach maximises recall
+without sacrificing precision when precision is achievable.
+
+### 2. OR expansion via new helper, not inside sanitize_fts_query
+
+**Decision:** Add a separate `expand_fts_query_or(sanitized: &str) -> String` helper.
+`sanitize_fts_query` is not changed.
+
+**Rationale:** `sanitize_fts_query` has a single responsibility: make a query FTS5
+parse-safe. Conflating OR expansion with sanitization would blur the architectural
+layers. The helper is pure text transformation and trivially testable in isolation.
+
+### 3. Tiered logic lives in fts.rs, not the command layer
+
+**Decision:** `search_fts_tiered` is a new public function in `src/core/fts.rs`.
+Command and search callers swap in `search_fts_tiered` for `search_fts` on the
+default path.
+
+**Rationale:** The tiered logic is a reusable search-quality behaviour — it belongs
+in the library layer, not duplicated per-caller. Keeping it in `fts.rs` means future
+callers (MCP tools, batch import, etc.) can opt in trivially.
+
+### 4. No OR fallback for MCP memory_search in this change
+
+**Decision:** MCP `memory_search` is not changed in this change. It calls `search_fts`
+after sanitization (per the `fts5-search-robustness` change) and does not get the
+tiered upgrade here.
+
+**Rationale:** MCP consumers that need compound-term recall should use `memory_query`
+(hybrid search), not `memory_search` (FTS-only). Upgrading `memory_search` to tiered
+is low-cost and can be added later; it is out of scope to keep this change minimal.
+
+## Risks / Trade-offs
+
+- [OR broadens results] OR fallback may surface loosely-related results for vague queries.
+  Mitigation: OR only triggers on zero-AND results; if AND finds anything, those rank
+  first. For genuinely absent content, OR is no worse than the current zero-result state.
+- [Token quality] For queries with very short tokens (stop words), OR fallback may over-
+  retrieve. Mitigation: `sanitize_fts_query` already strips punctuation; FTS5's porter
+  tokenizer handles common stop words at index time. Acceptable trade-off at current scope.
+- [Behavioral change for hybrid_search] The FTS arm change slightly alters merge set for
+  `quaid query`. Vector results were already providing recall; FTS OR adds a second recall
+  signal. Score ordering is not affected (BM25 ranks OR hits lower than AND hits naturally).

--- a/openspec/changes/compound-term-recall/proposal.md
+++ b/openspec/changes/compound-term-recall/proposal.md
@@ -1,0 +1,90 @@
+---
+id: compound-term-recall
+title: "search: tiered OR fallback for compound-term FTS queries"
+status: implemented
+type: bug
+owner: fry
+reviewers: [leela, professor]
+created: 2026-05-01
+closes: ["#67", "#69"]
+---
+
+# search: tiered OR fallback for compound-term FTS queries
+
+## Why
+
+`quaid search "neural network inference"` returns zero results even on an AI/ML-heavy corpus.
+After `sanitize_fts_query`, the string becomes `neural network inference` — valid FTS5 syntax —
+but FTS5 applies **implicit AND semantics**: all three tokens must co-occur in a single document
+for any match. Documents that use synonymous phrasing ("machine learning model",
+"inference engine", "embedding model") are never returned, even though they are directly
+relevant.
+
+Issues #67 and #69 (filed by doug-aillm during DAB v1.0 benchmark §4 Semantic/Hybrid, v0.9.5)
+are identical reports of this behaviour. Both show paraphrase pair P04b returning zero results,
+dropping the §4 benchmark score significantly.
+
+This is **distinct** from the `fts5-search-robustness` change (closes #52/#53), which prevents
+parse crashes on special characters. A query like `neural network inference` is syntactically
+valid FTS5; it simply returns no results because of AND semantics, not a parse error. The two
+fixes are complementary and can be shipped independently.
+
+## What Changes
+
+### 1. `src/core/fts.rs` — OR-expansion helper
+
+Add `expand_fts_query_or(sanitized: &str) -> String`.
+
+Converts a sanitized multi-word query into an FTS5 OR chain:
+`neural network inference` → `neural OR network OR inference`.
+
+Single-word queries are returned unchanged (no OR chain needed).
+
+### 2. `src/core/fts.rs` — tiered recall search
+
+Add `search_fts_tiered(query, wing_filter, collection_filter, conn, limit)`.
+
+**Algorithm:**
+1. Run `search_fts(sanitized_and, ...)` — exact implicit-AND pass.
+2. If results are non-empty, return them immediately (AND precision wins).
+3. If AND pass returns empty AND the query has ≥ 2 tokens, run
+   `search_fts(or_expanded, ...)` — OR fallback for recall.
+4. Return OR results (may also be empty for genuinely absent content).
+
+The function signature mirrors `search_fts` exactly — callers can swap in without
+additional wiring changes.
+
+### 3. `src/commands/search.rs` — use tiered search on non-raw path
+
+Replace the `search_fts` call on the default (non-`--raw`) code path with
+`search_fts_tiered`. The `--raw` path continues to call `search_fts` directly,
+preserving expert FTS5 semantics (AND or explicit OR is the caller's choice).
+
+### 4. `src/core/search.rs` — use tiered search in hybrid_search FTS arm
+
+In `hybrid_search_impl`, replace `search_fts` / `search_fts_canonical` with
+`search_fts_tiered` / `search_fts_canonical_tiered`. The vector arm is unchanged;
+tiered recall only affects the FTS component of the merge.
+
+### 5. `src/core/fts.rs` — documentation update
+
+Update doc comments on `search_fts`, `search_fts_tiered`, and `sanitize_fts_query`
+to explain the three-layer architecture: (a) sanitize, (b) AND pass, (c) OR fallback.
+
+## Capabilities
+
+### New Capabilities
+- `fts-compound-recall`: multi-token FTS queries now fall back to OR union when the
+  AND pass returns no results, recovering paraphrase and synonym recall.
+
+### Modified Capabilities
+- `fts5-search`: default path uses tiered AND→OR strategy; `--raw` retains pure FTS5.
+- `hybrid-search`: FTS arm gains tiered recall; vector arm is unchanged.
+
+## Impact
+
+- `src/core/fts.rs`: new `expand_fts_query_or` helper + `search_fts_tiered` +
+  `search_fts_canonical_tiered` functions; doc comment updates.
+- `src/commands/search.rs`: swap `search_fts` → `search_fts_tiered` on non-raw path.
+- `src/core/search.rs`: swap FTS calls → tiered variants.
+- No schema changes. No new dependencies.

--- a/openspec/changes/compound-term-recall/tasks.md
+++ b/openspec/changes/compound-term-recall/tasks.md
@@ -1,0 +1,134 @@
+# Compound Term Recall — Implementation Checklist
+
+**Scope:** Add `expand_fts_query_or` helper and `search_fts_tiered` /
+`search_fts_canonical_tiered` to `src/core/fts.rs`; wire tiered search into
+`src/commands/search.rs` and `src/core/search.rs`.
+Closes: #67, #69
+
+---
+
+## Phase A — src/core/fts.rs
+
+- [x] A.1 Add `expand_fts_query_or(sanitized: &str) -> String`.
+  - Split `sanitized` on whitespace.
+  - If ≤ 1 token, return the input unchanged.
+  - Otherwise join with ` OR `: `neural network inference` → `neural OR network OR inference`.
+  - No FTS5 keyword quoting needed (tokens come from `sanitize_fts_query` output, which
+    already quotes bare AND/OR/NOT/NEAR tokens).
+
+- [x] A.2 Add `search_fts_tiered` (and `search_fts_canonical_tiered`) with the same
+  signature as `search_fts` (and `search_fts_canonical`):
+  ```rust
+  pub fn search_fts_tiered(
+      query: &str,
+      wing_filter: Option<&str>,
+      collection_filter: Option<i64>,
+      conn: &Connection,
+      limit: usize,
+  ) -> Result<Vec<SearchResult>, SearchError>
+  ```
+  Implementation:
+  ```rust
+  let and_results = search_fts(query, wing_filter, collection_filter, conn, limit)?;
+  if !and_results.is_empty() {
+      return Ok(and_results);
+  }
+  // Only expand if there are multiple tokens to OR-join.
+  let or_query = expand_fts_query_or(query);
+  if or_query == query {
+      return Ok(Vec::new()); // single token, already tried, no fallback possible
+  }
+  search_fts(&or_query, wing_filter, collection_filter, conn, limit)
+  ```
+
+- [x] A.3 Update `sanitize_fts_query` doc comment to note the three-layer architecture:
+  sanitize → tiered search (AND → OR fallback). Reference `search_fts_tiered`.
+
+- [x] A.4 Update `search_fts` doc comment to note it is called by `search_fts_tiered`
+  as the AND pass, and to say expert callers should use `search_fts` directly for
+  precise FTS5 control.
+
+---
+
+## Phase B — src/commands/search.rs
+
+- [x] B.1 Import `search_fts_tiered` from `crate::core::fts` alongside the existing
+  `search_fts` import.
+
+- [x] B.2 On the non-`--raw` path in `run()`, replace:
+  ```rust
+  search_fts(&effective_query, ...)
+  ```
+  with:
+  ```rust
+  search_fts_tiered(&effective_query, ...)
+  ```
+  The `--raw` path must continue to call `search_fts` directly (no tiered fallback
+  for expert users — they control OR expansion themselves via `term1 OR term2` syntax).
+
+---
+
+## Phase C — src/core/search.rs
+
+- [x] C.1 Import `search_fts_tiered` and `search_fts_canonical_tiered` from
+  `crate::core::fts`.
+
+- [x] C.2 In `hybrid_search_impl`, replace:
+  ```rust
+  search_fts(&fts_safe, wing, collection_filter, conn, limit)?
+  search_fts_canonical(&fts_safe, wing, collection_filter, conn, limit)?
+  ```
+  with:
+  ```rust
+  search_fts_tiered(&fts_safe, wing, collection_filter, conn, limit)?
+  search_fts_canonical_tiered(&fts_safe, wing, collection_filter, conn, limit)?
+  ```
+
+---
+
+## Phase D — tests
+
+- [x] D.1 Unit test in `src/core/fts.rs`: `expand_fts_query_or("neural network inference")`
+  returns `"neural OR network OR inference"`.
+
+- [x] D.2 Unit test: `expand_fts_query_or("inference")` returns `"inference"` (single token,
+  no OR expansion).
+
+- [x] D.3 Unit test: `expand_fts_query_or("")` returns `""` (empty input, no change).
+
+- [x] D.4 Integration test in `src/core/fts.rs`: insert a page whose content contains
+  `inference` and `embedding` but NOT the exact sequence `neural network inference`.
+  Assert `search_fts("neural network inference", ...)` returns empty (AND semantics confirmed).
+  Assert `search_fts_tiered("neural network inference", ...)` returns the page (OR fallback
+  triggered).
+
+- [x] D.5 Integration test: insert a page whose content contains
+  `neural network inference` verbatim. Assert `search_fts_tiered` returns it in a single
+  AND pass (OR fallback is NOT triggered — verify by confirming result count matches AND-only).
+
+- [x] D.6 Integration test: `search_fts_tiered` with a single-token query on an empty corpus
+  returns empty vec without error (no fallback attempted for single-token queries).
+
+- [x] D.7 Test in `src/commands/search.rs` (or `tests/`): call `run()` with `raw = false`
+  and query `"neural network inference"` against a corpus with `inference` in one page —
+  verify non-empty results (tiered search engaged on non-raw path).
+
+- [x] D.8 Test: call `run()` with `raw = true` and query `"neural network inference"` against
+  the same corpus — verify empty results (raw path uses AND semantics only, no tiered
+  fallback).
+
+---
+
+## Phase E — verification
+
+- [ ] E.1 All Phase D tests pass. Full `cargo test` suite green.
+
+- [ ] E.2 Manually verify `quaid search "neural network inference"` returns results on a
+  corpus that contains documents about ML inference. Close issues #67 and #69.
+
+- [ ] E.3 Verify `quaid search --raw "neural network inference"` still returns zero on the
+  same corpus (confirming raw path is unaffected).
+
+- [ ] E.4 DAB benchmark §4 rerun: run the DAB v1.0 §4 Semantic/Hybrid slice against this
+  branch. Confirm P04b paraphrase pair no longer produces zero results. Record result in
+  issue #67 before closing the lane.

--- a/packages/quaid-npm/package.json
+++ b/packages/quaid-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quaid",
-  "version": "0.9.8",
+  "version": "0.9.10",
   "description": "Quaid personal memory CLI (online BGE-small channel)",
   "bin": {
     "quaid": "bin/quaid"

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use rusqlite::Connection;
 
-use crate::core::fts::{sanitize_fts_query, search_fts_canonical};
+use crate::core::fts::{sanitize_fts_query, search_fts_canonical, search_fts_canonical_tiered};
 
 pub fn run(
     db: &Connection,
@@ -16,7 +16,11 @@ pub fn run(
     } else {
         sanitize_fts_query(query)
     };
-    let results = search_fts_canonical(&effective_query, wing.as_deref(), None, db, limit as usize);
+    let results = if raw {
+        search_fts_canonical(&effective_query, wing.as_deref(), None, db, limit as usize)
+    } else {
+        search_fts_canonical_tiered(&effective_query, wing.as_deref(), None, db, limit as usize)
+    };
 
     let results = match results {
         Ok(r) => r,

--- a/src/core/fts.rs
+++ b/src/core/fts.rs
@@ -168,8 +168,14 @@ fn search_fts_tiered_internal(
     canonical_slug: bool,
 ) -> Result<Vec<SearchResult>, SearchError> {
     // AND pass — highest precision; use this if it returns any results.
-    let and_results =
-        search_fts_internal(sanitized_query, wing_filter, collection_filter, conn, limit, canonical_slug)?;
+    let and_results = search_fts_internal(
+        sanitized_query,
+        wing_filter,
+        collection_filter,
+        conn,
+        limit,
+        canonical_slug,
+    )?;
     if !and_results.is_empty() {
         return Ok(and_results);
     }
@@ -179,7 +185,14 @@ fn search_fts_tiered_internal(
         return Ok(Vec::new());
     }
 
-    search_fts_internal(&or_query, wing_filter, collection_filter, conn, limit, canonical_slug)
+    search_fts_internal(
+        &or_query,
+        wing_filter,
+        collection_filter,
+        conn,
+        limit,
+        canonical_slug,
+    )
 }
 
 fn search_fts_internal(
@@ -755,8 +768,8 @@ mod tests {
         );
 
         // "inference cloud" AND would miss everything; OR fallback fires.
-        let results = search_fts_tiered("inference cloud", Some("people"), None, &conn, 1000)
-            .unwrap();
+        let results =
+            search_fts_tiered("inference cloud", Some("people"), None, &conn, 1000).unwrap();
         for r in &results {
             assert_eq!(r.wing, "people", "OR fallback must respect wing filter");
         }

--- a/src/core/fts.rs
+++ b/src/core/fts.rs
@@ -25,8 +25,11 @@ use super::types::{SearchError, SearchResult};
 /// left unquoted.  This handles inputs like `AND?` → stripped `AND` → quoted
 /// `"AND"`.
 ///
-/// The explicit FTS5 query interface (`search_fts`) is intentionally *not*
-/// touched — it preserves full FTS5 syntax for expert callers.
+/// Natural-language callers should pass this output to [`search_fts_tiered`],
+/// which keeps the initial implicit-AND pass and only widens to OR when the
+/// AND pass returns no results. The explicit FTS5 query interface
+/// ([`search_fts`]) is intentionally *not* touched — it preserves full FTS5
+/// syntax for expert callers.
 pub(crate) fn sanitize_fts_query(raw: &str) -> String {
     const FTS5_KEYWORDS: &[&str] = &["AND", "OR", "NOT", "NEAR"];
 
@@ -72,12 +75,14 @@ pub(crate) fn sanitize_fts_query(raw: &str) -> String {
 /// **Explicit FTS5 semantics are preserved.** Quoted phrases, boolean operators
 /// (`AND`, `OR`, `NOT`), and prefix wildcards (`*`) all work as documented by
 /// SQLite FTS5.  Invalid syntax is propagated as `Err` — this is intentional for
-/// expert callers using `quaid search --raw`.
+/// expert callers using `quaid search --raw`. `search_fts_tiered` uses this
+/// function as its precision-first AND pass before widening to OR fallback.
 ///
 /// Default callers are sanitized upstream:
 /// - `src/commands/search.rs` applies `sanitize_fts_query` unless `--raw` is set.
 /// - `src/mcp/server.rs` (`memory_search`) always sanitizes.
-/// - `hybrid_search` in `src/core/search.rs` sanitizes before calling this function.
+/// - `hybrid_search` in `src/core/search.rs` sanitizes before calling
+///   `search_fts_tiered`.
 pub fn search_fts(
     query: &str,
     wing_filter: Option<&str>,
@@ -96,6 +101,85 @@ pub fn search_fts_canonical(
     limit: usize,
 ) -> Result<Vec<SearchResult>, SearchError> {
     search_fts_internal(query, wing_filter, collection_filter, conn, limit, true)
+}
+
+/// Expands a sanitized multi-token query into an explicit FTS5 OR chain.
+///
+/// Single-token or empty inputs are returned unchanged.
+pub fn expand_fts_query_or(sanitized: &str) -> String {
+    let tokens: Vec<_> = sanitized.split_whitespace().collect();
+    if tokens.len() <= 1 {
+        sanitized.to_owned()
+    } else {
+        tokens.join(" OR ")
+    }
+}
+
+/// Natural-language FTS5 search with tiered AND→OR fallback for compound-term
+/// recall.
+///
+/// Tries an AND query first (highest precision). If AND returns no results and
+/// the sanitized query has more than one token, retries with an explicit OR
+/// chain so documents matching any individual term are surfaced.
+///
+/// Callers must pass a **sanitized** query from [`sanitize_fts_query`].
+pub fn search_fts_tiered(
+    sanitized_query: &str,
+    wing_filter: Option<&str>,
+    collection_filter: Option<i64>,
+    conn: &Connection,
+    limit: usize,
+) -> Result<Vec<SearchResult>, SearchError> {
+    search_fts_tiered_internal(
+        sanitized_query,
+        wing_filter,
+        collection_filter,
+        conn,
+        limit,
+        false,
+    )
+}
+
+/// Canonical-slug variant of [`search_fts_tiered`].
+/// Returns slugs in `<collection>::<slug>` format.
+pub fn search_fts_canonical_tiered(
+    sanitized_query: &str,
+    wing_filter: Option<&str>,
+    collection_filter: Option<i64>,
+    conn: &Connection,
+    limit: usize,
+) -> Result<Vec<SearchResult>, SearchError> {
+    search_fts_tiered_internal(
+        sanitized_query,
+        wing_filter,
+        collection_filter,
+        conn,
+        limit,
+        true,
+    )
+}
+
+fn search_fts_tiered_internal(
+    sanitized_query: &str,
+    wing_filter: Option<&str>,
+    collection_filter: Option<i64>,
+    conn: &Connection,
+    limit: usize,
+    canonical_slug: bool,
+) -> Result<Vec<SearchResult>, SearchError> {
+    // AND pass — highest precision; use this if it returns any results.
+    let and_results =
+        search_fts_internal(sanitized_query, wing_filter, collection_filter, conn, limit, canonical_slug)?;
+    if !and_results.is_empty() {
+        return Ok(and_results);
+    }
+
+    let or_query = expand_fts_query_or(sanitized_query);
+    if or_query == sanitized_query {
+        return Ok(Vec::new());
+    }
+
+    search_fts_internal(&or_query, wing_filter, collection_filter, conn, limit, canonical_slug)
 }
 
 fn search_fts_internal(
@@ -536,5 +620,145 @@ mod tests {
             result.is_err(),
             "search_fts must propagate FTS5 syntax errors"
         );
+    }
+
+    // ── expand_fts_query_or ──────────────────────────────────────
+
+    #[test]
+    fn expand_fts_query_or_joins_multi_token_query_with_or() {
+        assert_eq!(
+            expand_fts_query_or("neural network inference"),
+            "neural OR network OR inference"
+        );
+    }
+
+    #[test]
+    fn expand_fts_query_or_leaves_single_token_query_unchanged() {
+        assert_eq!(expand_fts_query_or("inference"), "inference");
+    }
+
+    #[test]
+    fn expand_fts_query_or_leaves_empty_query_unchanged() {
+        assert_eq!(expand_fts_query_or(""), "");
+    }
+
+    // ── search_fts_tiered: OR fallback for compound-term recall (issues #67, #69) ──
+
+    /// Regression #67/#69: "neural network inference" returned zero results when
+    /// documents contain the terms in different pages. `search_fts_tiered` must
+    /// fall back to OR and surface those pages.
+    #[test]
+    fn search_tiered_compound_term_falls_back_to_or_when_and_empty() {
+        let conn = open_test_db();
+        insert_page(
+            &conn,
+            "concepts/inference-engine",
+            "Inference Engine",
+            "concepts",
+            "Model serving",
+            "An inference engine serves trained embedding models in production.",
+        );
+
+        // AND search returns zero — no single page has all three tokens.
+        let and_results = search_fts("neural network inference", None, None, &conn, 1000).unwrap();
+        assert!(
+            and_results.is_empty(),
+            "AND search must return empty when no page contains all three tokens"
+        );
+
+        // Natural search must fall back to OR and find all three pages.
+        let results =
+            search_fts_tiered("neural network inference", None, None, &conn, 1000).unwrap();
+        assert!(
+            !results.is_empty(),
+            "OR fallback must surface pages containing any of the query tokens"
+        );
+        assert_eq!(results[0].slug, "concepts/inference-engine");
+    }
+
+    /// Precision-first: when AND finds results, OR fallback must NOT be triggered.
+    #[test]
+    fn search_tiered_returns_and_results_without_or_fallback() {
+        let conn = open_test_db();
+        insert_page(
+            &conn,
+            "concepts/combined",
+            "Neural Network Inference",
+            "concepts",
+            "Combined page",
+            "Neural network inference is the deployment of a trained model.",
+        );
+        insert_page(
+            &conn,
+            "concepts/neural",
+            "Neural only",
+            "concepts",
+            "Neural",
+            "A standalone neural science article.",
+        );
+        insert_page(
+            &conn,
+            "concepts/inference",
+            "Inference only",
+            "concepts",
+            "Inference",
+            "Inference in formal logic.",
+        );
+
+        let and_results = search_fts("neural network inference", None, None, &conn, 1000).unwrap();
+        let tiered_results =
+            search_fts_tiered("neural network inference", None, None, &conn, 1000).unwrap();
+
+        assert_eq!(tiered_results.len(), and_results.len());
+        assert_eq!(tiered_results[0].slug, "concepts/combined");
+    }
+
+    /// Single-token query: no OR fallback attempted; empty returns empty.
+    #[test]
+    fn search_tiered_single_token_empty_corpus_returns_empty() {
+        let conn = open_test_db();
+        let results = search_fts_tiered("zzznomatch", None, None, &conn, 1000).unwrap();
+        assert!(
+            results.is_empty(),
+            "single-token miss must return empty, not trigger OR fallback"
+        );
+    }
+
+    /// Empty sanitized query: no crash, empty vec returned.
+    #[test]
+    fn search_tiered_empty_query_returns_empty() {
+        let conn = open_test_db();
+        let results = search_fts_tiered("", None, None, &conn, 1000).unwrap();
+        assert!(results.is_empty());
+    }
+
+    /// Wing filter is respected in OR-fallback path.
+    #[test]
+    fn search_tiered_or_fallback_respects_wing_filter() {
+        let conn = open_test_db();
+        // Same token appears in two wings; filter must restrict to one.
+        insert_page(
+            &conn,
+            "people/alice",
+            "Alice",
+            "people",
+            "Engineer",
+            "Alice works on inference engines.",
+        );
+        insert_page(
+            &conn,
+            "companies/acme",
+            "Acme",
+            "companies",
+            "Startup",
+            "Acme builds inference products.",
+        );
+
+        // "inference cloud" AND would miss everything; OR fallback fires.
+        let results = search_fts_tiered("inference cloud", Some("people"), None, &conn, 1000)
+            .unwrap();
+        for r in &results {
+            assert_eq!(r.wing, "people", "OR fallback must respect wing filter");
+        }
     }
 }

--- a/src/core/fts.rs
+++ b/src/core/fts.rs
@@ -83,6 +83,7 @@ pub(crate) fn sanitize_fts_query(raw: &str) -> String {
 /// - `src/mcp/server.rs` (`memory_search`) always sanitizes.
 /// - `hybrid_search` in `src/core/search.rs` sanitizes before calling
 ///   `search_fts_tiered`.
+#[cfg_attr(not(test), allow(dead_code))]
 pub fn search_fts(
     query: &str,
     wing_filter: Option<&str>,

--- a/src/core/inference.rs
+++ b/src/core/inference.rs
@@ -638,7 +638,7 @@ fn download_model_files(model: &ModelConfig) -> Result<(PathBuf, PathBuf, PathBu
 
     let client = reqwest::blocking::Client::builder()
         .timeout(std::time::Duration::from_secs(300))
-        .user_agent("quaid-runtime/0.9.8")
+        .user_agent("quaid-runtime/0.9.10")
         .build()
         .map_err(|e| format!("build download client: {e}"))?;
 

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -578,8 +578,8 @@ mod tests {
             "no embeddings are written in this proof, so vector recall must stay empty"
         );
 
-        let results =
-            hybrid_search("neural network inference", None, None, &conn, 1000).expect("hybrid search");
+        let results = hybrid_search("neural network inference", None, None, &conn, 1000)
+            .expect("hybrid search");
 
         assert_eq!(
             results

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use rusqlite::Connection;
 
 use super::collections::{self, OpKind, SlugResolution};
-use super::fts::{sanitize_fts_query, search_fts, search_fts_canonical};
+use super::fts::{sanitize_fts_query, search_fts_canonical_tiered, search_fts_tiered};
 use super::inference::{search_vec, search_vec_canonical};
 use super::types::{SearchError, SearchMergeStrategy, SearchResult};
 
@@ -59,9 +59,9 @@ fn hybrid_search_impl(
     }
 
     let fts_results = if canonical_slug {
-        search_fts_canonical(&fts_safe, wing, collection_filter, conn, limit)?
+        search_fts_canonical_tiered(&fts_safe, wing, collection_filter, conn, limit)?
     } else {
-        search_fts(&fts_safe, wing, collection_filter, conn, limit)?
+        search_fts_tiered(&fts_safe, wing, collection_filter, conn, limit)?
     };
     let vec_results = if canonical_slug {
         search_vec_canonical(trimmed, 10, wing, collection_filter, conn)?
@@ -392,11 +392,15 @@ fn normalize_score(score: f64, max_score: f64) -> f64 {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
+
     use rusqlite::Connection;
 
     use super::*;
     use crate::commands::embed;
     use crate::core::db;
+    use crate::core::fts::{sanitize_fts_query, search_fts};
+    use crate::core::inference::{search_vec, search_vec_canonical};
 
     fn open_test_db() -> Connection {
         let dir = tempfile::TempDir::new().expect("create temp dir");
@@ -538,6 +542,99 @@ mod tests {
 
         assert!(slugs.contains(&"people/alice"));
         assert!(slugs.contains(&"companies/acme"));
+    }
+
+    #[test]
+    fn hybrid_search_uses_tiered_fts_recall_when_and_and_vector_are_empty() {
+        let conn = open_test_db();
+        insert_page(
+            &conn,
+            "concepts/neural",
+            "Neural Networks",
+            "Representation learning",
+            "Neural networks learn useful representations.",
+            "concepts",
+        );
+        insert_page(
+            &conn,
+            "concepts/inference-engine",
+            "Inference Engine",
+            "Model serving",
+            "An inference engine deploys trained models.",
+            "concepts",
+        );
+
+        let sanitized = sanitize_fts_query("neural network inference");
+        assert!(
+            search_fts(&sanitized, None, None, &conn, 1000)
+                .expect("AND-only FTS query")
+                .is_empty(),
+            "the deterministic proof corpus must force the implicit-AND FTS pass to miss"
+        );
+        assert!(
+            search_vec("neural network inference", 10, None, None, &conn)
+                .expect("vector search without embeddings")
+                .is_empty(),
+            "no embeddings are written in this proof, so vector recall must stay empty"
+        );
+
+        let results =
+            hybrid_search("neural network inference", None, None, &conn, 1000).expect("hybrid search");
+
+        assert_eq!(
+            results
+                .iter()
+                .map(|result| result.slug.clone())
+                .collect::<BTreeSet<_>>(),
+            BTreeSet::from([
+                "concepts/inference-engine".to_owned(),
+                "concepts/neural".to_owned(),
+            ]),
+            "hybrid_search should recover compound-term recall from the tiered FTS arm alone"
+        );
+    }
+
+    #[test]
+    fn hybrid_search_canonical_preserves_collection_prefix_on_tiered_fts_recall() {
+        let conn = open_test_db();
+        insert_page(
+            &conn,
+            "concepts/neural",
+            "Neural Networks",
+            "Representation learning",
+            "Neural networks learn useful representations.",
+            "concepts",
+        );
+        insert_page(
+            &conn,
+            "concepts/inference-engine",
+            "Inference Engine",
+            "Model serving",
+            "An inference engine deploys trained models.",
+            "concepts",
+        );
+
+        assert!(
+            search_vec_canonical("neural network inference", 10, None, None, &conn)
+                .expect("canonical vector search without embeddings")
+                .is_empty(),
+            "canonical hybrid proof must not depend on vector quality"
+        );
+
+        let results = hybrid_search_canonical("neural network inference", None, None, &conn, 1000)
+            .expect("canonical hybrid search");
+
+        assert_eq!(
+            results
+                .iter()
+                .map(|result| result.slug.clone())
+                .collect::<BTreeSet<_>>(),
+            BTreeSet::from([
+                "default::concepts/inference-engine".to_owned(),
+                "default::concepts/neural".to_owned(),
+            ]),
+            "canonical hybrid results should keep the collection prefix on FTS fallback hits"
+        );
     }
 
     #[test]

--- a/tests/search_hardening.rs
+++ b/tests/search_hardening.rs
@@ -228,7 +228,10 @@ fn search_compound_terms_and_path_takes_precedence() {
     drop(conn);
 
     let output = run_quaid(&db_path, &["--json", "search", "neural network inference"]);
-    assert!(output.status.success(), "search should exit cleanly: {output:?}");
+    assert!(
+        output.status.success(),
+        "search should exit cleanly: {output:?}"
+    );
 
     let parsed = parse_stdout_json(&output);
     let results = parsed.as_array().expect("output must be a JSON array");
@@ -269,7 +272,10 @@ fn search_raw_mode_bypasses_or_fallback() {
         &db_path,
         &["--json", "search", "--raw", "neural network inference"],
     );
-    assert!(output.status.success(), "raw search should exit cleanly: {output:?}");
+    assert!(
+        output.status.success(),
+        "raw search should exit cleanly: {output:?}"
+    );
     let parsed = parse_stdout_json(&output);
     let results = parsed.as_array().expect("output must be a JSON array");
     assert!(

--- a/tests/search_hardening.rs
+++ b/tests/search_hardening.rs
@@ -1,6 +1,7 @@
 use quaid::core::db;
 use rusqlite::Connection;
 use serde_json::Value;
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -34,6 +35,19 @@ fn parse_stdout_json(output: &std::process::Output) -> Value {
 
 fn test_db_path(dir: &tempfile::TempDir, name: &str) -> PathBuf {
     dir.path().join(name)
+}
+
+fn result_slugs(results: &[Value]) -> BTreeSet<String> {
+    results
+        .iter()
+        .map(|result| {
+            result
+                .get("slug")
+                .and_then(Value::as_str)
+                .expect("each result must include a slug")
+                .to_owned()
+        })
+        .collect()
 }
 
 #[test]
@@ -129,5 +143,189 @@ fn call_memory_search_question_query_returns_json_array() {
     assert!(
         parsed.is_array(),
         "memory_search call must emit a JSON array"
+    );
+}
+
+// ── Regression: compound-term recall issues #67 and #69 ──────────────────────
+
+/// Regression #67/#69: `quaid search "neural network inference"` must not return
+/// an empty array when the corpus contains pages about neural networks and inference
+/// separately.  The OR fallback must surface them.
+#[test]
+fn search_compound_terms_finds_docs_when_any_token_matches() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let db_path = test_db_path(&dir, "compound-recall.db");
+    let conn = open_test_db(&db_path);
+
+    // Three pages — each covers only ONE of the three query tokens.
+    insert_page(
+        &conn,
+        "concepts/neural",
+        "concept",
+        "Neural Networks",
+        "A neural network is a layered ML model.",
+    );
+    insert_page(
+        &conn,
+        "concepts/inference",
+        "concept",
+        "Inference Engines",
+        "Inference engines deploy trained models.",
+    );
+    insert_page(
+        &conn,
+        "concepts/network",
+        "concept",
+        "Computer Networks",
+        "Packet-switched network topology.",
+    );
+    drop(conn);
+
+    let output = run_quaid(&db_path, &["--json", "search", "neural network inference"]);
+
+    assert!(
+        output.status.success(),
+        "search should exit cleanly: {output:?}"
+    );
+
+    let parsed = parse_stdout_json(&output);
+    let results = parsed.as_array().expect("output must be a JSON array");
+    let slugs = result_slugs(results);
+    assert!(
+        slugs
+            == BTreeSet::from([
+                "default::concepts/inference".to_owned(),
+                "default::concepts/network".to_owned(),
+                "default::concepts/neural".to_owned(),
+            ]),
+        "compound-term search must widen to canonical OR results when no page satisfies the \
+         implicit-AND pass (regression for issues #67 and #69)"
+    );
+}
+
+/// When at least one page matches ALL tokens (AND path), results must include it.
+#[test]
+fn search_compound_terms_and_path_takes_precedence() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let db_path = test_db_path(&dir, "compound-and.db");
+    let conn = open_test_db(&db_path);
+
+    // One page contains all three tokens; others contain only one.
+    insert_page(
+        &conn,
+        "concepts/combined",
+        "concept",
+        "Neural Network Inference",
+        "Neural network inference is the deployment of a trained model.",
+    );
+    insert_page(
+        &conn,
+        "concepts/neural-only",
+        "concept",
+        "Neural",
+        "Neural science article unrelated to networks.",
+    );
+    drop(conn);
+
+    let output = run_quaid(&db_path, &["--json", "search", "neural network inference"]);
+    assert!(output.status.success(), "search should exit cleanly: {output:?}");
+
+    let parsed = parse_stdout_json(&output);
+    let results = parsed.as_array().expect("output must be a JSON array");
+    assert_eq!(
+        result_slugs(results),
+        BTreeSet::from(["default::concepts/combined".to_owned()]),
+        "non-raw CLI search must keep canonical slugs and stop at the AND hit instead of \
+         widening to OR results"
+    );
+}
+
+/// `--raw` flag must bypass OR fallback — expert FTS5 query behaviour is unchanged.
+#[test]
+fn search_raw_mode_bypasses_or_fallback() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let db_path = test_db_path(&dir, "raw-no-fallback.db");
+    let conn = open_test_db(&db_path);
+
+    // Corpus: two pages, each with one token.
+    insert_page(
+        &conn,
+        "concepts/neural",
+        "concept",
+        "Neural",
+        "Neural network model.",
+    );
+    insert_page(
+        &conn,
+        "concepts/inference",
+        "concept",
+        "Inference",
+        "Inference engine.",
+    );
+    drop(conn);
+
+    // Raw search preserves implicit AND semantics — no single page matches all terms.
+    let output = run_quaid(
+        &db_path,
+        &["--json", "search", "--raw", "neural network inference"],
+    );
+    assert!(output.status.success(), "raw search should exit cleanly: {output:?}");
+    let parsed = parse_stdout_json(&output);
+    let results = parsed.as_array().expect("output must be a JSON array");
+    assert!(
+        results.is_empty(),
+        "--raw query must not get an OR fallback; expected empty array"
+    );
+}
+
+/// MCP memory_search returns a valid JSON array (safety contract — no crash).
+/// NOTE: compound-term OR fallback is NOT applied to memory_search per the
+/// compound-term-recall design decision (MCP agents needing compound recall
+/// should use memory_query which includes the hybrid/vector arm).
+#[test]
+fn memory_search_compound_query_returns_valid_json_array() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let db_path = test_db_path(&dir, "mcp-compound-safety.db");
+    let conn = open_test_db(&db_path);
+
+    insert_page(
+        &conn,
+        "concepts/neural",
+        "concept",
+        "Neural Networks",
+        "A neural network is a machine learning model.",
+    );
+    insert_page(
+        &conn,
+        "concepts/inference",
+        "concept",
+        "Inference Engines",
+        "Inference engines deploy trained models.",
+    );
+    drop(conn);
+
+    let output = run_quaid(
+        &db_path,
+        &[
+            "call",
+            "memory_search",
+            r#"{"query":"neural network inference","limit":10}"#,
+        ],
+    );
+
+    assert!(
+        output.status.success(),
+        "call memory_search should exit cleanly: {output:?}"
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).trim().is_empty(),
+        "call memory_search should not write errors to stderr: {:?}",
+        output.stderr
+    );
+
+    let parsed = parse_stdout_json(&output);
+    assert!(
+        parsed.is_array(),
+        "memory_search must always emit a JSON array (may be empty for compound-term AND miss)"
     );
 }

--- a/website/src/content/docs/how-to/airgapped-vs-online.mdx
+++ b/website/src/content/docs/how-to/airgapped-vs-online.mdx
@@ -71,7 +71,7 @@ There's no schema migration involved.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/quaid-app/quaid/main/scripts/install.sh \
-  | QUAID_VERSION=v0.9.8 QUAID_CHANNEL=online sh
+  | QUAID_VERSION=v0.9.10 QUAID_CHANNEL=online sh
 ```
 
 `QUAID_VERSION` pins the release tag; `QUAID_CHANNEL` pins the channel. The installer validates SHA-256 either way.

--- a/website/src/content/docs/how-to/upgrade.mdx
+++ b/website/src/content/docs/how-to/upgrade.mdx
@@ -42,7 +42,7 @@ Note the binary version and the schema version on the memory (`schema_version` i
 curl -fsSL https://api.github.com/repos/quaid-app/quaid/releases/latest | jq -r '.tag_name'
 
 # Or pin
-QUAID_VERSION=v0.9.8
+QUAID_VERSION=v0.9.10
 ```
 
 Read the release notes before upgrading. Schema bumps require a migration window.
@@ -53,7 +53,7 @@ The shell installer is the supported upgrade path:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/quaid-app/quaid/main/scripts/install.sh \
-  | QUAID_VERSION=v0.9.8 sh
+  | QUAID_VERSION=v0.9.10 sh
 ```
 
 It:
@@ -68,7 +68,7 @@ If you installed manually, repeat the manual steps:
 
 ```bash
 ASSET="quaid-darwin-arm64-airgapped"
-VERSION="v0.9.8"
+VERSION="v0.9.10"
 curl -fsSL "https://github.com/quaid-app/quaid/releases/download/${VERSION}/${ASSET}" -o "${ASSET}"
 curl -fsSL "https://github.com/quaid-app/quaid/releases/download/${VERSION}/${ASSET}.sha256" -o "${ASSET}.sha256"
 shasum -a 256 -c "${ASSET}.sha256"

--- a/website/src/content/docs/tutorials/install.mdx
+++ b/website/src/content/docs/tutorials/install.mdx
@@ -57,7 +57,7 @@ The installer always grabs the latest release. To pin:
   tone="terminal"
   label="Pinned install"
   code={`curl -fsSL https://raw.githubusercontent.com/quaid-app/quaid/main/scripts/install.sh \
-  | QUAID_VERSION=v0.9.8 sh`}
+  | QUAID_VERSION=v0.9.10 sh`}
 />
 
 ## What you got


### PR DESCRIPTION
## Summary
Quaid v0.9.10 ships compound-term FTS recall recovery for issues #67 and #69.

### Changes
1. **Compound-term FTS recall (#67, #69)**
   - Implement tiered search strategy: AND pass first, then OR fallback when no results are found
   - Sanitize natural-language queries and preserve raw/expert semantics
   - Wire the tiered recall path into hybrid search and CLI search surfaces
   - Add regression tests for compound-term behavior and JSON-safe output

2. **Release alignment**
   - Update version and runtime surfaces to v0.9.10
   - Refresh docs, release workflow, and release checklist to match the shipped scope
   - Include OpenSpec proposal, design, and tasks for the change

### Validation
Local cargo validation could not be run in this environment because the machine does not have a Rust toolchain installed. GitHub Actions on this PR are the validation gate.

### Scope
This PR is limited to the #67/#69 recall fix and directly related release/docs alignment.
