### PR TITLE
docs: add vision sections to Why Quaid page

### DIFF
--- a/website/src/content/docs/why-quaid.mdx
+++ b/website/src/content/docs/why-quaid.mdx
@@ -10,6 +10,58 @@ import GuideActionBanner from "../../components/docs/GuideActionBanner.astro";
 import GuideFeatureCard from "../../components/docs/GuideFeatureCard.astro";
 import GuideVisualPanel from "../../components/docs/GuideVisualPanel.astro";
 
+## Darn, this thinks like me.
+
+<p class="gb-guide-section-intro">
+  We are, to some extent, the sum of our memories and experiences. They guide
+  our behavior without conscious recall.
+</p>
+
+<p>
+  Karpathy calls this <strong>compiled knowledge</strong>. The person who has
+  built a startup knows which questions to ask before writing code. The investor
+  who has seen a hundred decks knows the pattern of a deal that will not close.
+  They do not reason from first principles each time. They operate from an
+  accumulated self that has been shaped by everything they have encountered.
+</p>
+
+<p>
+  Quaid is building that for AI agents. Not "here is a document you might find
+  relevant" but an agent that operates from a persistent accumulated self. One
+  that leads with downside risk because it knows you always want that first.
+  One that does not need to be briefed on history because it was there. One
+  that, over time, earns the reaction: <em>darn, this thinks like me.</em>
+</p>
+
+<GuideVisualPanel
+  variant={"studio"}
+  label={"Memory that compounds"}
+  note={"Every session adds to what the agent knows. Every decision it witnesses shapes how it reasons next time. Intelligence that accumulates rather than resets."}
+/>
+
+## Trustworthy personalization
+
+<p>
+  There is a risk in systems that personalize aggressively: if the agent
+  rewrites your knowledge through your existing biases, it may reinforce wrong
+  beliefs. The book gets filtered through your current lens instead of
+  challenging it. The memory system becomes a mirror that only shows you what
+  you already think.
+</p>
+
+<p>
+  Quaid's ADD-only architecture exists specifically to prevent this. Memories
+  accumulate. Nothing is overwritten. A head-pointer resolves queries to
+  current truth, but the full history is always accessible. You can ask
+  what you believed before, trace how a view evolved, and verify that the
+  agent's understanding of you reflects reality rather than a convenient
+  simplification.
+</p>
+
+<blockquote class="gb-guide-quote">
+  Memories accumulate. Nothing is rewritten. You can always see the chain.
+</blockquote>
+
 ## Principles
 
 <div class="gb-guide-grid gb-guide-grid--two">

--- a/website/src/content/docs/why-quaid.mdx
+++ b/website/src/content/docs/why-quaid.mdx
@@ -20,13 +20,13 @@ import GuideVisualPanel from "../../components/docs/GuideVisualPanel.astro";
 <p>
   Karpathy calls this <strong>compiled knowledge</strong>. The person who has
   built a startup knows which questions to ask before writing code. The investor
-  who has seen a hundred decks knows the pattern of a deal that will not close.
+  who has seen a hundred decks knows the pattern of a deal that does not close.
   They do not reason from first principles each time. They operate from an
   accumulated self that has been shaped by everything they have encountered.
 </p>
 
 <p>
-  Quaid is building that for AI agents. Not "here is a document you might find
+  Quaid builds that for AI agents. Not "here is a document you might find
   relevant" but an agent that operates from a persistent accumulated self. One
   that leads with downside risk because it knows you always want that first.
   One that does not need to be briefed on history because it was there. One


### PR DESCRIPTION
Adds two new opening sections to why-quaid.mdx before the existing Principles grid:

**'Darn, this thinks like me.'** - The north star. Compiled knowledge, the accumulated self, why agents with Quaid are different from document retrieval.

**'Trustworthy personalization'** - Why ADD-only matters. The personalization drift risk in systems that rewrite memory through your biases. Quaid's answer: nothing is overwritten, the chain is always visible.

Both sections use existing MDX components and match the existing page tone.