### PR TITLE
fix: bump Cargo version to v0.11.2

### DIFF
--- a/.squad/agents/fry/history.md
+++ b/.squad/agents/fry/history.md
@@ -1,3 +1,7 @@
 # fry history
 
 - [2026-04-29T07-04-07Z] History summarized and archived
+
+## Learnings
+
+- [2026-04-29T06:15:00Z] When a release tag already exists on origin, cut the repair from fresh `main` under the next clean version branch instead of trying to reuse the rejected tag lane.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quaid"
-version = "0.11.0"
+version = "0.11.2"
 edition = "2021"
 description = "Local-first personal memory. SQLite + FTS5 + local vector embeddings. One static binary."
 license = "MIT"


### PR DESCRIPTION
## Summary
- bump Cargo package version from 0.11.0 to 0.11.2 from current main
- replace the rejected v0.11.1 release-lane repair with a fresh v0.11.2 draft PR
- supersedes #116 because tag v0.11.1 already exists on origin

## Validation
- could not run cargo test or cargo clippy locally in this environment because cargo is not installed on PATH