### PR TITLE
chore: bump version to 0.17.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2064,7 +2064,7 @@ dependencies = [
 
 [[package]]
 name = "quaid"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quaid"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 description = "Local-first personal memory. SQLite + FTS5 + local vector embeddings. One static binary."
 license = "MIT"


### PR DESCRIPTION
Version bump for v0.17.0 release.

Main feature in this release: vault sync Batch 7 (PR #144) - completes the vault-sync-engine spec end-state including removal of `quaid import` (replaced by `quaid collection add`).

Follow-up bug fix tracked in fix/cli-namespace-search (issue #145 - CLI namespace search filter).