### PR TITLE
fix: bump Cargo version to v0.11.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quaid"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 description = "Local-first personal memory. SQLite + FTS5 + local vector embeddings. One static binary."
 license = "MIT"


### PR DESCRIPTION
## Summary
- bump Cargo package version from 0.11.0 to 0.11.1
- ship the repair from current main via draft PR

## Validation
- could not run cargo test locally in this environment because the Rust cargo executable is not installed on PATH or present under the user profile