### PR TITLE
chore: bump version to 0.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2064,7 +2064,7 @@ dependencies = [
 
 [[package]]
 name = "quaid"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quaid"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "Local-first personal memory. SQLite + FTS5 + local vector embeddings. One static binary."
 license = "MIT"


### PR DESCRIPTION
Version bump for v0.16.0 release. Namespace isolation (#137) is the main feature in this release.