### PR TITLE
fix: align v0.15.0 release truth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2064,7 +2064,7 @@ dependencies = [
 
 [[package]]
 name = "quaid"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quaid"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 description = "Local-first personal memory. SQLite + FTS5 + local vector embeddings. One static binary."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -86,13 +86,13 @@ Sets up `PATH` and `QUAID_DB` automatically. Use `QUAID_CHANNEL=online` for the 
 ### Download a binary
 
 ```bash
-VERSION="<published-tag>"   # for example: the latest public tag until v0.14.0 is published
+VERSION="<published-tag>"   # for example: the latest public tag until v0.15.0 is published
 PLATFORM="darwin-arm64"   # darwin-arm64 | darwin-x86_64 | linux-x86_64 | linux-aarch64
 curl -fsSL "https://github.com/quaid-app/quaid/releases/download/${VERSION}/quaid-${PLATFORM}-online" \
   -o quaid && chmod +x quaid && sudo mv quaid /usr/local/bin/
 ```
 
-Use a published tag here. This branch is preparing `v0.14.0`, so build from source if you need the unreleased Batch 5 live-serve single-file `quaid put` proxying and IPC trust-boundary hardening before the tag exists.
+Use a published tag here. This branch is preparing `v0.15.0`, so build from source if you need the unreleased Batch 5 live-serve single-file `quaid put` proxying and IPC trust-boundary hardening before the tag exists.
 
 ### Build from source
 
@@ -169,7 +169,7 @@ quaid serve
 
 ## MCP tools
 
-The MCP surface stays at 17 tools on this branch and in the current release line. The `v0.14.0` docs pass is about Batch 5 Unix live-write handling — same-root single-file `quaid put` now proxies through a live `quaid serve` owner with authenticated per-session IPC, while bulk rewrites stay offline-only — not new tool names:
+The MCP surface stays at 17 tools on this branch and in the current release line. The `v0.15.0` docs pass is about Batch 5 Unix live-write handling — same-root single-file `quaid put` now proxies through a live `quaid serve` owner with authenticated per-session IPC, while bulk rewrites stay offline-only — not new tool names:
 
 | Category | Tools |
 |----------|-------|

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started with Quaid
 
-> Quaid is a local-first personal AI memory layer: SQLite + FTS5 + local vector embeddings in one file. This branch prepares `v0.14.0`: it keeps the 17-tool surface, carries Batches 1–4 vault-sync follow-ons already on `main`, and adds Batch 5 authenticated live-serve single-file write proxying for collection-backed vaults on Unix.
+> Quaid is a local-first personal AI memory layer: SQLite + FTS5 + local vector embeddings in one file. This branch prepares `v0.15.0`: it keeps the 17-tool surface, carries Batches 1–4 vault-sync follow-ons already on `main`, and adds Batch 5 authenticated live-serve single-file write proxying for collection-backed vaults on Unix.
 
 ## What it does
 
@@ -15,9 +15,9 @@ You search it with full-text keywords and semantic queries. Any MCP-compatible A
 
 ## Status
 
-> **Phase 3 is complete, and the vault-sync line is in Batch 5.** This branch prepares `v0.14.0`: it preserves the current 17-tool surface, keeps Batches 1–4 vault-sync follow-ons already shipped, and adds Batch 5 authenticated same-root single-file `quaid put` proxying through a live `quaid serve` owner on Unix, with the reviewed IPC trust boundary and peer-auth checks.
+> **Phase 3 is complete, and the vault-sync line is in Batch 5.** This branch prepares `v0.15.0`: it preserves the current 17-tool surface, keeps Batches 1–4 vault-sync follow-ons already shipped, and adds Batch 5 authenticated same-root single-file `quaid put` proxying through a live `quaid serve` owner on Unix, with the reviewed IPC trust boundary and peer-auth checks.
 >
-> Published GitHub Release binaries still come from the latest public tag until the `v0.14.0` workflow completes. See [roadmap.md](roadmap.md) for the full delivery plan.
+> Published GitHub Release binaries still come from the latest public tag until the `v0.15.0` workflow completes. See [roadmap.md](roadmap.md) for the full delivery plan.
 
 ---
 
@@ -26,13 +26,13 @@ You search it with full-text keywords and semantic queries. Any MCP-compatible A
 | Method | Status |
 | ------ | ------ |
 | Build from source (`cargo build --release`) | ✅ Available now — source builds reflect this branch, including the Batch 5 same-root `quaid put` live-proxy / IPC-auth slice |
-| GitHub Release binary (macOS ARM/x86, Linux x86_64/ARM64) | ✅ Available — use the latest published tag until `v0.14.0` is cut |
+| GitHub Release binary (macOS ARM/x86, Linux x86_64/ARM64) | ✅ Available — use the latest published tag until `v0.15.0` is cut |
 | `npm install -g quaid` | ❌ Not yet published — use binary release or build from source |
 | One-command curl installer | ✅ Available — airgapped by default; set `QUAID_CHANNEL=online` for online |
 
 > **Configurable BGE models.** The `online` build selects `small` (default), `base`, `large`, or `m3` via `QUAID_MODEL` / `--model`. The `airgapped` build embeds BGE-small-en-v1.5.
 >
-> **Pre-release note.** GitHub Releases downloads and `install.sh` resolve against published tags. Build from source if you need the unreleased `v0.14.0` Batch 5 live-serve single-file write proxying before the tag exists.
+> **Pre-release note.** GitHub Releases downloads and `install.sh` resolve against published tags. Build from source if you need the unreleased `v0.15.0` Batch 5 live-serve single-file write proxying before the tag exists.
 
 ---
 
@@ -69,7 +69,7 @@ cross build --release --target aarch64-unknown-linux-musl     # Linux ARM64 (ful
 
 ## Your first memory store
 
-> **Phase 1 commands** are implemented. **Phase 2 commands** (graph, check, gaps) are implemented. **Phase 3 commands** (validate, call, pipe, skills) are implemented. Build from source to use the full branch state described below before `v0.14.0` is published; see [Status](#status) and [Install options](#install-options) above.
+> **Phase 1 commands** are implemented. **Phase 2 commands** (graph, check, gaps) are implemented. **Phase 3 commands** (validate, call, pipe, skills) are implemented. Build from source to use the full branch state described below before `v0.15.0` is published; see [Status](#status) and [Install options](#install-options) above.
 
 > **Post-install note:** The shell installer (`scripts/install.sh`) automatically adds `PATH` and `QUAID_DB` to your shell profile. If you built from source or used the manual GitHub Releases download, add these to your profile yourself:
 > ```bash
@@ -192,7 +192,7 @@ The MCP server exposes tools over stdio JSON-RPC 2.0.
 
 **vault-sync tools:** `memory_collections` — read-only per-collection status including state, ignore diagnostics, recovery flags, and embedding queue health
 
-All 17 tools remain live on this branch and in the current release line. The `v0.14.0` slice keeps the tool names stable while carrying Batch 3 UUID identity hardening, Batch 4 rename-before-commit completion, and Batch 5 authenticated same-root single-file `quaid put` proxying on Unix. See [spec.md](spec.md#mcp-server) for tool signatures.
+All 17 tools remain live on this branch and in the current release line. The `v0.15.0` slice keeps the tool names stable while carrying Batch 3 UUID identity hardening, Batch 4 rename-before-commit completion, and Batch 5 authenticated same-root single-file `quaid put` proxying on Unix. See [spec.md](spec.md#mcp-server) for tool signatures.
 
 ---
 
@@ -403,7 +403,7 @@ quaid skills doctor   # verify SHA-256 hashes, detect override shadowing
 
 ## vault-sync-engine: Collections and live-sync
 
-> These commands first shipped in `v0.9.6`. This branch carries the `v0.14.0` follow-on: Batches 1–4 vault-sync follow-ons stay in place, while Batch 5 upgrades same-root single-file `quaid put` to proxy through the live serve owner over authenticated per-session IPC on Unix. Bulk rewrites still refuse and stay offline-only.
+> These commands first shipped in `v0.9.6`. This branch carries the `v0.15.0` follow-on: Batches 1–4 vault-sync follow-ons stay in place, while Batch 5 upgrades same-root single-file `quaid put` to proxy through the live serve owner over authenticated per-session IPC on Unix. Bulk rewrites still refuse and stay offline-only.
 
 ### Attach a vault
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -164,7 +164,7 @@ These are known design choices that are _not_ oversights:
 | `v0.11.0` | Batch 2 embedding worker: background queue drain, retry/resume handling, `embedding_queue_depth` in `memory_collections`, and `failing_jobs` in `quaid collection info` |
 | `v0.12.0` | Batch 3 UUID identity hardening: opt-in `--write-quaid-id`, offline `quaid collection migrate-uuids [--dry-run]`, UUID-migration preflight before restore/remap, and `memory_put` preserving `quaid_id` |
 | `v0.13.0` | Batch 4 full rename-before-commit hardening: CLI write routing (`quaid put` refuses while serve owns the collection), `DuplicateWriteDedupError` on concurrent dedup collision, and complete test coverage for all 13-step rename-before-commit failure modes |
-| `v0.14.0` | Batch 5 live-serve single-file write proxying: same-root `quaid put` now authenticates and proxies through the serve-owned per-session IPC socket, while bulk rewrite flows remain offline-only |
+| `v0.15.0` | Batch 5 live-serve single-file write proxying: same-root `quaid put` now authenticates and proxies through the serve-owned per-session IPC socket, while bulk rewrite flows remain offline-only |
 
 ---
 


### PR DESCRIPTION
## Summary
- bump the crate version metadata from 0.14.0 to 0.15.0
- update the lockfile package entry to match the release lane
- refresh the release-facing docs that still claimed this branch was preparing v0.14.0

## Validation
- cargo run --quiet -- version
- cargo test --locked --quiet