### PR TITLE
chore: prep v0.12.0 release truth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2064,7 +2064,7 @@ dependencies = [
 
 [[package]]
 name = "quaid"
-version = "0.11.6"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quaid"
-version = "0.11.6"
+version = "0.12.0"
 edition = "2021"
 description = "Local-first personal memory. SQLite + FTS5 + local vector embeddings. One static binary."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -86,13 +86,13 @@ Sets up `PATH` and `QUAID_DB` automatically. Use `QUAID_CHANNEL=online` for the 
 ### Download a binary
 
 ```bash
-VERSION="<published-tag>"   # for example: v0.10.0 until v0.11.0 is published
+VERSION="<published-tag>"   # for example: the latest public tag until v0.12.0 is published
 PLATFORM="darwin-arm64"   # darwin-arm64 | darwin-x86_64 | linux-x86_64 | linux-aarch64
 curl -fsSL "https://github.com/quaid-app/quaid/releases/download/${VERSION}/quaid-${PLATFORM}-online" \
   -o quaid && chmod +x quaid && sudo mv quaid /usr/local/bin/
 ```
 
-Use a published tag here. This branch is preparing `v0.11.0`, so build from source if you need the unreleased Batch 2 embedding-worker slice before the tag exists.
+Use a published tag here. This branch is preparing `v0.12.0`, so build from source if you need the unreleased Batch 3 UUID write-back / `migrate-uuids` slice before the tag exists.
 
 ### Build from source
 
@@ -169,7 +169,7 @@ quaid serve
 
 ## MCP tools
 
-The MCP surface stays at 17 tools on this branch and in the current release line. The `v0.11.0` docs pass is about Batch 2 background embedding drain and queue reporting, not new tool names:
+The MCP surface stays at 17 tools on this branch and in the current release line. The `v0.12.0` docs pass is about Batch 3 UUID identity hardening — opt-in `quaid_id` write-back (`quaid collection add --write-quaid-id`), offline `quaid collection migrate-uuids`, and `memory_put` preserving existing IDs — not new tool names:
 
 | Category | Tools |
 |----------|-------|

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -429,7 +429,7 @@ In this release line, `quaid collection info` also surfaces `queue_depth` and `f
 
 Once attached, `quaid serve` starts a file watcher for the collection. Changes you make in Obsidian or any editor are debounced over 1.5 s and flushed via the stat-diff reconciler.
 
-`quaid collection migrate-uuids` and `quaid collection add --write-quaid-id` are Unix-only bulk rewrite paths. They refuse when `quaid serve` already owns the collection, so stop `serve`, run the migration offline, then restart.
+Collection attach and other filesystem-mutating collection operations in this release line are Unix-only, including `quaid collection add`, `quaid collection migrate-uuids`, and `quaid collection add --write-quaid-id`. These offline rewrite flows refuse when `quaid serve` already owns the collection, so stop `serve`, run the migration or attach step offline, then restart.
 
 > **Platform note.** `quaid serve` and the core MCP tools are cross-platform. Live vault-sync watcher threads start only on Unix (macOS / Linux); on Windows `quaid serve` starts the MCP server normally but watcher-backed auto-reconcile is not active. The MCP read/write tools (`memory_get`, `memory_put`, `memory_query`, etc.) work on all platforms.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started with Quaid
 
-> Quaid is a local-first personal AI memory layer: SQLite + FTS5 + local vector embeddings in one file. This branch prepares `v0.11.0`: it keeps the vault-sync surface from `v0.10.0` and adds Batch 2 background embedding draining plus queue-depth / failing-job visibility for collection status.
+> Quaid is a local-first personal AI memory layer: SQLite + FTS5 + local vector embeddings in one file. This branch prepares `v0.12.0`: it keeps the 17-tool surface, carries the Batch 1/2 vault-sync follow-ons already on `main`, and adds Batch 3 UUID identity hardening for collection-backed vaults.
 
 ## What it does
 
@@ -15,9 +15,9 @@ You search it with full-text keywords and semantic queries. Any MCP-compatible A
 
 ## Status
 
-> **Phase 3 is complete, and the vault-sync line is in Batch 2.** This branch prepares `v0.11.0`: it preserves the current 17-tool surface, keeps the Batch 1 watcher-reliability hardening from `v0.10.0`, and adds the background embedding worker plus queue-depth / failing-job reporting.
+> **Phase 3 is complete, and the vault-sync line is in Batch 3.** This branch prepares `v0.12.0`: it preserves the current 17-tool surface, keeps the watcher / embedding-worker hardening already shipped through Batch 2, and adds opt-in `quaid_id` write-back plus offline `migrate-uuids` repair for collection-backed vaults.
 >
-> Published GitHub Release binaries still come from the latest public tag until the `v0.11.0` workflow completes. See [roadmap.md](roadmap.md) for the full delivery plan.
+> Published GitHub Release binaries still come from the latest public tag until the `v0.12.0` workflow completes. See [roadmap.md](roadmap.md) for the full delivery plan.
 
 ---
 
@@ -25,14 +25,14 @@ You search it with full-text keywords and semantic queries. Any MCP-compatible A
 
 | Method | Status |
 | ------ | ------ |
-| Build from source (`cargo build --release`) | ✅ Available now — source builds reflect this branch, including the Batch 2 slice |
-| GitHub Release binary (macOS ARM/x86, Linux x86_64/ARM64) | ✅ Available — use the latest published tag until `v0.11.0` is cut |
+| Build from source (`cargo build --release`) | ✅ Available now — source builds reflect this branch, including the Batch 3 UUID write-back / `migrate-uuids` slice |
+| GitHub Release binary (macOS ARM/x86, Linux x86_64/ARM64) | ✅ Available — use the latest published tag until `v0.12.0` is cut |
 | `npm install -g quaid` | ❌ Not yet published — use binary release or build from source |
 | One-command curl installer | ✅ Available — airgapped by default; set `QUAID_CHANNEL=online` for online |
 
 > **Configurable BGE models.** The `online` build selects `small` (default), `base`, `large`, or `m3` via `QUAID_MODEL` / `--model`. The `airgapped` build embeds BGE-small-en-v1.5.
 >
-> **Pre-release note.** GitHub Releases downloads and `install.sh` resolve against published tags. Build from source if you need the unreleased `v0.11.0` Batch 2 behavior before the tag exists.
+> **Pre-release note.** GitHub Releases downloads and `install.sh` resolve against published tags. Build from source if you need the unreleased `v0.12.0` Batch 3 UUID write-back / `migrate-uuids` behavior before the tag exists.
 
 ---
 
@@ -69,7 +69,7 @@ cross build --release --target aarch64-unknown-linux-musl     # Linux ARM64 (ful
 
 ## Your first memory store
 
-> **Phase 1 commands** are implemented. **Phase 2 commands** (graph, check, gaps) are implemented. **Phase 3 commands** (validate, call, pipe, skills) are implemented. Build from source to use the full branch state described below before `v0.11.0` is published; see [Status](#status) and [Install options](#install-options) above.
+> **Phase 1 commands** are implemented. **Phase 2 commands** (graph, check, gaps) are implemented. **Phase 3 commands** (validate, call, pipe, skills) are implemented. Build from source to use the full branch state described below before `v0.12.0` is published; see [Status](#status) and [Install options](#install-options) above.
 
 > **Post-install note:** The shell installer (`scripts/install.sh`) automatically adds `PATH` and `QUAID_DB` to your shell profile. If you built from source or used the manual GitHub Releases download, add these to your profile yourself:
 > ```bash
@@ -101,7 +101,7 @@ Quaid ingests each markdown file, parses frontmatter, splits compiled-truth from
 > quaid serve
 > ```
 >
-> Use `quaid import` for one-shot bulk ingest. Use collections when you want Quaid to stay in sync with a markdown or Obsidian vault. For an OpenClaw setup, see [openclaw-harness.md](openclaw-harness.md).
+> Use `quaid import` for one-shot bulk ingest. Use collections when you want Quaid to stay in sync with a markdown or Obsidian vault. On Unix, Batch 3 also lets you persist missing `quaid_id` frontmatter during attach (`quaid collection add <name> <path> --write-quaid-id`) or backfill it later with `quaid collection migrate-uuids <name> [--dry-run]`. For an OpenClaw setup, see [openclaw-harness.md](openclaw-harness.md).
 
 ### 3. Search
 
@@ -192,7 +192,7 @@ The MCP server exposes tools over stdio JSON-RPC 2.0.
 
 **vault-sync tools:** `memory_collections` — read-only per-collection status including state, ignore diagnostics, recovery flags, and embedding queue health
 
-All 17 tools remain live on this branch and in the current release line. Batch 2 changes background embedding drain and queue reporting, not the MCP tool count. See [spec.md](spec.md#mcp-server) for tool signatures.
+All 17 tools remain live on this branch and in the current release line. Batch 3 adds UUID identity hardening for collection-backed vaults — opt-in `--write-quaid-id`, offline `migrate-uuids`, and `memory_put` preserving existing `quaid_id` frontmatter — not new MCP tool names. See [spec.md](spec.md#mcp-server) for tool signatures.
 
 ---
 
@@ -403,13 +403,20 @@ quaid skills doctor   # verify SHA-256 hashes, detect override shadowing
 
 ## vault-sync-engine: Collections and live-sync
 
-> These commands first shipped in `v0.9.6`. This branch carries the `v0.11.0` follow-on: Batch 1 watcher hardening stays in place, Batch 2 adds background embedding drain plus queue health reporting, and the deferred IPC / broader restore follow-ons remain out of scope.
+> These commands first shipped in `v0.9.6`. This branch carries the `v0.12.0` follow-on: Batch 1 watcher hardening and Batch 2 embedding queue reporting stay in place, while Batch 3 adds opt-in `quaid_id` write-back during attach, offline `migrate-uuids`, and UUID-migration preflights for restore/remap.
 
 ### Attach a vault
 
 ```bash
 # Attach a directory as a named collection
 quaid collection add work /path/to/my-obsidian-vault
+
+# Opt in to persisting missing quaid_id frontmatter during attach
+quaid collection add work /path/to/my-obsidian-vault --write-quaid-id
+
+# Audit or backfill missing quaid_id frontmatter later (offline only)
+quaid collection migrate-uuids work --dry-run
+quaid collection migrate-uuids work
 
 # List all collections
 quaid collection list
@@ -418,9 +425,11 @@ quaid collection list
 quaid collection info work
 ```
 
-On this branch, `quaid collection info` also surfaces `queue_depth` and `failing_jobs` so you can see whether the background embedding worker is keeping up.
+In this release line, `quaid collection info` also surfaces `queue_depth` and `failing_jobs` so you can see whether the background embedding worker is keeping up.
 
 Once attached, `quaid serve` starts a file watcher for the collection. Changes you make in Obsidian or any editor are debounced over 1.5 s and flushed via the stat-diff reconciler.
+
+`quaid collection migrate-uuids` and `quaid collection add --write-quaid-id` are Unix-only bulk rewrite paths. They refuse when `quaid serve` already owns the collection, so stop `serve`, run the migration offline, then restart.
 
 > **Platform note.** `quaid serve` and the core MCP tools are cross-platform. Live vault-sync watcher threads start only on Unix (macOS / Linux); on Windows `quaid serve` starts the MCP server normally but watcher-backed auto-reconcile is not active. The MCP read/write tools (`memory_get`, `memory_put`, `memory_query`, etc.) work on all platforms.
 
@@ -461,7 +470,7 @@ quaid collection quarantine export work --out quarantine.json
 quaid collection quarantine discard work <page-slug>
 ```
 
-> Quarantine restore is deferred in the current release. The safe landed surface is `list`, `export`, and `discard` only.
+> Quarantine restore is available on Unix in the current release line. Windows still fails closed on that write surface, so the portable subset remains `list`, `export`, and `discard`.
 
 Auto-sweep TTL (`QUAID_QUARANTINE_TTL_DAYS`, default 30) silently discards clean quarantined pages only — pages with DB-only state are never auto-discarded.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -162,6 +162,7 @@ These are known design choices that are _not_ oversights:
 | `v0.9.9` | Intermediate hotfix release for vault-sync refinements |
 | `v0.10.0` | Batch 1 watcher reliability hardening: overflow recovery worker, native→poll fallback, crash/backoff supervisor, and CLI watcher-health reporting |
 | `v0.11.0` | Batch 2 embedding worker: background queue drain, retry/resume handling, `embedding_queue_depth` in `memory_collections`, and `failing_jobs` in `quaid collection info` |
+| `v0.12.0` | Batch 3 UUID identity hardening: opt-in `--write-quaid-id`, offline `quaid collection migrate-uuids [--dry-run]`, UUID-migration preflight before restore/remap, and `memory_put` preserving `quaid_id` |
 
 ---
 
@@ -171,18 +172,19 @@ These are known design choices that are _not_ oversights:
 **Branch:** `spec/vault-sync-engine`
 **OpenSpec:** [`openspec/changes/vault-sync-engine/`](../openspec/changes/vault-sync-engine/)
 
-Adds vault-as-collection attachment, a file watcher, a stat-diff reconciler, quarantine lifecycle, and a fully safe write-through path for `memory_put` on Unix.
+Adds vault-as-collection attachment, a file watcher, a stat-diff reconciler, quarantine lifecycle, UUID identity hardening for collection-backed vaults, and a fully safe write-through path for `memory_put` on Unix.
 
 ### What has landed
 
 - **Schema v7** — `collections`, `file_state`, `raw_imports`, `embedding_jobs`, quarantine indexes; Batch 2 adds embedding job state / retry metadata; older brains refuse with re-init instructions
-- **Collection management** — `quaid collection add|list|info|sync|restore|restore-reset|reconcile-reset`
+- **Collection management** — `quaid collection add|list|info|sync|migrate-uuids|restore|restore-reset|reconcile-reset`
 - **Ignore patterns** — `quaid collection ignore add|remove|list|clear --confirm`; atomic-parse `.quaidignore` with mirror refresh; built-in defaults (`.git/**`, `node_modules/**`, etc.) always applied
 - **Quarantine lifecycle** — `quaid collection quarantine list|export|discard|restore` (restore is a narrow Unix-only seam); auto-sweep TTL (`QUAID_QUARANTINE_TTL_DAYS`, default 30); pages with DB-only state (links, assertions, knowledge gaps, contradictions, raw_data) are quarantined rather than hard-deleted; `discard --force` or post-export discard available
 - **Reconciler** — stat-diff walk, UUID identity resolution, rename detection (native pair → UUID match → content-hash uniqueness), delete-vs-quarantine classifier, 500-file batch commit
 - **File watcher** — one `notify` watcher per active collection in `quaid serve` (Unix/macOS/Linux in `v0.9.6`); 1.5 s debounce (`QUAID_WATCH_DEBOUNCE_MS`); reconcile-backed flushes; path+hash self-write suppression with TTL expiry
 - **Embedding worker** — `quaid serve` drains the background embedding queue every 2 seconds, retries failed jobs with bounded backoff, resumes orphaned `running` jobs on startup, surfaces `embedding_queue_depth` in the frozen `memory_collections` MCP object, and surfaces `queue_depth` plus `failing_jobs` in `quaid collection info`
 - **Write-through `memory_put`** *(Unix)* — full rename-before-commit sequence (recovery sentinel → tempfile → `renameat` → fsync parent dir → single SQLite tx); mandatory `expected_version` for updates; `check_fs_precondition` four-field CAS
+- **UUID identity hardening** *(Unix write surface)* — `quaid collection add --write-quaid-id` can persist missing `quaid_id` frontmatter during first attach, `quaid collection migrate-uuids <name> [--dry-run]` backfills it later offline, restore/remap preflights now fail closed with `UuidMigrationRequiredError` when trivial-content notes still lack frontmatter IDs, and `memory_put` preserves existing `quaid_id` on write
 - **Write interlock** — `state='restoring'` or `needs_full_sync=1` blocks all mutating CLI/MCP ops with `CollectionRestoringError`
 - **Offline restore** — `quaid collection restore <name> <target>` → Tx-A → atomic rename → Tx-B; `sync --finalize-pending` drives full-hash reconcile and reopens writes
 - **`memory_collections` MCP tool** — frozen 13-field per-collection object; truthful state, recovery, and ignore-diagnostic surfacing (17 MCP tools total)
@@ -199,5 +201,4 @@ Adds vault-as-collection attachment, a file watcher, a stat-diff reconciler, qua
 | `quaid collection remove` | Detach + optional purge not yet implemented |
 | `quaid stats` per-collection augmentation | Per-collection row + aggregate totals pending |
 | Online restore handshake (`17.5pp/qq*`) | Live-serve ack protocol not yet implemented |
-| Opt-in UUID write-back (`5a.5`, `migrate-uuids`) | `--write-quaid-id` and `migrate-uuids` CLI not yet implemented |
 | Legacy `quaid import` removal (`15.*`) | Import path remains until reconciler covers all ingest use cases |

--- a/src/core/reconciler.rs
+++ b/src/core/reconciler.rs
@@ -5939,6 +5939,22 @@ mod tests {
     }
 
     #[test]
+    fn default_restore_stability_max_iters_guard_restores_previous_value() {
+        let _guard = env_mutation_lock().lock().unwrap();
+        let _original = EnvVarGuard::set("QUAID_RESTORE_STABILITY_MAX_ITERS", "7");
+        {
+            let _env = EnvVarGuard::set("QUAID_RESTORE_STABILITY_MAX_ITERS", "12");
+            assert_eq!(default_restore_stability_max_iters(), 12);
+        }
+
+        assert_eq!(
+            std::env::var("QUAID_RESTORE_STABILITY_MAX_ITERS").as_deref(),
+            Ok("7")
+        );
+        assert_eq!(default_restore_stability_max_iters(), 7);
+    }
+
+    #[test]
     fn sentinel_count_ignores_files_without_needs_full_sync_extension() {
         let recovery_root = tempfile::TempDir::new().unwrap();
         let collection_id = 1i64;

--- a/src/core/reconciler.rs
+++ b/src/core/reconciler.rs
@@ -2674,8 +2674,8 @@ impl From<std::io::Error> for ReconcileError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::ffi::OsString;
     use crate::core::file_state::upsert_file_state;
+    use std::ffi::OsString;
     use std::fs;
     #[cfg(unix)]
     use std::os::unix::fs::symlink;

--- a/src/core/reconciler.rs
+++ b/src/core/reconciler.rs
@@ -2674,13 +2674,48 @@ impl From<std::io::Error> for ReconcileError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsString;
     use crate::core::file_state::upsert_file_state;
     use std::fs;
     #[cfg(unix)]
     use std::os::unix::fs::symlink;
+    use std::sync::{Mutex, OnceLock};
     #[cfg(unix)]
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
     use tempfile::TempDir;
+
+    static ENV_MUTATION_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    fn env_mutation_lock() -> &'static Mutex<()> {
+        ENV_MUTATION_LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var_os(key);
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            unsafe {
+                if let Some(value) = self.previous.as_ref() {
+                    std::env::set_var(self.key, value);
+                } else {
+                    std::env::remove_var(self.key);
+                }
+            }
+        }
+    }
 
     fn open_test_db() -> rusqlite::Connection {
         let conn = rusqlite::Connection::open_in_memory().unwrap();
@@ -5889,19 +5924,17 @@ mod tests {
 
     #[test]
     fn default_restore_stability_max_iters_uses_env_var_when_set() {
-        // Safety: we must reset after the test to avoid polluting other tests.
-        // This sets the env var for this thread only, but note: env is process-global.
-        std::env::set_var("QUAID_RESTORE_STABILITY_MAX_ITERS", "12");
+        let _guard = env_mutation_lock().lock().unwrap();
+        let _env = EnvVarGuard::set("QUAID_RESTORE_STABILITY_MAX_ITERS", "12");
         let value = default_restore_stability_max_iters();
-        std::env::remove_var("QUAID_RESTORE_STABILITY_MAX_ITERS");
         assert_eq!(value, 12);
     }
 
     #[test]
     fn default_restore_stability_max_iters_falls_back_to_default_when_var_is_zero() {
-        std::env::set_var("QUAID_RESTORE_STABILITY_MAX_ITERS", "0");
+        let _guard = env_mutation_lock().lock().unwrap();
+        let _env = EnvVarGuard::set("QUAID_RESTORE_STABILITY_MAX_ITERS", "0");
         let value = default_restore_stability_max_iters();
-        std::env::remove_var("QUAID_RESTORE_STABILITY_MAX_ITERS");
         assert_eq!(value, DEFAULT_RESTORE_STABILITY_MAX_ITERS);
     }
 

--- a/website/src/content/docs/tutorials/install.mdx
+++ b/website/src/content/docs/tutorials/install.mdx
@@ -60,7 +60,7 @@ The installer always grabs the latest release. To pin:
   | QUAID_VERSION=<published-tag> sh`}
 />
 
-Replace `<published-tag>` with a GitHub Release tag. If you need the unreleased `v0.11.0` branch state, build from source instead.
+Replace `<published-tag>` with a GitHub Release tag. If you need the unreleased `v0.12.0` branch state — including Batch 3 `quaid_id` write-back / `migrate-uuids` support for collection-backed vaults — build from source instead.
 
 ## What you got
 


### PR DESCRIPTION
## Summary
- prep the v0.12.0 release truth on the dedicated release branch
- merge this single release-prep commit to `main` before tagging
- no tag is created in this PR lane

## Validation
- existing branch push workflow is running on `release/v0.12.0`
- required merge-gate checks will run on this PR