### PR TITLE
chore: repair v0.11.6 release lane

### DIFF
--- a/.squad/agents/bender/history.md
+++ b/.squad/agents/bender/history.md
@@ -1,7 +1,3 @@
 # bender history
 
 - [2026-04-29T07-04-07Z] History summarized and archived
-
-## Learnings
-
-- [2026-04-29T07:25:00Z] Burned release tags stay burned even when the repair is tiny; cut the next PR from a fresh version lane and keep the fix scoped to the version files plus required bookkeeping.

--- a/.squad/agents/bender/history.md
+++ b/.squad/agents/bender/history.md
@@ -1,3 +1,7 @@
 # bender history
 
 - [2026-04-29T07-04-07Z] History summarized and archived
+
+## Learnings
+
+- [2026-04-29T07:25:00Z] Burned release tags stay burned even when the repair is tiny; cut the next PR from a fresh version lane and keep the fix scoped to the version files plus required bookkeeping.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2064,7 +2064,7 @@ dependencies = [
 
 [[package]]
 name = "quaid"
-version = "0.11.0"
+version = "0.11.6"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quaid"
-version = "0.11.0"
+version = "0.11.6"
 edition = "2021"
 description = "Local-first personal memory. SQLite + FTS5 + local vector embeddings. One static binary."
 license = "MIT"


### PR DESCRIPTION
## Summary
- bump the crate version to 0.11.6 in Cargo.toml
- sync the root quaid package version in Cargo.lock
- supersede #116, #117, and #118 with a clean release repair lane

## Notes
- Draft PR only; do not merge, tag, or release from this branch.
- #116, #117, and #118 are superseded by this clean lane.