### PR TITLE
fix: bump Cargo version to v0.11.5

### DIFF
--- a/.squad/agents/fry/history.md
+++ b/.squad/agents/fry/history.md
@@ -1,3 +1,7 @@
 # fry history
 
 - [2026-04-29T07-04-07Z] History summarized and archived
+
+## Learnings
+
+- [2026-04-29T08:06:00Z] PR #118 on `release/v0.11.5` was blocked by package-version drift: `Cargo.toml` had `0.11.5` while the root `quaid` entry in `Cargo.lock` still reported `0.11.0`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2064,7 +2064,7 @@ dependencies = [
 
 [[package]]
 name = "quaid"
-version = "0.11.0"
+version = "0.11.5"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quaid"
-version = "0.11.0"
+version = "0.11.5"
 edition = "2021"
 description = "Local-first personal memory. SQLite + FTS5 + local vector embeddings. One static binary."
 license = "MIT"


### PR DESCRIPTION
## Summary
- bump the Cargo package version from 0.11.0 to 0.11.5 on a fresh release branch from current main
- replace the burned v0.11.1 and v0.11.2 release lanes with a clean v0.11.5 repair PR
- supersedes #116 and #117 with this clean lane

## Validation
- attempted cargo test, but cargo is not installed or not available on PATH in this environment