### PR TITLE
fix(namespace): add CLI regression test for --namespace search filter (#145)

### DIFF
--- a/openspec/changes/fix-cli-namespace-search/.openspec.yaml
+++ b/openspec/changes/fix-cli-namespace-search/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-03

--- a/openspec/changes/fix-cli-namespace-search/design.md
+++ b/openspec/changes/fix-cli-namespace-search/design.md
@@ -1,0 +1,136 @@
+## Context
+
+The existing `namespace-isolation` OpenSpec added namespace filtering across read paths and
+states that omitted CLI/MCP namespace reads default to global-only. GitHub issue #145 shows
+that `quaid search --namespace workns "bitcoin"` can still leak results from unrelated
+namespaces.
+
+`quaid search` is an FTS5-only command. It does not initialize embeddings and should not
+depend on the airgapped vs online model channel. Both release channels compile the same
+`src/main.rs`, `src/commands/search.rs`, and `src/core/fts.rs` search filtering path.
+
+## Call Chain
+
+### CLI dispatch
+
+`src/main.rs` defines:
+
+```rust
+Commands::Search {
+    query,
+    wing,
+    namespace,
+    limit,
+    raw,
+}
+```
+
+The dispatch must pass a concrete read scope into the command layer:
+
+```rust
+commands::search::run(
+    &db,
+    &query,
+    wing,
+    namespace.as_deref().or(Some("")),
+    limit,
+    cli.json,
+    raw,
+)
+```
+
+This means:
+
+- omitted `--namespace` becomes `Some("")`
+- `--namespace workns` becomes `Some("workns")`
+- the CLI does not pass `None` for read searches
+
+### Command layer
+
+`src/commands/search.rs::run()` must validate and preserve that namespace:
+
+```rust
+crate::core::namespace::validate_optional_namespace(namespace)?;
+let namespace = namespace.or(Some(""));
+```
+
+Then it must call namespace-aware helpers in both modes:
+
+```rust
+if raw {
+    search_fts_canonical_with_namespace(..., namespace, db, ...)
+} else {
+    search_fts_canonical_tiered_with_namespace(..., namespace, db, ...)
+}
+```
+
+The bug exists if either branch calls a non-namespace helper or passes `None` after the CLI
+provided `Some("workns")`.
+
+### Core FTS helper
+
+`src/core/fts.rs::search_fts_canonical_with_namespace()` delegates to
+`search_fts_internal(..., canonical_slug = true)`. The SQL builder must apply these exact
+semantics:
+
+```rust
+if let Some(namespace) = namespace_filter {
+    if namespace.is_empty() {
+        sql.push_str(" AND p.namespace = ?");
+        params.push(Box::new(String::new()));
+    } else {
+        sql.push_str(" AND (p.namespace = ?");
+        sql.push_str(&(params.len() + 1).to_string());
+        sql.push_str(" OR p.namespace = '')");
+        params.push(Box::new(namespace.to_owned()));
+    }
+}
+```
+
+That produces the effective predicate:
+
+- global-only: `p.namespace = ''`
+- explicit namespace: `(p.namespace = 'workns' OR p.namespace = '')`
+- all namespaces: no predicate, only when an internal caller deliberately passes `None`
+
+The implementation should keep the parameterized SQL shape rather than interpolating the
+namespace value into SQL text.
+
+## Test Design
+
+Add one subprocess integration test using the real `quaid` binary:
+
+1. Create a temp database.
+2. Insert three FTS-visible pages containing the same unique term, for example `bitcoin`:
+   - `namespace = ''`, slug `notes/global-bitcoin`
+   - `namespace = 'workns'`, slug `notes/work-bitcoin`
+   - `namespace = 'otherns'`, slug `notes/other-bitcoin`
+3. Run `quaid --db <db> --json search --namespace workns bitcoin`.
+4. Assert stdout is valid JSON.
+5. Assert result slugs include the global and `workns` pages.
+6. Assert result slugs do not include the `otherns` page.
+7. Run `quaid --db <db> --json search bitcoin`.
+8. Assert omitted namespace returns only the global page.
+
+This test catches the exact issue #145 CLI surface, including `src/main.rs` dispatch,
+`src/commands/search.rs` normalization, query sanitization/tiered FTS fallback, and the
+core FTS SQL predicate.
+
+## Airgapped vs Online
+
+There should be no behavioral difference between airgapped and online binaries for this
+bug. `quaid search` uses FTS5 helpers and does not call embedding inference. The
+`embedded-model` and `online-model` feature gates live in `src/core/inference.rs`; they do
+not conditionalize `src/commands/search.rs` or `src/core/fts.rs`.
+
+Validation should include the default feature set at minimum. If CI has an online-channel
+job, the same CLI integration test should run there as part of the normal test matrix, but
+the code fix itself is shared.
+
+## Non-Goals
+
+- No change to MCP `memory_search` unless the same regression is found there.
+- No change to `quaid query`; it uses hybrid search and already carries namespace through
+  `hybrid_search_canonical_with_namespace`.
+- No schema migration.
+- No new all-namespace CLI mode.

--- a/openspec/changes/fix-cli-namespace-search/proposal.md
+++ b/openspec/changes/fix-cli-namespace-search/proposal.md
@@ -1,0 +1,74 @@
+---
+id: fix-cli-namespace-search
+title: "Fix CLI namespace filtering for quaid search"
+status: proposed
+type: bugfix
+owner: doug
+reviewers: []
+created: 2026-05-03
+closes: ["#145"]
+---
+
+# Fix CLI namespace filtering for quaid search
+
+## Why
+
+GitHub issue #145 reports that `quaid search --namespace workns "bitcoin"` returns pages
+from every namespace instead of only pages from namespace `workns` plus global pages in
+namespace `""`.
+
+This violates the completed `openspec/changes/namespace-isolation/` contract. That change
+explicitly says omitted CLI/MCP namespace reads default to global-only, while explicit
+namespace reads include only the requested namespace and global pages. `search` is one of
+the commands that namespace-isolation added `--namespace` to, so its behavior must match
+`query`, `get`, and `list`.
+
+The high-risk gap is the CLI search path:
+
+1. `src/main.rs` parses `Search { namespace, .. }`.
+2. `src/main.rs` calls `commands::search::run(..., namespace.as_deref().or(Some("")), ...)`.
+3. `src/commands/search.rs::run()` validates and normalizes the namespace, then calls the
+   FTS5 canonical helpers.
+4. `src/core/fts.rs::search_fts_canonical_with_namespace()` and
+   `search_fts_canonical_tiered_with_namespace()` must append the namespace predicate.
+
+If any step passes `None` for an explicit namespace, the core FTS helper intentionally
+performs an unfiltered search across all namespaces. That is useful for internal callers,
+but it is not the CLI read default or explicit CLI namespace behavior.
+
+## What Changes
+
+- Preserve the CLI contract that `quaid search --namespace <id> <query>` passes
+  `Some("<id>")` to the FTS5 namespace-aware helper.
+- Preserve the omitted CLI contract that `quaid search <query>` passes `Some("")`, not
+  `None`, so omitted namespace means global-only rather than all namespaces.
+- Ensure both default sanitized search and `--raw` search use namespace-aware canonical
+  helper functions:
+  - sanitized path: `search_fts_canonical_tiered_with_namespace`
+  - raw path: `search_fts_canonical_with_namespace`
+- Ensure `search_fts_canonical_with_namespace` implements:
+  - `namespace = ""`: `AND p.namespace = ?`
+  - `namespace = "workns"`: `AND (p.namespace = ? OR p.namespace = '')`
+  - `namespace = None`: no namespace predicate, reserved for deliberate all-namespace
+    internal calls
+- Add a CLI integration regression test that reproduces issue #145 with three matching
+  pages: global, requested namespace, and unrelated namespace.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `namespace-isolation`: `quaid search --namespace <id>` filters FTS5 results to the
+  requested namespace plus global pages, and omitted `--namespace` remains global-only.
+
+## Impact
+
+- `src/commands/search.rs`: audit and fix namespace normalization and helper selection if
+  it regressed.
+- `src/core/fts.rs`: audit and fix namespace predicate construction if needed.
+- `tests/search_hardening.rs` or `tests/namespace_isolation.rs`: add a CLI integration
+  regression test for issue #145.
+- No schema changes.
+- No release-channel-specific behavior: airgapped and online binaries compile the same
+  CLI and FTS5 namespace filtering code. The model feature flags only affect embedding
+  loading and vector search, not `quaid search`.

--- a/openspec/changes/fix-cli-namespace-search/proposal.md
+++ b/openspec/changes/fix-cli-namespace-search/proposal.md
@@ -77,7 +77,6 @@ but it is not the CLI read default or explicit CLI namespace behavior.
 
 - GitHub issue #145 (the bug this fixes)
 - GitHub issue #146 (closed: `quaid import --namespace` missing flag) — **moot** as of
-  vault-sync Batch 7 (PR #144), which removed `src/commands/import.rs`. Pages are now
-  added via `quaid collection add`, which already has `--namespace` support.
-  The removal of `quaid import` is a breaking CLI change that should be retroactively
-  specced under the vault-sync-engine change or a new standalone spec.
+  vault-sync Batch 7 (PR #144), which removed `src/commands/import.rs`. This removal is
+  covered by the `vault-sync-engine` OpenSpec (§15 / end-state: `quaid import` is removed,
+  `quaid collection add` is the supported ingest surface). No retroactive spec needed.

--- a/openspec/changes/fix-cli-namespace-search/proposal.md
+++ b/openspec/changes/fix-cli-namespace-search/proposal.md
@@ -72,3 +72,12 @@ but it is not the CLI read default or explicit CLI namespace behavior.
 - No release-channel-specific behavior: airgapped and online binaries compile the same
   CLI and FTS5 namespace filtering code. The model feature flags only affect embedding
   loading and vector search, not `quaid search`.
+
+## Related
+
+- GitHub issue #145 (the bug this fixes)
+- GitHub issue #146 (closed: `quaid import --namespace` missing flag) — **moot** as of
+  vault-sync Batch 7 (PR #144), which removed `src/commands/import.rs`. Pages are now
+  added via `quaid collection add`, which already has `--namespace` support.
+  The removal of `quaid import` is a breaking CLI change that should be retroactively
+  specced under the vault-sync-engine change or a new standalone spec.

--- a/openspec/changes/fix-cli-namespace-search/tasks.md
+++ b/openspec/changes/fix-cli-namespace-search/tasks.md
@@ -1,0 +1,56 @@
+# Tasks
+
+## 1. Reproduce and confirm the bug
+
+- [ ] 1.1 Add a failing CLI integration test for issue #145 with matching pages in global,
+  `workns`, and `otherns`.
+- [ ] 1.2 Assert `quaid --json search --namespace workns bitcoin` returns only global plus
+  `workns` pages.
+- [ ] 1.3 Assert `quaid --json search bitcoin` returns only global pages when `--namespace`
+  is omitted.
+- [ ] 1.4 Run the new test before the fix and confirm it fails if the issue is present on
+  the implementation branch.
+
+## 2. Fix CLI search namespace propagation
+
+- [ ] 2.1 Inspect `src/main.rs` search dispatch and ensure it passes
+  `namespace.as_deref().or(Some(""))` to `commands::search::run`.
+- [ ] 2.2 Inspect `src/commands/search.rs::run()` and ensure it validates the original
+  namespace input before normalization.
+- [ ] 2.3 Ensure `src/commands/search.rs::run()` normalizes omitted namespace with
+  `let namespace = namespace.or(Some(""));`.
+- [ ] 2.4 Ensure the sanitized path calls `search_fts_canonical_tiered_with_namespace`
+  with that normalized namespace.
+- [ ] 2.5 Ensure the `--raw` path calls `search_fts_canonical_with_namespace` with that
+  normalized namespace.
+- [ ] 2.6 Remove or replace any non-namespace FTS helper call in the CLI search path.
+
+## 3. Verify core FTS predicate
+
+- [ ] 3.1 Inspect `src/core/fts.rs::search_fts_internal()`.
+- [ ] 3.2 Confirm `Some("")` appends `AND p.namespace = ?` with an empty-string parameter.
+- [ ] 3.3 Confirm `Some("workns")` appends `AND (p.namespace = ? OR p.namespace = '')`.
+- [ ] 3.4 Confirm `None` appends no namespace predicate and remains an internal
+  all-namespace mode only.
+- [ ] 3.5 Add or update a focused unit test for
+  `search_fts_canonical_with_namespace` if the CLI integration test does not make the
+  failing branch obvious.
+
+## 4. Release-channel check
+
+- [ ] 4.1 Confirm no `embedded-model` or `online-model` cfg affects `src/main.rs`,
+  `src/commands/search.rs`, or `src/core/fts.rs`.
+- [ ] 4.2 Run the regression test under the default airgapped feature set.
+- [ ] 4.3 If CI supports the online feature set, run the same test with
+  `--no-default-features --features bundled,online-model`.
+- [ ] 4.4 Document that airgapped and online binaries share the same FTS namespace filter
+  code path for `quaid search`.
+
+## 5. Verification
+
+- [ ] 5.1 Run `cargo fmt --all --check`.
+- [ ] 5.2 Run the new CLI namespace search integration test.
+- [ ] 5.3 Run `cargo test` or the closest available namespace/search test subset.
+- [ ] 5.4 Manually verify:
+  `quaid --db <temp.db> --json search --namespace workns bitcoin`.
+- [ ] 5.5 Close GitHub issue #145 after the fix lands.

--- a/openspec/changes/fix-cli-namespace-search/tasks.md
+++ b/openspec/changes/fix-cli-namespace-search/tasks.md
@@ -2,55 +2,55 @@
 
 ## 1. Reproduce and confirm the bug
 
-- [ ] 1.1 Add a failing CLI integration test for issue #145 with matching pages in global,
+- [x] 1.1 Add a failing CLI integration test for issue #145 with matching pages in global,
   `workns`, and `otherns`.
-- [ ] 1.2 Assert `quaid --json search --namespace workns bitcoin` returns only global plus
+- [x] 1.2 Assert `quaid --json search --namespace workns bitcoin` returns only global plus
   `workns` pages.
-- [ ] 1.3 Assert `quaid --json search bitcoin` returns only global pages when `--namespace`
+- [x] 1.3 Assert `quaid --json search bitcoin` returns only global pages when `--namespace`
   is omitted.
 - [ ] 1.4 Run the new test before the fix and confirm it fails if the issue is present on
   the implementation branch.
 
 ## 2. Fix CLI search namespace propagation
 
-- [ ] 2.1 Inspect `src/main.rs` search dispatch and ensure it passes
+- [x] 2.1 Inspect `src/main.rs` search dispatch and ensure it passes
   `namespace.as_deref().or(Some(""))` to `commands::search::run`.
-- [ ] 2.2 Inspect `src/commands/search.rs::run()` and ensure it validates the original
+- [x] 2.2 Inspect `src/commands/search.rs::run()` and ensure it validates the original
   namespace input before normalization.
-- [ ] 2.3 Ensure `src/commands/search.rs::run()` normalizes omitted namespace with
+- [x] 2.3 Ensure `src/commands/search.rs::run()` normalizes omitted namespace with
   `let namespace = namespace.or(Some(""));`.
-- [ ] 2.4 Ensure the sanitized path calls `search_fts_canonical_tiered_with_namespace`
+- [x] 2.4 Ensure the sanitized path calls `search_fts_canonical_tiered_with_namespace`
   with that normalized namespace.
-- [ ] 2.5 Ensure the `--raw` path calls `search_fts_canonical_with_namespace` with that
+- [x] 2.5 Ensure the `--raw` path calls `search_fts_canonical_with_namespace` with that
   normalized namespace.
-- [ ] 2.6 Remove or replace any non-namespace FTS helper call in the CLI search path.
+- [x] 2.6 Remove or replace any non-namespace FTS helper call in the CLI search path.
 
 ## 3. Verify core FTS predicate
 
-- [ ] 3.1 Inspect `src/core/fts.rs::search_fts_internal()`.
-- [ ] 3.2 Confirm `Some("")` appends `AND p.namespace = ?` with an empty-string parameter.
-- [ ] 3.3 Confirm `Some("workns")` appends `AND (p.namespace = ? OR p.namespace = '')`.
-- [ ] 3.4 Confirm `None` appends no namespace predicate and remains an internal
+- [x] 3.1 Inspect `src/core/fts.rs::search_fts_internal()`.
+- [x] 3.2 Confirm `Some("")` appends `AND p.namespace = ?` with an empty-string parameter.
+- [x] 3.3 Confirm `Some("workns")` appends `AND (p.namespace = ? OR p.namespace = '')`.
+- [x] 3.4 Confirm `None` appends no namespace predicate and remains an internal
   all-namespace mode only.
-- [ ] 3.5 Add or update a focused unit test for
+- [x] 3.5 Add or update a focused unit test for
   `search_fts_canonical_with_namespace` if the CLI integration test does not make the
   failing branch obvious.
 
 ## 4. Release-channel check
 
-- [ ] 4.1 Confirm no `embedded-model` or `online-model` cfg affects `src/main.rs`,
+- [x] 4.1 Confirm no `embedded-model` or `online-model` cfg affects `src/main.rs`,
   `src/commands/search.rs`, or `src/core/fts.rs`.
-- [ ] 4.2 Run the regression test under the default airgapped feature set.
+- [x] 4.2 Run the regression test under the default airgapped feature set.
 - [ ] 4.3 If CI supports the online feature set, run the same test with
   `--no-default-features --features bundled,online-model`.
-- [ ] 4.4 Document that airgapped and online binaries share the same FTS namespace filter
+- [x] 4.4 Document that airgapped and online binaries share the same FTS namespace filter
   code path for `quaid search`.
 
 ## 5. Verification
 
-- [ ] 5.1 Run `cargo fmt --all --check`.
-- [ ] 5.2 Run the new CLI namespace search integration test.
-- [ ] 5.3 Run `cargo test` or the closest available namespace/search test subset.
-- [ ] 5.4 Manually verify:
+- [x] 5.1 Run `cargo fmt --all --check`.
+- [x] 5.2 Run the new CLI namespace search integration test.
+- [x] 5.3 Run `cargo test` or the closest available namespace/search test subset.
+- [x] 5.4 Manually verify:
   `quaid --db <temp.db> --json search --namespace workns bitcoin`.
 - [ ] 5.5 Close GitHub issue #145 after the fix lands.

--- a/tests/search_hardening.rs
+++ b/tests/search_hardening.rs
@@ -14,11 +14,23 @@ fn open_test_db(path: &Path) -> Connection {
 }
 
 fn insert_page(conn: &Connection, slug: &str, page_type: &str, title: &str, summary: &str) {
+    insert_page_with_namespace(conn, "", slug, page_type, title, summary, "");
+}
+
+fn insert_page_with_namespace(
+    conn: &Connection,
+    namespace: &str,
+    slug: &str,
+    page_type: &str,
+    title: &str,
+    summary: &str,
+    compiled_truth: &str,
+) {
     conn.execute(
-        "INSERT INTO pages (slug, type, title, summary, compiled_truth, timeline, \
+        "INSERT INTO pages (namespace, slug, type, title, summary, compiled_truth, timeline, \
                             frontmatter, wing, room, version) \
-         VALUES (?1, ?2, ?3, ?4, '', '', '{}', '', '', 1)",
-        rusqlite::params![slug, page_type, title, summary],
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, '', '{}', '', '', 1)",
+        rusqlite::params![namespace, slug, page_type, title, summary, compiled_truth],
     )
     .expect("insert page");
 }
@@ -109,6 +121,89 @@ fn search_raw_json_invalid_query_returns_error_object() {
         .and_then(Value::as_str)
         .expect("raw invalid query must emit an error string");
     assert!(!error.is_empty(), "error message must not be empty");
+}
+
+#[test]
+fn search_namespace_filter_returns_requested_namespace_plus_global_only() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let db_path = test_db_path(&dir, "search-namespace-filter.db");
+    let conn = open_test_db(&db_path);
+    insert_page_with_namespace(
+        &conn,
+        "",
+        "notes/global-bitcoin",
+        "concept",
+        "Global Bitcoin",
+        "Global namespace page",
+        "bitcoin evidence in global namespace",
+    );
+    insert_page_with_namespace(
+        &conn,
+        "workns",
+        "notes/work-bitcoin",
+        "concept",
+        "Work Bitcoin",
+        "Work namespace page",
+        "bitcoin evidence in work namespace",
+    );
+    insert_page_with_namespace(
+        &conn,
+        "otherns",
+        "notes/other-bitcoin",
+        "concept",
+        "Other Bitcoin",
+        "Other namespace page",
+        "bitcoin evidence in another namespace",
+    );
+    drop(conn);
+
+    let namespaced_output = run_quaid(
+        &db_path,
+        &["--json", "search", "--namespace", "workns", "bitcoin"],
+    );
+    assert!(
+        namespaced_output.status.success(),
+        "namespaced search should exit cleanly: {namespaced_output:?}"
+    );
+    assert!(
+        String::from_utf8_lossy(&namespaced_output.stderr)
+            .trim()
+            .is_empty(),
+        "namespaced search should not write errors to stderr: {:?}",
+        namespaced_output.stderr
+    );
+
+    let parsed = parse_stdout_json(&namespaced_output);
+    let results = parsed.as_array().expect("output must be a JSON array");
+    assert_eq!(
+        result_slugs(results),
+        BTreeSet::from([
+            "default::notes/global-bitcoin".to_owned(),
+            "default::notes/work-bitcoin".to_owned(),
+        ]),
+        "--namespace workns must return only workns plus global matches"
+    );
+
+    let global_output = run_quaid(&db_path, &["--json", "search", "bitcoin"]);
+    assert!(
+        global_output.status.success(),
+        "global search should exit cleanly: {global_output:?}"
+    );
+    assert!(
+        String::from_utf8_lossy(&global_output.stderr)
+            .trim()
+            .is_empty(),
+        "global search should not write errors to stderr: {:?}",
+        global_output.stderr
+    );
+
+    let parsed = parse_stdout_json(&global_output);
+    let results = parsed.as_array().expect("output must be a JSON array");
+    assert_eq!(
+        result_slugs(results),
+        BTreeSet::from(["default::notes/global-bitcoin".to_owned()]),
+        "omitted --namespace must default to global-only search"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Addresses GitHub issue #145 (reported by DAB v1.0 testing of v0.16.0).

## Finding

The DAB agent reported that `quaid search --namespace workns` returned results from all namespaces. Investigation shows the namespace filter was already correctly implemented in PR #141 (the copilot review fixes set omitted namespace to global-only and explicit namespace to namespace + global). 

The fix: a regression test that locks in correct behavior and prevents future regressions.

## Test

`tests/search_hardening.rs::search_namespace_filter_returns_requested_namespace_plus_global_only`

- Creates 3 pages: global (`""`), `workns`, `otherns`
- Asserts `quaid search --namespace workns bitcoin` returns only global + workns
- Asserts `quaid search bitcoin` (omitted flag) returns only global

Test passes on current main.

## OpenSpec

Implemented per `openspec/changes/fix-cli-namespace-search/` (propose + apply steps complete).

Closes #145