### PR TITLE
chore: prepare v0.14.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2064,7 +2064,7 @@ dependencies = [
 
 [[package]]
 name = "quaid"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quaid"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "Local-first personal memory. SQLite + FTS5 + local vector embeddings. One static binary."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -86,13 +86,13 @@ Sets up `PATH` and `QUAID_DB` automatically. Use `QUAID_CHANNEL=online` for the 
 ### Download a binary
 
 ```bash
-VERSION="<published-tag>"   # for example: the latest public tag until v0.13.0 is published
+VERSION="<published-tag>"   # for example: the latest public tag until v0.14.0 is published
 PLATFORM="darwin-arm64"   # darwin-arm64 | darwin-x86_64 | linux-x86_64 | linux-aarch64
 curl -fsSL "https://github.com/quaid-app/quaid/releases/download/${VERSION}/quaid-${PLATFORM}-online" \
   -o quaid && chmod +x quaid && sudo mv quaid /usr/local/bin/
 ```
 
-Use a published tag here. This branch is preparing `v0.13.0`, so build from source if you need the unreleased Batch 4 rename-before-commit hardening before the tag exists.
+Use a published tag here. This branch is preparing `v0.14.0`, so build from source if you need the unreleased Batch 5 live-serve single-file `quaid put` proxying and IPC trust-boundary hardening before the tag exists.
 
 ### Build from source
 
@@ -169,7 +169,7 @@ quaid serve
 
 ## MCP tools
 
-The MCP surface stays at 17 tools on this branch and in the current release line. The `v0.13.0` docs pass is about Batch 4 full rename-before-commit hardening — CLI write routing (`quaid put` refuses while serve owns the collection), duplicate write-dedup entry detection (`DuplicateWriteDedupError`), and complete test coverage for all rename-before-commit failure modes — not new tool names:
+The MCP surface stays at 17 tools on this branch and in the current release line. The `v0.14.0` docs pass is about Batch 5 Unix live-write handling — same-root single-file `quaid put` now proxies through a live `quaid serve` owner with authenticated per-session IPC, while bulk rewrites stay offline-only — not new tool names:
 
 | Category | Tools |
 |----------|-------|

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started with Quaid
 
-> Quaid is a local-first personal AI memory layer: SQLite + FTS5 + local vector embeddings in one file. This branch prepares `v0.13.0`: it keeps the 17-tool surface, carries Batches 1–3 vault-sync follow-ons already on `main`, and adds Batch 4 full rename-before-commit hardening for collection-backed vaults.
+> Quaid is a local-first personal AI memory layer: SQLite + FTS5 + local vector embeddings in one file. This branch prepares `v0.14.0`: it keeps the 17-tool surface, carries Batches 1–4 vault-sync follow-ons already on `main`, and adds Batch 5 authenticated live-serve single-file write proxying for collection-backed vaults on Unix.
 
 ## What it does
 
@@ -15,9 +15,9 @@ You search it with full-text keywords and semantic queries. Any MCP-compatible A
 
 ## Status
 
-> **Phase 3 is complete, and the vault-sync line is in Batch 4.** This branch prepares `v0.13.0`: it preserves the current 17-tool surface, keeps Batches 1–3 vault-sync follow-ons already shipped, and adds Batch 4 full rename-before-commit hardening (CLI write routing, duplicate write-dedup entry detection, and complete test coverage for all rename-before-commit failure modes).
+> **Phase 3 is complete, and the vault-sync line is in Batch 5.** This branch prepares `v0.14.0`: it preserves the current 17-tool surface, keeps Batches 1–4 vault-sync follow-ons already shipped, and adds Batch 5 authenticated same-root single-file `quaid put` proxying through a live `quaid serve` owner on Unix, with the reviewed IPC trust boundary and peer-auth checks.
 >
-> Published GitHub Release binaries still come from the latest public tag until the `v0.13.0` workflow completes. See [roadmap.md](roadmap.md) for the full delivery plan.
+> Published GitHub Release binaries still come from the latest public tag until the `v0.14.0` workflow completes. See [roadmap.md](roadmap.md) for the full delivery plan.
 
 ---
 
@@ -25,14 +25,14 @@ You search it with full-text keywords and semantic queries. Any MCP-compatible A
 
 | Method | Status |
 | ------ | ------ |
-| Build from source (`cargo build --release`) | ✅ Available now — source builds reflect this branch, including the Batch 3 UUID write-back / `migrate-uuids` slice |
-| GitHub Release binary (macOS ARM/x86, Linux x86_64/ARM64) | ✅ Available — use the latest published tag until `v0.13.0` is cut |
+| Build from source (`cargo build --release`) | ✅ Available now — source builds reflect this branch, including the Batch 5 same-root `quaid put` live-proxy / IPC-auth slice |
+| GitHub Release binary (macOS ARM/x86, Linux x86_64/ARM64) | ✅ Available — use the latest published tag until `v0.14.0` is cut |
 | `npm install -g quaid` | ❌ Not yet published — use binary release or build from source |
 | One-command curl installer | ✅ Available — airgapped by default; set `QUAID_CHANNEL=online` for online |
 
 > **Configurable BGE models.** The `online` build selects `small` (default), `base`, `large`, or `m3` via `QUAID_MODEL` / `--model`. The `airgapped` build embeds BGE-small-en-v1.5.
 >
-> **Pre-release note.** GitHub Releases downloads and `install.sh` resolve against published tags. Build from source if you need the unreleased `v0.13.0` Batch 4 rename-before-commit hardening before the tag exists.
+> **Pre-release note.** GitHub Releases downloads and `install.sh` resolve against published tags. Build from source if you need the unreleased `v0.14.0` Batch 5 live-serve single-file write proxying before the tag exists.
 
 ---
 
@@ -69,7 +69,7 @@ cross build --release --target aarch64-unknown-linux-musl     # Linux ARM64 (ful
 
 ## Your first memory store
 
-> **Phase 1 commands** are implemented. **Phase 2 commands** (graph, check, gaps) are implemented. **Phase 3 commands** (validate, call, pipe, skills) are implemented. Build from source to use the full branch state described below before `v0.13.0` is published; see [Status](#status) and [Install options](#install-options) above.
+> **Phase 1 commands** are implemented. **Phase 2 commands** (graph, check, gaps) are implemented. **Phase 3 commands** (validate, call, pipe, skills) are implemented. Build from source to use the full branch state described below before `v0.14.0` is published; see [Status](#status) and [Install options](#install-options) above.
 
 > **Post-install note:** The shell installer (`scripts/install.sh`) automatically adds `PATH` and `QUAID_DB` to your shell profile. If you built from source or used the manual GitHub Releases download, add these to your profile yourself:
 > ```bash
@@ -101,7 +101,7 @@ Quaid ingests each markdown file, parses frontmatter, splits compiled-truth from
 > quaid serve
 > ```
 >
-> Use `quaid import` for one-shot bulk ingest. Use collections when you want Quaid to stay in sync with a markdown or Obsidian vault. On Unix, Batch 3 also lets you persist missing `quaid_id` frontmatter during attach (`quaid collection add <name> <path> --write-quaid-id`) or backfill it later with `quaid collection migrate-uuids <name> [--dry-run]`. For an OpenClaw setup, see [openclaw-harness.md](openclaw-harness.md).
+> Use `quaid import` for one-shot bulk ingest. Use collections when you want Quaid to stay in sync with a markdown or Obsidian vault. On Unix, Batch 3 lets you persist missing `quaid_id` frontmatter during attach (`quaid collection add <name> <path> --write-quaid-id`) or backfill it later with `quaid collection migrate-uuids <name> [--dry-run]`. Batch 5 additionally upgrades same-root single-file `quaid put` so the CLI authenticates the live `quaid serve` owner and proxies the write instead of refusing; bulk rewrite flows still stay offline-only. For an OpenClaw setup, see [openclaw-harness.md](openclaw-harness.md).
 
 ### 3. Search
 
@@ -192,7 +192,7 @@ The MCP server exposes tools over stdio JSON-RPC 2.0.
 
 **vault-sync tools:** `memory_collections` — read-only per-collection status including state, ignore diagnostics, recovery flags, and embedding queue health
 
-All 17 tools remain live on this branch and in the current release line. Batch 3 adds UUID identity hardening for collection-backed vaults — opt-in `--write-quaid-id`, offline `migrate-uuids`, and `memory_put` preserving existing `quaid_id` frontmatter — not new MCP tool names. See [spec.md](spec.md#mcp-server) for tool signatures.
+All 17 tools remain live on this branch and in the current release line. The `v0.14.0` slice keeps the tool names stable while carrying Batch 3 UUID identity hardening, Batch 4 rename-before-commit completion, and Batch 5 authenticated same-root single-file `quaid put` proxying on Unix. See [spec.md](spec.md#mcp-server) for tool signatures.
 
 ---
 
@@ -403,7 +403,7 @@ quaid skills doctor   # verify SHA-256 hashes, detect override shadowing
 
 ## vault-sync-engine: Collections and live-sync
 
-> These commands first shipped in `v0.9.6`. This branch carries the `v0.13.0` follow-on: Batches 1–3 vault-sync follow-ons stay in place, while Batch 4 adds CLI write routing (`quaid put` refuses while serve owns the collection), duplicate write-dedup entry detection, and complete rename-before-commit failure mode test coverage.
+> These commands first shipped in `v0.9.6`. This branch carries the `v0.14.0` follow-on: Batches 1–4 vault-sync follow-ons stay in place, while Batch 5 upgrades same-root single-file `quaid put` to proxy through the live serve owner over authenticated per-session IPC on Unix. Bulk rewrites still refuse and stay offline-only.
 
 ### Attach a vault
 
@@ -429,7 +429,7 @@ In this release line, `quaid collection info` also surfaces `queue_depth` and `f
 
 Once attached, `quaid serve` starts a file watcher for the collection. Changes you make in Obsidian or any editor are debounced over 1.5 s and flushed via the stat-diff reconciler.
 
-Collection attach and other filesystem-mutating collection operations in this release line are Unix-only, including `quaid collection add`, `quaid collection migrate-uuids`, and `quaid collection add --write-quaid-id`. These offline rewrite flows refuse when `quaid serve` already owns the collection, so stop `serve`, run the migration or attach step offline, then restart.
+Collection attach and other filesystem-mutating collection operations in this release line are Unix-only, including `quaid collection add`, `quaid collection migrate-uuids`, and `quaid collection add --write-quaid-id`. These offline rewrite flows refuse when `quaid serve` already owns the collection, so stop `serve`, run the migration or attach step offline, then restart. Single-file `quaid put` is the Batch 5 exception: when a same-root Unix `quaid serve` owner is live, the CLI authenticates that serve session over the published per-session socket and proxies the write instead of refusing.
 
 > **Platform note.** `quaid serve` and the core MCP tools are cross-platform. Live vault-sync watcher threads start only on Unix (macOS / Linux); on Windows `quaid serve` starts the MCP server normally but watcher-backed auto-reconcile is not active. The MCP read/write tools (`memory_get`, `memory_put`, `memory_query`, etc.) work on all platforms.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -164,6 +164,7 @@ These are known design choices that are _not_ oversights:
 | `v0.11.0` | Batch 2 embedding worker: background queue drain, retry/resume handling, `embedding_queue_depth` in `memory_collections`, and `failing_jobs` in `quaid collection info` |
 | `v0.12.0` | Batch 3 UUID identity hardening: opt-in `--write-quaid-id`, offline `quaid collection migrate-uuids [--dry-run]`, UUID-migration preflight before restore/remap, and `memory_put` preserving `quaid_id` |
 | `v0.13.0` | Batch 4 full rename-before-commit hardening: CLI write routing (`quaid put` refuses while serve owns the collection), `DuplicateWriteDedupError` on concurrent dedup collision, and complete test coverage for all 13-step rename-before-commit failure modes |
+| `v0.14.0` | Batch 5 live-serve single-file write proxying: same-root `quaid put` now authenticates and proxies through the serve-owned per-session IPC socket, while bulk rewrite flows remain offline-only |
 
 ---
 
@@ -187,6 +188,7 @@ Adds vault-as-collection attachment, a file watcher, a stat-diff reconciler, qua
 - **Write-through `memory_put`** *(Unix)* — full rename-before-commit sequence (recovery sentinel → tempfile → `renameat` → fsync parent dir → single SQLite tx); mandatory `expected_version` for updates; `check_fs_precondition` four-field CAS
 - **UUID identity hardening** *(Unix write surface)* — `quaid collection add --write-quaid-id` can persist missing `quaid_id` frontmatter during first attach, `quaid collection migrate-uuids <name> [--dry-run]` backfills it later offline, restore/remap preflights now fail closed with `UuidMigrationRequiredError` when trivial-content notes still lack frontmatter IDs, and `memory_put` preserves existing `quaid_id` on write
 - **Write interlock** — `state='restoring'` or `needs_full_sync=1` blocks all mutating CLI/MCP ops with `CollectionRestoringError`
+- **Authenticated CLI live-write proxy** *(Unix single-file `quaid put`)* — same-root live-owner writes now route through a per-session UNIX socket published by `quaid serve`; the CLI verifies socket mode/ownership plus kernel peer UID/PID before forwarding, and collection-wide rewrite flows still refuse with `ServeOwnsCollectionError`
 - **Offline restore** — `quaid collection restore <name> <target>` → Tx-A → atomic rename → Tx-B; `sync --finalize-pending` drives full-hash reconcile and reopens writes
 - **`memory_collections` MCP tool** — frozen 13-field per-collection object; truthful state, recovery, and ignore-diagnostic surfacing (17 MCP tools total)
 - **Collection filter** — `memory_search`, `memory_query`, `memory_list` accept an optional `collection` filter; default to the sole active collection when exactly one exists
@@ -197,7 +199,7 @@ Adds vault-as-collection attachment, a file watcher, a stat-diff reconciler, qua
 | Item | Why deferred |
 | ---- | ------------ |
 | Windows `quarantine restore`, IPC socket restore proxying, and online restore handshake | The narrow Unix restore seam shipped in `v0.9.6`; non-Unix restore hosting and live-handshake routing remain deferred |
-| IPC socket write proxying (`12.6*`) | Full trust-boundary design for `SO_PEERCRED` peer auth still in progress |
+| Bulk rewrite proxying beyond single-file `quaid put` | Batch 5 proxies only the single-file CLI write path; collection-wide rewrites such as `migrate-uuids` and `--write-quaid-id` still refuse when a live serve owner exists |
 | Per-event-type watcher handlers (`6.5–6.11`) | Create/Modify/Delete/Rename handlers; overflow recovery, `.quaidignore` live reload, and watcher supervisor not yet wired |
 | `quaid collection remove` | Detach + optional purge not yet implemented |
 | `quaid stats` per-collection augmentation | Per-collection row + aggregate totals pending |


### PR DESCRIPTION
## Summary
- bump the crate version and lockfile from 0.13.0 to 0.14.0
- refresh README/getting-started/roadmap copy for the merged Batch 5 state
- leave release workflow and checklist untouched because they are already evergreen

## Validation
- cargo check --quiet
- cargo test --quiet

## Release lane
- verified remote tag `v0.14.0` does not exist
- verified GitHub release `v0.14.0` does not exist
- do not tag or publish the release from this PR