### PR TITLE
feat: land SLM schema v9 foundation + release truth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,7 +238,7 @@ jobs:
             >
             > Install docs: https://github.com/quaid-app/quaid/blob/${{ github.ref_name }}/docs/getting-started.md
             >
-            > Pre-rename upgrade path: https://github.com/quaid-app/quaid/blob/${{ github.ref_name }}/docs/MIGRATION.md
+            > Pre-rename upgrade path: https://github.com/quaid-app/quaid/blob/${{ github.ref_name }}/MIGRATION.md
 
             ---
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,7 +238,7 @@ jobs:
             >
             > Install docs: https://github.com/quaid-app/quaid/blob/${{ github.ref_name }}/docs/getting-started.md
             >
-            > Pre-rename upgrade path: https://github.com/quaid-app/quaid/blob/${{ github.ref_name }}/MIGRATION.md
+            > Pre-rename upgrade path: https://github.com/quaid-app/quaid/blob/${{ github.ref_name }}/docs/MIGRATION.md
 
             ---
 

--- a/.squad/agents/amy/history.md
+++ b/.squad/agents/amy/history.md
@@ -5,6 +5,7 @@
 ## Learnings
 
 - [2026-04-29T21:29:11.071+08:00] Pre-tag release truth for a new CLI write path is not just the feature name; docs also need the operating constraints (for example Unix-only, offline-only, or blocked while `serve` owns the collection) so branch-only behavior is described honestly.
+- [2026-05-04T07:22:12.881+08:00] When a release lane adds MCP tools, the docs need a published-vs-branch split for tool counts as well as version numbers; for this lane the truthful release story is public `v0.17.0` = 19 tools, branch `v0.18.0` = 22 tools.
 
 ## 2026-04-29 Release Checkpoint
 - Zapp: release prep COMPLETE (v0.12.0 validation green)

--- a/.squad/agents/fry/history.md
+++ b/.squad/agents/fry/history.md
@@ -4,6 +4,7 @@
 
 ## Learnings
 
+- [2026-05-04T07:22:12.881+08:00] Release-lane truth prep is two coupled checks, not one: bump the version-gated manifest only on the release-bound commit, then audit every public/install surface for moved doc links or stale “upcoming tag” copy so the branch can be tagged without shipping broken release-note pointers.
 - [2026-05-04T07:22:12.881+08:00] `memory_close_action` stayed truest once its MCP surface was tightened back to the spec-sized `{slug, status, note?}` contract and its OCC race proof used an internal pre-write seam, not extra public routing arguments or timing-based concurrency tests.
 - [2026-05-04T07:22:12.881+08:00] Conversation-session Wave 2 needed two tiny but coupled contracts to stay truthful: persist `closed_at` in conversation frontmatter so `memory_close_session` can re-close idempotently without rewriting, and qualify queue `session_id` values with namespace internally so identical session ids do not collapse across namespace-local extraction queues.
 - [2026-05-04T07:22:12.881+08:00] Conversation-memory slice 1 can stay v8 without widening migration scope: keep the existing `pages.type` column, add the new supersede/queue artefacts in-place, and make the `idx_pages_session` expression index `json_valid(frontmatter)`-guarded so malformed-frontmatter rows/tests keep opening instead of failing at insert time.

--- a/.squad/decisions/inbox/amy-conversation-memory-release-docs.md
+++ b/.squad/decisions/inbox/amy-conversation-memory-release-docs.md
@@ -1,0 +1,6 @@
+# Amy — conversation memory release docs
+
+- **Timestamp:** 2026-05-04T07:22:12.881+08:00
+- **Context:** `v0.18.0` release-doc truth pass for `conversation-memory-foundations`
+- **Decision:** Public release docs must split the shipped `v0.17.0` state from the branch-prep `v0.18.0` state, and must call out the tool-count delta explicitly (`v0.17.0` = 19 MCP tools, `v0.18.0` branch = 22).
+- **Why:** The branch adds `memory_add_turn`, `memory_close_session`, and `memory_close_action`, but GitHub Releases and `install.sh` still resolve to the published `v0.17.0` tag until `v0.18.0` exists. Treating those as the same state makes install docs, release copy, and tool-count claims untruthful.

--- a/.squad/decisions/inbox/fry-slm-first-batch.md
+++ b/.squad/decisions/inbox/fry-slm-first-batch.md
@@ -1,0 +1,18 @@
+# Fry — SLM first batch boundary
+
+- Date: 2026-05-05
+- Change: `slm-extraction-and-correction`
+
+## Decision
+
+Land the first truthful batch as the v9 schema/config reset only: `correction_sessions`, extraction/fact-resolution config defaults, schema-version bump, and the rejection/acceptance tests that prove fresh v9 bootstrap and fail-closed v8 reopen behavior.
+
+## Why
+
+- Every later SLM/control/worker slice depends on the persisted schema and defaults being stable first.
+- The branch is already dirty in nearby conversation/runtime files, so keeping Batch 1 to schema + tests avoids widening into active seams before the base contract is locked.
+- This keeps the branch moving toward v0.19.0 with a reviewable, low-blast-radius slice that future runtime/CLI work can build on.
+
+## Follow-up
+
+- Next batch should start at runtime/model lifecycle wiring (`2.*` / `3.*`) or the thinnest CLI plumbing that consumes the new defaults without broadening into worker/correction orchestration prematurely.

--- a/.squad/decisions/inbox/fry-v0180-manifest-lane.md
+++ b/.squad/decisions/inbox/fry-v0180-manifest-lane.md
@@ -1,0 +1,21 @@
+---
+recorded_at: 2026-05-04T07:22:12.881+08:00
+author: Fry
+change: release-v0.18.0
+topic: manifest-and-doc-truth
+---
+
+# Decision
+
+The `v0.18.0` release-bound commit should move the Cargo manifest surface to `0.18.0` and, in the same pass, repair every release-facing link or status line that still points at moved docs or an older upcoming tag.
+
+# Why
+
+- `release.yml` hard-fails when `Cargo.toml` does not match the pushed tag, so the branch is not truthfully releasable until the manifest and lockfile both carry `0.18.0`.
+- Public install and upgrade guidance still participates in the release lane: a tag can succeed while release notes, README/download instructions, or upgrade docs still point at missing files like the old root `MIGRATION.md`.
+- Keeping the version bump and the doc/link repair in one coherent release-lane commit prevents a half-prepared state where tagging would pass CI but ship broken release references.
+
+# Consequence
+
+- Future release prep should audit workflow release-note links, README/install docs, and web upgrade docs alongside the version bump.
+- The branch can now truthfully stay in “preparing `v0.18.0` / latest public tag still older” mode until the actual tag and GitHub Release are cut.

--- a/.squad/decisions/inbox/zapp-slm-pr-release.md
+++ b/.squad/decisions/inbox/zapp-slm-pr-release.md
@@ -1,0 +1,6 @@
+# Zapp — SLM PR / release surface decision
+
+- **Date:** 2026-05-05
+- **Decision:** Do **not** reuse `feat/slm-conversation-mem` as the next draft-PR head. Its remote ref already backed merged PR #153, while the local head now diverges with a smaller, coherent `v0.18.0` release-truth slice. Publish that slice under a fresh head ref, and keep any future `v0.19.0` PR claims blocked until extraction/correction code actually lands.
+- **Why:** A truthful draft PR must describe only the pushed scope. The active branch currently contains manifest + release-doc truth work for the pending `v0.18.0` release lane, not the `slm-extraction-and-correction` implementation proposed for the next lane. Reusing the merged head name would blur those scopes and misstate what is actually ready for review.
+- **Consequences:** Open the draft PR now for the pushed `v0.18.0` release-prep slice only, with explicit non-claims for SLM extraction/correction. For `v0.19.0`, keep the pre-tag truth checklist ready: Cargo version parity, release workflow/tag gate, README + getting-started + install docs wording, roadmap status, MCP tool-count copy, and release asset contract all need a fresh truth pass once the implementation branch is real.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2064,7 +2064,7 @@ dependencies = [
 
 [[package]]
 name = "quaid"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quaid"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 description = "Local-first personal memory. SQLite + FTS5 + local vector embeddings. One static binary."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Most agent memory systems require a cloud service, a running database, or an API
 
 - **Local-first** — single SQLite file, no cloud dependency, works offline
 - **PARA-native** — organizes memory as a knowledge base (Projects, Areas, Resources, Archives), not a flat list of facts
-- **17 MCP tools** — works with Claude Code, Cursor, Windsurf, and any MCP-compatible agent out of the box
+- **22 MCP tools on the `v0.18.0` branch** — the latest public release (`v0.17.0`) exposes 19; the branch adds conversation capture without changing the published install flow
 - **Hybrid retrieval** — FTS5 full-text + local BGE vector embeddings, combined via RRF
 - **Verified by benchmarks** — [193/215 (90%) on DAB](https://quaid-app.github.io/quaid-evals), P@5 on MSMARCO ahead of BM25 baseline
 
@@ -69,7 +69,7 @@ Add to your `.mcp.json`:
 }
 ```
 
-Your agent now has 17 memory tools — `memory_search`, `memory_query`, `memory_put`, `memory_get`, `memory_graph`, and more.
+Your agent now has 22 memory tools on this branch. The latest public release (`v0.17.0`) still exposes 19 until `v0.18.0` is tagged and published.
 
 ---
 
@@ -86,13 +86,13 @@ Sets up `PATH` and `QUAID_DB` automatically. Use `QUAID_CHANNEL=online` for the 
 ### Download a binary
 
 ```bash
-VERSION="<published-tag>"   # for example: the latest public tag until v0.15.0 is published
+VERSION="<published-tag>"   # for example: the latest public tag until v0.18.0 is published
 PLATFORM="darwin-arm64"   # darwin-arm64 | darwin-x86_64 | linux-x86_64 | linux-aarch64
 curl -fsSL "https://github.com/quaid-app/quaid/releases/download/${VERSION}/quaid-${PLATFORM}-online" \
   -o quaid && chmod +x quaid && sudo mv quaid /usr/local/bin/
 ```
 
-Use a published tag here. This branch is preparing `v0.15.0`, so build from source if you need the unreleased Batch 5 live-serve single-file `quaid put` proxying and IPC trust-boundary hardening before the tag exists.
+Use a published tag here. GitHub Releases currently publish `v0.17.0`; this branch prepares `v0.18.0` with conversation-memory foundations plus the existing Unix live-write handling, so build from source if you need that unreleased branch state before the tag exists.
 
 ### Build from source
 
@@ -115,7 +115,7 @@ Two ideas borrowed from Andrej Karpathy's compiled knowledge model:
 
 **Timeline (below the line)** — append-only, never rewritten. What happened and when.
 
-Every page in Quaid has both. Agents read and write through 17 MCP tools via stdio — no REST API, no network dependency.
+Every page in Quaid has both. Agents read and write through Quaid's MCP surface via stdio — 19 tools in the latest public release and 22 on the `v0.18.0` branch — with no REST API and no network dependency.
 
 **Hybrid retrieval:** FTS5 keyword search for exact recall (names, slugs, tags) combined with local BGE vector embeddings for semantic search. Set-union merge, exact-match short-circuit.
 
@@ -169,14 +169,15 @@ quaid serve
 
 ## MCP tools
 
-The MCP surface stays at 17 tools on this branch and in the current release line. The `v0.15.0` docs pass is about Batch 5 Unix live-write handling — same-root single-file `quaid put` now proxies through a live `quaid serve` owner with authenticated per-session IPC, while bulk rewrites stay offline-only — not new tool names:
+The latest public release (`v0.17.0`) exposes 19 MCP tools. This branch prepares `v0.18.0` by keeping those 19 stable and adding 3 conversation-memory capture tools; published install commands should still use a real release tag until `v0.18.0` exists:
 
 | Category | Tools |
 |----------|-------|
 | **Core read/write** | `memory_get`, `memory_put`, `memory_query`, `memory_search`, `memory_list` |
+| **Conversation capture** | `memory_add_turn`, `memory_close_session`, `memory_close_action` |
 | **Intelligence** | `memory_link`, `memory_link_close`, `memory_backlinks`, `memory_graph`, `memory_check`, `memory_timeline`, `memory_tags` |
 | **Gaps + stats** | `memory_gap`, `memory_gaps`, `memory_stats`, `memory_raw` |
-| **Collections** | `memory_collections` |
+| **Collections + namespaces** | `memory_collections`, `memory_namespace_create`, `memory_namespace_destroy` |
 
 ---
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -65,7 +65,7 @@ quaid/
 ├── docs/                     # User-facing documentation (you are here)
 │   ├── spec.md               # Full technical specification
 │   ├── getting-started.md    # New user / new contributor onboarding
-│   ├── roadmap.md            # Phased delivery plan and status
+│   ├── roadmap_v3.md         # Phased delivery plan and status
 │   └── contributing.md       # This file
 ├── openspec/                 # Structured change proposals
 │   └── changes/              # One directory per proposal
@@ -309,6 +309,6 @@ To override a default skill locally, drop a `SKILL.md` in your working directory
 ## Getting help
 
 - Full technical spec: [docs/spec.md](spec.md)
-- Phased delivery plan: [docs/roadmap.md](roadmap.md)
+- Phased delivery plan: [docs/roadmap_v3.md](roadmap_v3.md)
 - Agent instructions: [AGENTS.md](../AGENTS.md) and [CLAUDE.md](../CLAUDE.md)
 - Open an issue on GitHub for bugs or feature requests.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -95,7 +95,7 @@ quaid serve
 
 `quaid collection add` performs the initial vault scan, records the collection, and writes pages into the database. On Unix/macOS/Linux, `quaid serve` keeps that collection in sync continuously. For one-off files outside a collection, use `quaid ingest /path/to/file.md`.
 
-> On Unix, you can persist missing `quaid_id` frontmatter during attach (`quaid collection add <name> <path> --write-quaid-id`) or backfill it later with `quaid collection migrate-uuids <name> [--dry-run]`. Batch 5 additionally upgrades same-root single-file `quaid put` so the CLI authenticates the live `quaid serve` owner and proxies the write instead of refusing. For an OpenClaw setup, see [openclaw-harness.md](openclaw-harness.md).
+> On Unix, you can persist missing `quaid_id` frontmatter during attach (`quaid collection add <name> <path> --write-quaid-id`) or backfill it later with `quaid collection migrate-uuids <name> [--dry-run]`. Same-root single-file `quaid put` can also authenticate a live `quaid serve` owner and proxy the write instead of refusing. For an OpenClaw setup, see [openclaw-harness.md](openclaw-harness.md).
 
 ### 3. Search
 
@@ -189,6 +189,16 @@ The MCP server exposes tools over stdio JSON-RPC 2.0.
 **Collections + namespaces (3):** `memory_collections`, `memory_namespace_create`, `memory_namespace_destroy`
 
 The latest public GitHub Release (`v0.17.0`) exposes the first 19 tools. This branch prepares `v0.18.0` by adding the 3 conversation-memory capture tools plus the queue and supersede plumbing behind them. See [spec.md](spec.md#mcp-server) for tool signatures.
+
+### Capture a conversation on this branch
+
+```bash
+quaid call memory_add_turn '{"session_id":"demo","role":"user","content":"I prefer weekly written updates."}'
+quaid call memory_add_turn '{"session_id":"demo","role":"assistant","content":"Got it. I will keep updates written and weekly."}'
+quaid call memory_close_session '{"session_id":"demo"}'
+```
+
+Those calls append turns to `conversations/YYYY-MM-DD/<session-id>.md` and queue extraction work. On this branch, the capture layer, queue, and supersede-aware retrieval are landed; the background SLM extractor that writes new fact pages is still follow-on work.
 
 ---
 
@@ -384,11 +394,12 @@ Exit 0 means clean; exit 1 means violations were found.
 
 ### Raw MCP tool invocation
 
-Call MCP tools directly from the CLI without starting the server. The dispatcher covers all 17 shipped MCP tools, including `memory_collections`.
+Call MCP tools directly from the CLI without starting the server. On this branch, the dispatcher covers all 22 MCP tools.
 
 ```bash
 quaid call memory_stats '{}'
 quaid call memory_get '{"slug": "people/alice"}'
+quaid call memory_add_turn '{"session_id":"demo","role":"user","content":"Ship the docs before lunch."}'
 quaid call memory_gap '{"query": "who founded acme corp"}'
 quaid call memory_collections '{}'
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started with Quaid
 
-> Quaid is a local-first personal AI memory layer: SQLite + FTS5 + local vector embeddings in one file. This branch prepares `v0.15.0`: it keeps the 17-tool surface, carries Batches 1–4 vault-sync follow-ons already on `main`, and adds Batch 5 authenticated live-serve single-file write proxying for collection-backed vaults on Unix.
+> Quaid is a local-first personal AI memory layer: SQLite + FTS5 + local vector embeddings in one file. This branch prepares `v0.18.0`: it keeps the published `v0.17.0` vault-sync surface, raises the branch MCP surface from 19 tools to 22, and lands the conversation-memory foundations (`memory_add_turn`, `memory_close_session`, `memory_close_action`, conversation day-files, the extraction queue, and supersede-aware retrieval).
 
 ## What it does
 
@@ -15,9 +15,9 @@ You search it with full-text keywords and semantic queries. Any MCP-compatible A
 
 ## Status
 
-> **Phase 3 is complete, and the vault-sync line is in Batch 5.** This branch prepares `v0.15.0`: it preserves the current 17-tool surface, keeps Batches 1–4 vault-sync follow-ons already shipped, and adds Batch 5 authenticated same-root single-file `quaid put` proxying through a live `quaid serve` owner on Unix, with the reviewed IPC trust boundary and peer-auth checks.
+> **The latest public release is `v0.17.0`, and this branch prepares `v0.18.0`.** The branch keeps the shipped vault-sync work in place, adds the 3 conversation-memory capture tools, and lands the conversation file / queue / supersede plumbing that the follow-on extractor work will build on.
 >
-> Published GitHub Release binaries still come from the latest public tag until the `v0.15.0` workflow completes. See [roadmap.md](roadmap.md) for the full delivery plan.
+> Published GitHub Release binaries and `install.sh` still resolve to `v0.17.0` until the `v0.18.0` tag exists. The background SLM extractor and correction flow are still follow-on work. See [roadmap_v3.md](roadmap_v3.md) for the full delivery plan.
 
 ---
 
@@ -25,14 +25,14 @@ You search it with full-text keywords and semantic queries. Any MCP-compatible A
 
 | Method | Status |
 | ------ | ------ |
-| Build from source (`cargo build --release`) | ✅ Available now — source builds reflect this branch, including the Batch 5 same-root `quaid put` live-proxy / IPC-auth slice |
-| GitHub Release binary (macOS ARM/x86, Linux x86_64/ARM64) | ✅ Available — use the latest published tag until `v0.15.0` is cut |
+| Build from source (`cargo build --release`) | ✅ Available now — source builds reflect the `v0.18.0` branch state, including conversation-memory foundations and the existing Unix live-write handling |
+| GitHub Release binary (macOS ARM/x86, Linux x86_64/ARM64) | ✅ Available — the latest published tag is `v0.17.0`; it does not include the new conversation-memory tools yet |
 | `npm install -g quaid` | ❌ Not yet published — use binary release or build from source |
 | One-command curl installer | ✅ Available — airgapped by default; set `QUAID_CHANNEL=online` for online |
 
 > **Configurable BGE models.** The `online` build selects `small` (default), `base`, `large`, or `m3` via `QUAID_MODEL` / `--model`. The `airgapped` build embeds BGE-small-en-v1.5.
 >
-> **Pre-release note.** GitHub Releases downloads and `install.sh` resolve against published tags. Build from source if you need the unreleased `v0.15.0` Batch 5 live-serve single-file write proxying before the tag exists.
+> **Pre-release note.** GitHub Releases downloads and `install.sh` resolve against published tags. Build from source if you need the unreleased `v0.18.0` conversation-memory foundations before the tag exists.
 
 ---
 
@@ -69,7 +69,7 @@ cross build --release --target aarch64-unknown-linux-musl     # Linux ARM64 (ful
 
 ## Your first memory store
 
-> **Phase 1 commands** are implemented. **Phase 2 commands** (graph, check, gaps) are implemented. **Phase 3 commands** (validate, call, pipe, skills) are implemented. Build from source to use the full branch state described below before `v0.15.0` is published; see [Status](#status) and [Install options](#install-options) above.
+> **Phase 1 commands** are implemented. **Phase 2 commands** (graph, check, gaps) are implemented. **Phase 3 commands** (validate, call, pipe, skills) are implemented. Build from source to use the branch-only conversation-memory foundations before `v0.18.0` is published; see [Status](#status) and [Install options](#install-options) above.
 
 > **Post-install note:** The shell installer (`scripts/install.sh`) automatically adds `PATH` and `QUAID_DB` to your shell profile. If you built from source or used the manual GitHub Releases download, add these to your profile yourself:
 > ```bash
@@ -84,7 +84,7 @@ cross build --release --target aarch64-unknown-linux-musl     # Linux ARM64 (ful
 quaid init ~/.quaid/memory.db
 ```
 
-This creates a new `memory.db` file with the full v8 schema — pages, embeddings, links, assertions, knowledge gaps, collections, `file_state`, `raw_imports`, and `embedding_jobs`.
+This creates a new `memory.db` file with the full v8 schema — pages, embeddings, links, assertions, knowledge gaps, collections, `file_state`, `raw_imports`, `embedding_jobs`, and `extraction_queue`.
 
 ### 2. Attach a markdown directory or ingest a single file
 
@@ -178,15 +178,17 @@ The MCP server exposes tools over stdio JSON-RPC 2.0.
 
 > For OpenClaw, put the same server definition under `mcp.servers` in `openclaw.json`. See [openclaw-harness.md](openclaw-harness.md) for the full harness setup, collections-based vault sync, and `memory_collections` health checks.
 
-**Phase 1 tools (core read/write):** `memory_get`, `memory_put`, `memory_query`, `memory_search`, `memory_list`
+**Core read/write (5):** `memory_get`, `memory_put`, `memory_query`, `memory_search`, `memory_list`
 
-**Phase 2 tools (intelligence layer):** `memory_link`, `memory_link_close`, `memory_backlinks`, `memory_graph`, `memory_check`, `memory_timeline`, `memory_tags`
+**Conversation capture (3):** `memory_add_turn`, `memory_close_session`, `memory_close_action`
 
-**Phase 3 tools (gaps, stats, raw data):** `memory_gap`, `memory_gaps`, `memory_stats`, `memory_raw`
+**Knowledge + graph (7):** `memory_link`, `memory_link_close`, `memory_backlinks`, `memory_graph`, `memory_check`, `memory_timeline`, `memory_tags`
 
-**vault-sync tools:** `memory_collections` — read-only per-collection status including state, ignore diagnostics, recovery flags, and embedding queue health
+**Gaps, stats, and raw data (4):** `memory_gap`, `memory_gaps`, `memory_stats`, `memory_raw`
 
-All 17 tools remain live on this branch and in the current release line. The `v0.15.0` slice keeps the tool names stable while carrying Batch 3 UUID identity hardening, Batch 4 rename-before-commit completion, and Batch 5 authenticated same-root single-file `quaid put` proxying on Unix. See [spec.md](spec.md#mcp-server) for tool signatures.
+**Collections + namespaces (3):** `memory_collections`, `memory_namespace_create`, `memory_namespace_destroy`
+
+The latest public GitHub Release (`v0.17.0`) exposes the first 19 tools. This branch prepares `v0.18.0` by adding the 3 conversation-memory capture tools plus the queue and supersede plumbing behind them. See [spec.md](spec.md#mcp-server) for tool signatures.
 
 ---
 
@@ -411,7 +413,7 @@ quaid skills doctor   # verify SHA-256 hashes, detect override shadowing
 
 ## vault-sync-engine: Collections and live-sync
 
-> These commands first shipped in `v0.9.6`. This branch carries the `v0.15.0` follow-on: Batches 1–4 vault-sync follow-ons stay in place, while Batch 5 upgrades same-root single-file `quaid put` to proxy through the live serve owner over authenticated per-session IPC on Unix. Bulk rewrites still refuse and stay offline-only.
+> These commands first shipped in `v0.9.6` and remain the published `v0.17.0` vault-sync surface. The `v0.18.0` lane keeps them in place — including same-root single-file `quaid put` proxying on Unix — while adding conversation-memory foundations elsewhere in this guide.
 
 ### Attach a vault
 
@@ -499,6 +501,6 @@ Typical resolution flow:
 
 ## Next steps
 
-- Read [roadmap.md](roadmap.md) to understand what is built vs. what is coming.
+- Read [roadmap_v3.md](roadmap_v3.md) to understand what is built vs. what is coming.
 - Read [contributing.md](contributing.md) to start contributing.
 - Read [spec.md](spec.md) for the full technical specification.

--- a/docs/openclaw-harness.md
+++ b/docs/openclaw-harness.md
@@ -90,7 +90,7 @@ QUAID_DB=~/.quaid/memory.db quaid serve
 
 ## MCP tools
 
-Quaid exposes 17 MCP tools via `quaid serve`. All tool names use the `memory_*` prefix.
+The latest public release exposes 19 MCP tools via `quaid serve`; this branch carries 22. All tool names use the `memory_*` prefix.
 
 ### `memory_query` vs `memory_search`
 
@@ -171,7 +171,7 @@ Live results: [benchmark.quaid.app](https://benchmark.quaid.app)
 
 ## Migration from GigaBrain / pre-v0.9.9
 
-Existing databases (schema v5) are incompatible with v0.9.9 (schema v6). See [MIGRATION.md](MIGRATION.md) for the full migration guide.
+Existing databases (schema v5) are incompatible with v0.9.9 (schema v6). See [MIGRATION.md](../MIGRATION.md) for the full migration guide.
 
 Quick summary:
 

--- a/docs/openclaw-harness.md
+++ b/docs/openclaw-harness.md
@@ -171,7 +171,7 @@ Live results: [benchmark.quaid.app](https://benchmark.quaid.app)
 
 ## Migration from GigaBrain / pre-v0.9.9
 
-Existing databases (schema v5) are incompatible with v0.9.9 (schema v6). See [MIGRATION.md](../MIGRATION.md) for the full migration guide.
+Existing databases (schema v5) are incompatible with v0.9.9 (schema v6). See [MIGRATION.md](MIGRATION.md) for the full migration guide.
 
 Quick summary:
 

--- a/docs/roadmap_v2.md
+++ b/docs/roadmap_v2.md
@@ -10,7 +10,7 @@ date: 2026-04-27
 
 Last updated: 2026-04-27 · Source: 23 open issues from beta testers ([github.com/quaid-app/quaid/issues](https://github.com/quaid-app/quaid/issues))
 
-This roadmap synthesises what beta testers are actually telling us. For the release-phase plan and shipped milestones, see [`docs/roadmap.md`](docs/roadmap.md).
+This roadmap synthesises what beta testers are actually telling us. For the release-phase plan and shipped milestones, see [`docs/roadmap_v3.md`](docs/roadmap_v3.md).
 
 ## How to read this roadmap
 
@@ -360,7 +360,7 @@ A handful of things the issues don't settle. Worth a tester poll before committi
 
 **Question 1 — Embedding model default.** §4 Semantic ceiling is 27/50 with bge-small. Does upgrading the airgapped default to bge-base (768d) move the needle enough to justify the binary-size cost? Imagine doubling the embedding-table footprint just to see what we already suspect: that domain paraphrasing is bottlenecked by model capacity. DAB §4 should answer this once Epic 6's model matrix runs.
 
-**Question 2 — LLM-assisted contradiction detection.** Currently deferred per `docs/roadmap.md` — *"the binary stays dumb."* Do we hold that line, or is the +3 points on §7 worth a config-gated opt-in?
+**Question 2 — LLM-assisted contradiction detection.** Currently deferred per `docs/roadmap_v3.md` — *"the binary stays dumb."* Do we hold that line, or is the +3 points on §7 worth a config-gated opt-in?
 
 **Question 3 — REFRAG-style compression** (#76). Worth pursuing only if latency becomes a tester complaint. Nobody is currently reporting it as pain. Defer until signalled.
 

--- a/docs/roadmap_v3.md
+++ b/docs/roadmap_v3.md
@@ -1,14 +1,14 @@
 ---
 title: "Quaid Product Roadmap"
 source: quaid-app/quaid
-date: 2026-05-03
+date: 2026-05-04
 tags: [quaid, roadmap, product, planning, memory-systems]
 aliases: [quaid-roadmap]
 ---
 
 # Quaid Product Roadmap
 
-**Last updated:** May 3, 2026
+**Last updated:** May 4, 2026
 **Latest public release:** v0.17.0
 **Current release lane:** v0.18.0
 **Benchmark baseline:** DAB v1 213/215 (99%), LoCoMo 0.1%, LongMemEval 0.0%, BEAM 0.0%
@@ -41,17 +41,16 @@ Temporal links, assertions, contradiction detection, progressive retrieval, 16 M
 ### Phase 3 - Skills, Benchmarks, CLI Polish (v0.9.2) ✅
 All 8 skills production-ready, BEIR regression gate, benchmark harnesses (LoCoMo, LongMemEval, BEAM adapters).
 
-### Phase 4 - Vault Sync Engine (v0.9.x → v0.18.0) 🔄 In Progress
-Multi-collection live filesystem sync. `quaid collection add/sync` replaces `quaid import`.
-Schema v6+, live watcher, write safety, namespace isolation shipped.
+### Phase 4 - Vault Sync Engine (v0.9.x → v0.17.0) ✅ Shipped core surface
+Multi-collection live filesystem sync, namespace isolation, collection health reporting, and the reviewed Unix same-root single-file live-write path are all in the latest public release. `quaid collection add/sync` replaced `quaid import`.
 
-**Remaining in Batch 7+:** Online restore handshake, Windows quarantine restore.
+**Still deferred:** Online restore handshake, Windows quarantine restore, and the remaining restore hardening follow-ons.
 
 ---
 
-## Phase 5 - Conversation Memory + SLM Extraction
+## Phase 5 - Conversation memory foundations + SLM extraction
 
-**Priority: NEXT — highest impact single feature**
+**Priority: current release lane — foundations landed, extractor follow-on next**
 **Target: >40% LoCoMo, >40% LongMemEval**
 **Issues: #137 (namespace, shipped), #105 (conversation memory), #135 (contradiction resolution)**
 
@@ -59,14 +58,28 @@ Schema v6+, live watcher, write safety, namespace isolation shipped.
 
 The single biggest gap vs Mem0/GBrain: Quaid stores raw conversation turns as documents. Fact extraction doesn't happen at write time. When asked "What degree did I graduate with?", Quaid can't answer from "Business Administration, spent 4 years at it" buried in casual conversation.
 
-### Core requirements
+### Landed on the `v0.18.0` branch
 
-**Namespace isolation** ✅ Shipped in v0.16.0 - multiple agents/sessions share one DB without bleed.
+**Namespace isolation** ✅ Shipped in `v0.16.0` — multiple agents and sessions share one DB without bleed.
 
-**Conversation ingestion** (`memory_add_turn` MCP tool)
-- Accept conversation turns: `{session_id, role, content, timestamp}`
-- Queue for background extraction
-- Non-blocking: ingest response is immediate
+**Conversation ingestion and session controls**
+- `memory_add_turn` accepts `{session_id, role, content, timestamp?, metadata?}`
+- `memory_close_session` forces the final queue flush for a session
+- `memory_close_action` updates `action_item` pages in place
+- Conversation turns are written to namespace-aware day files under `conversations/YYYY-MM-DD/<session-id>.md`
+- Request-path latency stays non-blocking; the request does file append + fsync + queue work only
+
+**Queue and retrieval foundations**
+- `extraction_queue` is landed with debounce and session-close triggers
+- ADD-only supersede chains are landed for page history
+- Head-only retrieval is now the default, with `--include-superseded` / `include_superseded` as the opt-in escape hatch
+- `memory_get` and `memory_graph` surface supersede relationships directly
+
+**Release truth**
+- The latest public binaries and `install.sh` still publish `v0.17.0`
+- The upcoming `v0.18.0` tag is the release that will publish the 3 new conversation-memory MCP tools
+
+### Still remaining after foundations
 
 **SLM-based fact extraction** (runs in background)
 - Local SLM: Phi-3.5 Mini (MIT, ~2GB) as default. Configurable to Gemma 3 1B/4B.
@@ -88,12 +101,11 @@ The single biggest gap vs Mem0/GBrain: Quaid stores raw conversation turns as do
 - Non-blocking - ingest latency unchanged
 - `quaid query "what did we decide about X last week"` returns relevant facts
 
-### Key design decisions for OpenSpec
-- Is SLM extraction synchronous or background queue?
-- What is the 3-5 turn context window boundary? (Session ID? Time window?)
-- How does contradiction resolution interact with ADD-only immutability?
+### Next design / delivery questions
+- What is the final 3-5 turn extraction boundary? (Strict session window, time window, or both?)
+- How does contradiction resolution interact with ADD-only immutability once extracted facts begin superseding each other automatically?
 - Model download: lazy (first use) or eager (at `extraction.enabled`)?
-- What structured format for extracted facts?
+- What structured format should extracted facts persist with, and what confidence metadata should survive review?
 
 ---
 
@@ -219,7 +231,7 @@ Both are right in different contexts. A future feature worth considering:
 
 `quaid eval --against-history` - run your N most recent queries against current binary, compare to stored baseline, report regressions. Each user gets their own personalized regression detector.
 
-Not on the current roadmap but worth an OpenSpec when Phase 5 is shipped.
+Not on the current roadmap but worth an OpenSpec after the `v0.18.0` foundations and the extraction follow-on are both shipped.
 
 ---
 
@@ -229,7 +241,7 @@ Not on the current roadmap but worth an OpenSpec when Phase 5 is shipped.
 |----------|-------|---------|-----------|
 | 1 | #137 ✅ | Namespace isolation | — |
 | 2 | #134 | Large corpus performance | — |
-| 3 | #105 | Conversation memory + SLM extraction | #137 |
+| 3 | #105 | Conversation memory foundations (`v0.18.0` lane) + SLM extraction follow-on | #137 |
 | 4 | #135 | Contradiction resolution | #105 |
 | 5 | #107 | Entity extraction | #105 (coordinate) |
 | 6 | #72 | Self-wiring knowledge graph | #107 |

--- a/docs/roadmap_v3.md
+++ b/docs/roadmap_v3.md
@@ -9,7 +9,8 @@ aliases: [quaid-roadmap]
 # Quaid Product Roadmap
 
 **Last updated:** May 3, 2026
-**Current release:** v0.17.0
+**Latest public release:** v0.17.0
+**Current release lane:** v0.18.0
 **Benchmark baseline:** DAB v1 213/215 (99%), LoCoMo 0.1%, LongMemEval 0.0%, BEAM 0.0%
 
 ---
@@ -40,7 +41,7 @@ Temporal links, assertions, contradiction detection, progressive retrieval, 16 M
 ### Phase 3 - Skills, Benchmarks, CLI Polish (v0.9.2) ✅
 All 8 skills production-ready, BEIR regression gate, benchmark harnesses (LoCoMo, LongMemEval, BEAM adapters).
 
-### Phase 4 - Vault Sync Engine (v0.9.x → v0.17.0) 🔄 In Progress
+### Phase 4 - Vault Sync Engine (v0.9.x → v0.18.0) 🔄 In Progress
 Multi-collection live filesystem sync. `quaid collection add/sync` replaces `quaid import`.
 Schema v6+, live watcher, write safety, namespace isolation shipped.
 

--- a/openspec/changes/slm-extraction-and-correction/tasks.md
+++ b/openspec/changes/slm-extraction-and-correction/tasks.md
@@ -1,11 +1,11 @@
 ## 1. Pre-release schema reset to v9
 
-- [ ] 1.1 Update `src/schema.sql`: add `correction_sessions` table with columns and CHECK constraints per the `correction-dialogue` spec
-- [ ] 1.2 Add partial index `idx_correction_open ON correction_sessions(status, expires_at) WHERE status = 'open'`
-- [ ] 1.3 Seed config defaults in the existing `config` table: `extraction.enabled='false'`, `extraction.model_alias='phi-3.5-mini'`, `extraction.window_turns='5'`, `extraction.debounce_ms='5000'`, `extraction.idle_close_ms='60000'`, `extraction.retention_days='30'`, `fact_resolution.dedup_cosine_min='0.92'`, `fact_resolution.supersede_cosine_min='0.4'`
-- [ ] 1.4 Bump `SCHEMA_VERSION`, `quaid_config.schema_version`, and schema-version tests to `9`
-- [ ] 1.5 Verify no v8 → v9 migration or rollback path is added; existing v8 DBs continue to fail with the schema-mismatch/re-init message
-- [ ] 1.6 Unit tests: fresh v9 schema accepts the new artefacts; v8 DB rejected at open; CHECK constraints on `correction_sessions.status` enforced
+- [x] 1.1 Update `src/schema.sql`: add `correction_sessions` table with columns and CHECK constraints per the `correction-dialogue` spec
+- [x] 1.2 Add partial index `idx_correction_open ON correction_sessions(status, expires_at) WHERE status = 'open'`
+- [x] 1.3 Seed config defaults in the existing `config` table: `extraction.enabled='false'`, `extraction.model_alias='phi-3.5-mini'`, `extraction.window_turns='5'`, `extraction.debounce_ms='5000'`, `extraction.idle_close_ms='60000'`, `extraction.retention_days='30'`, `fact_resolution.dedup_cosine_min='0.92'`, `fact_resolution.supersede_cosine_min='0.4'`
+- [x] 1.4 Bump `SCHEMA_VERSION`, `quaid_config.schema_version`, and schema-version tests to `9`
+- [x] 1.5 Verify no v8 → v9 migration or rollback path is added; existing v8 DBs continue to fail with the schema-mismatch/re-init message
+- [x] 1.6 Unit tests: fresh v9 schema accepts the new artefacts; v8 DB rejected at open; CHECK constraints on `correction_sessions.status` enforced
 
 ## 2. SLM runtime — candle Phi-3.5 wrapper
 

--- a/src/commands/call.rs
+++ b/src/commands/call.rs
@@ -404,7 +404,8 @@ mod tests {
             }),
         )
         .expect("memory_close_action should succeed");
-        assert_eq!(closed["status"], json!("done"));
+        assert!(closed["updated_at"].as_str().is_some());
+        assert!(closed["version"].as_i64().unwrap_or_default() >= 2);
     }
 
     #[test]

--- a/src/commands/call.rs
+++ b/src/commands/call.rs
@@ -31,6 +31,13 @@ pub fn dispatch_tool(server: &QuaidServer, tool: &str, params: Value) -> Result<
                 .memory_close_session(input)
                 .map_err(|e| e.message.to_string())
         }
+        "memory_close_action" => {
+            let input: MemoryCloseActionInput =
+                serde_json::from_value(params).map_err(|e| format!("invalid params: {e}"))?;
+            server
+                .memory_close_action(input)
+                .map_err(|e| e.message.to_string())
+        }
         "memory_query" => {
             let input: MemoryQueryInput =
                 serde_json::from_value(params).map_err(|e| format!("invalid params: {e}"))?;
@@ -376,6 +383,28 @@ mod tests {
         .expect("memory_close_session should succeed");
         assert_eq!(close["extraction_triggered"], json!(true));
         assert!(close["queue_position"].as_i64().unwrap_or_default() >= 1);
+
+        dispatch_tool(
+            &server,
+            "memory_put",
+            json!({
+                "slug": "action_item/dispatch-action",
+                "content": "---\ntype: action_item\ntitle: Dispatch Action\nstatus: open\n---\n\nShip the docs before lunch."
+            }),
+        )
+        .expect("memory_put action_item should succeed");
+
+        let closed = dispatch_tool(
+            &server,
+            "memory_close_action",
+            json!({
+                "slug": "action_item/dispatch-action",
+                "status": "done",
+                "note": "Closed from dispatch_tool test."
+            }),
+        )
+        .expect("memory_close_action should succeed");
+        assert_eq!(closed["status"], json!("done"));
     }
 
     #[test]

--- a/src/core/conversation/file_edit.rs
+++ b/src/core/conversation/file_edit.rs
@@ -55,7 +55,9 @@ pub enum FileEditError {
     PageUuid(#[from] crate::core::page_uuid::PageUuidError),
     #[error("JSON error: {0}")]
     Json(#[from] serde_json::Error),
-    #[error("file-edit supersede requires head page `{slug}`; current successor is `{successor_slug}`")]
+    #[error(
+        "file-edit supersede requires head page `{slug}`; current successor is `{successor_slug}`"
+    )]
     NonHeadTarget {
         slug: String,
         successor_slug: String,
@@ -307,10 +309,8 @@ pub fn handle_extracted_edit(
 
 pub fn is_extracted_path(relative_path: &Path) -> bool {
     let parts = path_parts(relative_path);
-    matches!(
-        parts.as_slice(),
-        ["extracted", ..] | [_, "extracted", ..]
-    ) && !is_history_sidecar_path(relative_path)
+    matches!(parts.as_slice(), ["extracted", ..] | [_, "extracted", ..])
+        && !is_history_sidecar_path(relative_path)
 }
 
 pub fn is_history_sidecar_path(relative_path: &Path) -> bool {
@@ -377,9 +377,11 @@ fn current_predecessor(
 }
 
 fn page_namespace(conn: &Connection, page_id: i64) -> Result<String, FileEditError> {
-    conn.query_row("SELECT namespace FROM pages WHERE id = ?1", [page_id], |row| {
-        row.get(0)
-    })
+    conn.query_row(
+        "SELECT namespace FROM pages WHERE id = ?1",
+        [page_id],
+        |row| row.get(0),
+    )
     .map_err(FileEditError::from)
 }
 
@@ -391,12 +393,10 @@ fn current_timestamp(conn: &Connection) -> Result<String, FileEditError> {
 }
 
 fn history_on_disk_enabled(conn: &Connection) -> Result<bool, FileEditError> {
-    Ok(db::read_config_value_or(
-        conn,
-        "corrections.history_on_disk",
-        "false",
-    )?
-    .eq_ignore_ascii_case("true"))
+    Ok(
+        db::read_config_value_or(conn, "corrections.history_on_disk", "false")?
+            .eq_ignore_ascii_case("true"),
+    )
 }
 
 fn history_relative_path(relative_path: &Path, slug: &str, archived_suffix: &str) -> PathBuf {

--- a/src/core/conversation/turn_writer.rs
+++ b/src/core/conversation/turn_writer.rs
@@ -745,9 +745,15 @@ mod tests {
         let latest = format::parse(&latest_path).unwrap();
 
         assert!(first.newly_closed);
-        assert_eq!(first.conversation_path, "conversations/2026-05-04/session-close.md");
+        assert_eq!(
+            first.conversation_path,
+            "conversations/2026-05-04/session-close.md"
+        );
         assert_eq!(latest.frontmatter.status, ConversationStatus::Closed);
-        assert_eq!(latest.frontmatter.closed_at.as_deref(), Some(first.closed_at.as_str()));
+        assert_eq!(
+            latest.frontmatter.closed_at.as_deref(),
+            Some(first.closed_at.as_str())
+        );
         assert!(!second.newly_closed);
         assert_eq!(second.closed_at, first.closed_at);
     }
@@ -773,20 +779,18 @@ mod tests {
             closed.conversation_path,
             "alpha/conversations/2026-05-03/session-alpha.md"
         );
-        assert!(
-            format::parse(
-                &vault_root
-                    .path()
-                    .join("alpha")
-                    .join("conversations")
-                    .join("2026-05-03")
-                    .join("session-alpha.md"),
-            )
-            .unwrap()
-            .frontmatter
-            .closed_at
-            .is_some()
-        );
+        assert!(format::parse(
+            &vault_root
+                .path()
+                .join("alpha")
+                .join("conversations")
+                .join("2026-05-03")
+                .join("session-alpha.md"),
+        )
+        .unwrap()
+        .frontmatter
+        .closed_at
+        .is_some());
     }
 
     #[test]

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -1130,9 +1130,8 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert!(correction_table_sql.contains(
-            "status IN ('open', 'committed', 'abandoned', 'expired')"
-        ));
+        assert!(correction_table_sql
+            .contains("status IN ('open', 'committed', 'abandoned', 'expired')"));
         assert!(correction_table_sql.contains("json_valid(exchange_log)"));
 
         let correction_index_sql: String = conn

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -12,7 +12,7 @@ use super::inference::{
 use super::types::DbError;
 
 static SQLITE_VEC_INIT: Once = Once::new();
-const SCHEMA_VERSION: i64 = 8;
+const SCHEMA_VERSION: i64 = 9;
 const PAGES_AU_QUARANTINE_GUARD: &str = "WHERE old.quarantined_at IS NULL";
 const PAGES_AU_TRIGGER_SQL: &str =
     "CREATE TRIGGER IF NOT EXISTS pages_au AFTER UPDATE ON pages BEGIN
@@ -859,9 +859,11 @@ pub fn read_quaid_config(conn: &Connection) -> Result<Option<QuaidConfig>, DbErr
 }
 
 pub fn read_config_value(conn: &Connection, key: &str) -> Result<Option<String>, DbError> {
-    conn.query_row("SELECT value FROM config WHERE key = ?1", [key], |row| row.get(0))
-        .optional()
-        .map_err(DbError::from)
+    conn.query_row("SELECT value FROM config WHERE key = ?1", [key], |row| {
+        row.get(0)
+    })
+    .optional()
+    .map_err(DbError::from)
 }
 
 pub fn read_config_value_or(
@@ -1022,6 +1024,7 @@ mod tests {
             "collection_owners",
             "config",
             "contradictions",
+            "correction_sessions",
             "embedding_jobs",
             "embedding_models",
             "extraction_queue",
@@ -1049,7 +1052,7 @@ mod tests {
     }
 
     #[test]
-    fn open_sets_user_version_to_8() {
+    fn open_sets_user_version_to_9() {
         let dir = tempfile::TempDir::new().unwrap();
         let db_path = dir.path().join("test_memory.db");
         let conn = open(db_path.to_str().unwrap()).unwrap();
@@ -1057,11 +1060,11 @@ mod tests {
         let version: i64 = conn
             .query_row("PRAGMA user_version", [], |row| row.get(0))
             .unwrap();
-        assert_eq!(version, 8);
+        assert_eq!(version, 9);
     }
 
     #[test]
-    fn fresh_v8_schema_includes_conversation_memory_artifacts_and_defaults() {
+    fn fresh_v9_schema_includes_conversation_memory_artifacts_and_defaults() {
         let conn = open(":memory:").unwrap();
 
         let page_columns: Vec<String> = conn
@@ -1120,10 +1123,44 @@ mod tests {
             .unwrap();
         assert!(pending_index_sql.contains("WHERE status = 'pending'"));
 
+        let correction_table_sql: String = conn
+            .query_row(
+                "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'correction_sessions'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(correction_table_sql.contains(
+            "status IN ('open', 'committed', 'abandoned', 'expired')"
+        ));
+        assert!(correction_table_sql.contains("json_valid(exchange_log)"));
+
+        let correction_index_sql: String = conn
+            .query_row(
+                "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = 'idx_correction_open'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(correction_index_sql.contains("WHERE status = 'open'"));
+
         let config_rows: Vec<(String, String)> = conn
             .prepare(
                 "SELECT key, value FROM config
-                 WHERE key IN ('version', 'memory.location', 'corrections.history_on_disk', 'extraction.max_retries')
+                 WHERE key IN (
+                     'version',
+                     'memory.location',
+                     'corrections.history_on_disk',
+                     'extraction.max_retries',
+                     'extraction.enabled',
+                     'extraction.model_alias',
+                     'extraction.window_turns',
+                     'extraction.debounce_ms',
+                     'extraction.idle_close_ms',
+                     'extraction.retention_days',
+                     'fact_resolution.dedup_cosine_min',
+                     'fact_resolution.supersede_cosine_min'
+                 )
                  ORDER BY key",
             )
             .unwrap()
@@ -1138,15 +1175,32 @@ mod tests {
                     "corrections.history_on_disk".to_string(),
                     "false".to_string()
                 ),
+                ("extraction.debounce_ms".to_string(), "5000".to_string()),
+                ("extraction.enabled".to_string(), "false".to_string()),
+                ("extraction.idle_close_ms".to_string(), "60000".to_string()),
                 ("extraction.max_retries".to_string(), "3".to_string()),
+                (
+                    "extraction.model_alias".to_string(),
+                    "phi-3.5-mini".to_string()
+                ),
+                ("extraction.retention_days".to_string(), "30".to_string()),
+                ("extraction.window_turns".to_string(), "5".to_string()),
+                (
+                    "fact_resolution.dedup_cosine_min".to_string(),
+                    "0.92".to_string()
+                ),
+                (
+                    "fact_resolution.supersede_cosine_min".to_string(),
+                    "0.4".to_string()
+                ),
                 ("memory.location".to_string(), "vault-subdir".to_string()),
-                ("version".to_string(), "8".to_string()),
+                ("version".to_string(), "9".to_string()),
             ]
         );
     }
 
     #[test]
-    fn fresh_v8_schema_enforces_superseded_by_foreign_key() {
+    fn fresh_v9_schema_enforces_superseded_by_foreign_key() {
         let conn = open(":memory:").unwrap();
 
         let err = conn
@@ -1162,7 +1216,7 @@ mod tests {
     }
 
     #[test]
-    fn fresh_v8_schema_rejects_invalid_extraction_queue_trigger_kind() {
+    fn fresh_v9_schema_rejects_invalid_extraction_queue_trigger_kind() {
         let conn = open(":memory:").unwrap();
 
         let err = conn
@@ -1178,7 +1232,7 @@ mod tests {
     }
 
     #[test]
-    fn fresh_v8_schema_rejects_invalid_extraction_queue_status() {
+    fn fresh_v9_schema_rejects_invalid_extraction_queue_status() {
         let conn = open(":memory:").unwrap();
 
         let err = conn
@@ -1189,6 +1243,22 @@ mod tests {
                 [],
             )
             .expect_err("invalid status should fail");
+
+        assert!(matches!(err, rusqlite::Error::SqliteFailure(_, _)));
+    }
+
+    #[test]
+    fn fresh_v9_schema_rejects_invalid_correction_session_status() {
+        let conn = open(":memory:").unwrap();
+
+        let err = conn
+            .execute(
+                "INSERT INTO correction_sessions
+                     (correction_id, fact_slug, exchange_log, turns_used, status, created_at, expires_at)
+                 VALUES (?1, 'facts/example', '[]', 0, 'paused', '2026-05-05T00:00:00Z', '2026-05-05T01:00:00Z')",
+                [uuid::Uuid::now_v7().to_string()],
+            )
+            .expect_err("invalid correction session status should fail");
 
         assert!(matches!(err, rusqlite::Error::SqliteFailure(_, _)));
     }
@@ -1232,7 +1302,7 @@ mod tests {
         let version: i64 = conn2
             .query_row("PRAGMA user_version", [], |row| row.get(0))
             .unwrap();
-        assert_eq!(version, 8);
+        assert_eq!(version, 9);
     }
 
     #[test]
@@ -1454,16 +1524,16 @@ mod tests {
     }
 
     #[test]
-    fn open_with_model_rejects_v7_database_before_creating_v8_tables() {
+    fn open_with_model_rejects_v8_database_before_creating_v9_tables() {
         let dir = tempfile::TempDir::new().unwrap();
         let db_path = dir.path().join("legacy.db");
-        seed_existing_db(&db_path, 7);
+        seed_existing_db(&db_path, 8);
 
         let err = open_with_model(db_path.to_str().unwrap(), &default_model())
             .expect_err("legacy database should be refused");
 
         assert!(matches!(err, DbError::Schema { .. }));
-        assert!(err.to_string().contains("Found version 7, expected 8"));
+        assert!(err.to_string().contains("Found version 8, expected 9"));
 
         let conn = Connection::open(&db_path).unwrap();
         assert!(!table_exists(&conn, "collections").unwrap());
@@ -1474,14 +1544,14 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(stored_version, "7");
+        assert_eq!(stored_version, "8");
     }
 
     #[test]
-    fn init_rejects_v7_database_before_creating_v8_tables() {
+    fn init_rejects_v8_database_before_creating_v9_tables() {
         let dir = tempfile::TempDir::new().unwrap();
         let db_path = dir.path().join("legacy.db");
-        seed_existing_db(&db_path, 7);
+        seed_existing_db(&db_path, 8);
 
         let err = init(db_path.to_str().unwrap(), &default_model())
             .expect_err("legacy database should be refused");
@@ -1497,11 +1567,11 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(config_version, "7");
+        assert_eq!(config_version, "8");
     }
 
     #[test]
-    fn open_connection_seeds_config_version_to_8_for_partial_v8_databases() {
+    fn open_connection_seeds_config_version_to_9_for_partial_v9_databases() {
         let dir = tempfile::TempDir::new().unwrap();
         let db_path = dir.path().join("partial-v8.db");
         let conn = open_connection(db_path.to_str().unwrap()).unwrap();
@@ -1512,17 +1582,17 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(config_version, "8");
+        assert_eq!(config_version, "9");
         drop(conn);
 
         assert!(
             preflight_existing_schema(db_path.to_str().unwrap()).is_ok(),
-            "freshly seeded v8 DDL should not be misclassified as legacy before quaid_config is written"
+            "freshly seeded v9 DDL should not be misclassified as legacy before quaid_config is written"
         );
     }
 
     #[test]
-    fn open_with_model_recovers_crash_partial_v8_bootstrap() {
+    fn open_with_model_recovers_crash_partial_v9_bootstrap() {
         let dir = tempfile::TempDir::new().unwrap();
         let db_path = dir.path().join("partial-v8.db");
         let conn = open_connection(db_path.to_str().unwrap()).unwrap();
@@ -1533,12 +1603,12 @@ mod tests {
         let stored = read_quaid_config(&opened.conn).unwrap().unwrap();
 
         assert_eq!(stored.model_alias, "small");
-        assert_eq!(stored.schema_version, 8);
+        assert_eq!(stored.schema_version, 9);
     }
 
     #[cfg(feature = "online-model")]
     #[test]
-    fn open_with_model_recovers_crash_partial_v8_bootstrap_from_registry_model() {
+    fn open_with_model_recovers_crash_partial_v9_bootstrap_from_registry_model() {
         let dir = tempfile::TempDir::new().unwrap();
         let db_path = dir.path().join("partial-v8-registry.db");
         let conn = open_connection(db_path.to_str().unwrap()).unwrap();
@@ -1556,7 +1626,7 @@ mod tests {
     }
 
     #[test]
-    fn init_recovers_crash_partial_v8_bootstrap() {
+    fn init_recovers_crash_partial_v9_bootstrap() {
         let dir = tempfile::TempDir::new().unwrap();
         let db_path = dir.path().join("partial-v8-init.db");
         let conn = open_connection(db_path.to_str().unwrap()).unwrap();
@@ -1567,7 +1637,7 @@ mod tests {
         let stored = read_quaid_config(&conn).unwrap().unwrap();
 
         assert_eq!(stored.model_alias, "small");
-        assert_eq!(stored.schema_version, 8);
+        assert_eq!(stored.schema_version, 9);
     }
 
     #[test]
@@ -1728,7 +1798,7 @@ mod tests {
         assert_eq!(config.model_id, "BAAI/bge-large-en-v1.5");
         assert_eq!(config.model_alias, "large");
         assert_eq!(config.embedding_dim, 1024);
-        assert_eq!(config.schema_version, 8);
+        assert_eq!(config.schema_version, 9);
     }
 
     #[test]
@@ -1744,7 +1814,7 @@ mod tests {
                 model_id: "BAAI/bge-small-en-v1.5".to_owned(),
                 model_alias: "small".to_owned(),
                 embedding_dim: 384,
-                schema_version: 8,
+                schema_version: 9,
             }
         );
     }

--- a/src/core/reconciler.rs
+++ b/src/core/reconciler.rs
@@ -248,7 +248,12 @@ pub(crate) fn reconcile_with_native_events(
             })?;
         let walked = walk_collection(conn, &root_fd, collection)?;
         detect_duplicate_uuids_in_tree(Path::new(&collection.root_path), &walked.files)?;
-        let diff = stat_diff_from_walk(conn, collection.id, Path::new(&collection.root_path), walked.files)?;
+        let diff = stat_diff_from_walk(
+            conn,
+            collection.id,
+            Path::new(&collection.root_path),
+            walked.files,
+        )?;
         let rename_resolution = resolve_rename_resolution(
             conn,
             collection.id,
@@ -2649,7 +2654,7 @@ fn apply_reingest(
             &edited_page,
             &raw_bytes,
         )
-        .map_err(|err| ReconcileError::Other(format!("apply_reingest: {err}")))? 
+        .map_err(|err| ReconcileError::Other(format!("apply_reingest: {err}")))?
         {
             HandleExtractedEditOutcome::Bypass => {}
             HandleExtractedEditOutcome::WhitespaceNoOp
@@ -2678,10 +2683,9 @@ fn apply_reingest(
     })?;
 
     let tx = conn.unchecked_transaction()?;
-    let now: String =
-        tx.query_row("SELECT strftime('%Y-%m-%dT%H:%M:%SZ', 'now')", [], |row| {
-            row.get(0)
-        })?;
+    let now: String = tx.query_row("SELECT strftime('%Y-%m-%dT%H:%M:%SZ', 'now')", [], |row| {
+        row.get(0)
+    })?;
 
     let (page_id, created) = if let Some((page_id, _)) = current_page {
         tx.execute(
@@ -3750,13 +3754,10 @@ mod tests {
             original.as_bytes(),
         )
         .unwrap();
-        let before_file_state = file_state::get_file_state(
-            &conn,
-            collection.id,
-            &path_to_string(&relative_path),
-        )
-        .unwrap()
-        .unwrap();
+        let before_file_state =
+            file_state::get_file_state(&conn, collection.id, &path_to_string(&relative_path))
+                .unwrap()
+                .unwrap();
 
         let whitespace_only =
             "---\nslug: preferences/noop\n title: Noop\ntype: preference\n---\nbody  \n\n";
@@ -3772,13 +3773,10 @@ mod tests {
         assert!(plan.unchanged[0].skip_metadata_refresh);
         apply_full_hash_metadata_self_heal(&conn, collection.id, &plan.unchanged).unwrap();
 
-        let after_file_state = file_state::get_file_state(
-            &conn,
-            collection.id,
-            &path_to_string(&relative_path),
-        )
-        .unwrap()
-        .unwrap();
+        let after_file_state =
+            file_state::get_file_state(&conn, collection.id, &path_to_string(&relative_path))
+                .unwrap()
+                .unwrap();
         assert_eq!(before_file_state.sha256, after_file_state.sha256);
         assert_eq!(before_file_state.mtime_ns, after_file_state.mtime_ns);
     }

--- a/src/core/vault_sync.rs
+++ b/src/core/vault_sync.rs
@@ -2441,7 +2441,8 @@ fn convert_reconcile_error(
 #[cfg(unix)]
 fn relative_markdown_path(root_path: &Path, path: &Path) -> Option<PathBuf> {
     let relative = path.strip_prefix(root_path).ok()?;
-    (is_markdown_file(relative) && !is_history_sidecar_path(relative)).then(|| relative.to_path_buf())
+    (is_markdown_file(relative) && !is_history_sidecar_path(relative))
+        .then(|| relative.to_path_buf())
 }
 
 #[cfg(unix)]

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -1,4 +1,4 @@
--- memory.db schema — Quaid v8
+-- memory.db schema — Quaid v9
 -- Embedded in binary via include_str!("schema.sql") in src/core/db.rs
 -- Standalone copy for reference and tooling.
 
@@ -402,6 +402,23 @@ CREATE INDEX IF NOT EXISTS idx_extraction_queue_pending
     ON extraction_queue(status, scheduled_for) WHERE status = 'pending';
 
 -- ============================================================
+-- correction_sessions: bounded fact-correction dialogues
+-- ============================================================
+CREATE TABLE IF NOT EXISTS correction_sessions (
+    correction_id TEXT PRIMARY KEY,
+    fact_slug     TEXT    NOT NULL,
+    exchange_log  TEXT    NOT NULL CHECK(json_valid(exchange_log) AND json_type(exchange_log) = 'array'),
+    turns_used    INTEGER NOT NULL DEFAULT 0 CHECK(turns_used >= 0),
+    status        TEXT    NOT NULL DEFAULT 'open'
+                          CHECK(status IN ('open', 'committed', 'abandoned', 'expired')),
+    created_at    TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    expires_at    TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '+1 hour'))
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_correction_open
+    ON correction_sessions(status, expires_at) WHERE status = 'open';
+
+-- ============================================================
 -- config: mutable runtime defaults
 -- ============================================================
 CREATE TABLE IF NOT EXISTS config (
@@ -410,7 +427,7 @@ CREATE TABLE IF NOT EXISTS config (
 );
 
 INSERT OR IGNORE INTO config (key, value) VALUES
-    ('version',               '8'),
+    ('version',               '9'),
     ('embedding_model',       'BAAI/bge-small-en-v1.5'),
     ('embedding_dimensions',  '384'),
     ('chunk_strategy',        'section'),
@@ -418,7 +435,15 @@ INSERT OR IGNORE INTO config (key, value) VALUES
     ('default_token_budget',  '4000'),
     ('memory.location',       'vault-subdir'),
     ('corrections.history_on_disk', 'false'),
-    ('extraction.max_retries', '3');
+    ('extraction.max_retries', '3'),
+    ('extraction.enabled', 'false'),
+    ('extraction.model_alias', 'phi-3.5-mini'),
+    ('extraction.window_turns', '5'),
+    ('extraction.debounce_ms', '5000'),
+    ('extraction.idle_close_ms', '60000'),
+    ('extraction.retention_days', '30'),
+    ('fact_resolution.dedup_cosine_min', '0.92'),
+    ('fact_resolution.supersede_cosine_min', '0.4');
 
 -- ============================================================
 -- contradictions: detected inconsistencies

--- a/tests/conversation_turn_capture.rs
+++ b/tests/conversation_turn_capture.rs
@@ -507,7 +507,10 @@ fn memory_add_turn_full_flow_creates_file_collapses_queue_and_syncs_conversation
             })
             .unwrap();
         let payload: serde_json::Value = serde_json::from_str(&extract_text(&result)).unwrap();
-        assert_eq!(payload["conversation_path"], "conversations/2026-05-03/session-e2e.md");
+        assert_eq!(
+            payload["conversation_path"],
+            "conversations/2026-05-03/session-e2e.md"
+        );
     }
 
     let conversation_path = vault_root
@@ -604,7 +607,10 @@ fn memory_close_session_marks_latest_day_closed_and_overrides_debounce_job() {
         .unwrap();
     let second_payload: serde_json::Value = serde_json::from_str(&extract_text(&second)).unwrap();
     assert_eq!(first_payload["closed_at"], second_payload["closed_at"]);
-    assert_eq!(fs::read_to_string(&conversation_path).unwrap(), closed_rendered);
+    assert_eq!(
+        fs::read_to_string(&conversation_path).unwrap(),
+        closed_rendered
+    );
 
     let db = db::open(db_path.to_str().unwrap()).unwrap();
     let queue_row: (String, String) = db

--- a/tests/file_edit_supersede.rs
+++ b/tests/file_edit_supersede.rs
@@ -48,13 +48,21 @@ fn set_default_root(conn: &Connection, root: &Path) {
 }
 
 fn page_id(conn: &Connection, slug: &str) -> i64 {
-    conn.query_row("SELECT id FROM pages WHERE collection_id = 1 AND slug = ?1", [slug], |row| {
-        row.get(0)
-    })
+    conn.query_row(
+        "SELECT id FROM pages WHERE collection_id = 1 AND slug = ?1",
+        [slug],
+        |row| row.get(0),
+    )
     .unwrap()
 }
 
-fn seed_tracked_file(conn: &Connection, root: &Path, relative_path: &str, page_id: i64, content: &str) {
+fn seed_tracked_file(
+    conn: &Connection,
+    root: &Path,
+    relative_path: &str,
+    page_id: i64,
+    content: &str,
+) {
     let absolute = root.join(relative_path);
     fs::create_dir_all(absolute.parent().unwrap()).unwrap();
     fs::write(&absolute, content).unwrap();
@@ -73,9 +81,7 @@ fn slugs(rows: &[Value]) -> Vec<String> {
 }
 
 fn preference_markdown(slug: &str, title: &str, body: &str, supersedes: Option<&str>) -> String {
-    let mut out = format!(
-        "---\nslug: {slug}\ntitle: {title}\ntype: preference\n"
-    );
+    let mut out = format!("---\nslug: {slug}\ntitle: {title}\ntype: preference\n");
     if let Some(supersedes) = supersedes {
         out.push_str(&format!("supersedes: {supersedes}\n"));
     }
@@ -94,7 +100,12 @@ fn editing_chained_extracted_preference_preserves_one_linear_chain() {
     let conn = open_test_db(&db_path);
     set_default_root(&conn, &root);
 
-    let seed = preference_markdown("preferences/foo-seed", "Foo seed", "shared marker seed", None);
+    let seed = preference_markdown(
+        "preferences/foo-seed",
+        "Foo seed",
+        "shared marker seed",
+        None,
+    );
     let head = preference_markdown(
         "preferences/foo",
         "Foo head",
@@ -184,7 +195,10 @@ fn editing_chained_extracted_preference_preserves_one_linear_chain() {
             .unwrap(),
     ))
     .unwrap();
-    assert_eq!(slugs(&search_default), vec!["default::preferences/foo".to_string()]);
+    assert_eq!(
+        slugs(&search_default),
+        vec!["default::preferences/foo".to_string()]
+    );
 
     let search_history: Vec<Value> = serde_json::from_str(&extract_text(
         &server
@@ -257,20 +271,33 @@ fn whitespace_only_edit_is_true_noop() {
     let original = preference_markdown("preferences/noop", "Noop", "body", None);
     put_page(&server, "preferences/noop", &original);
     let page_id = page_id(&conn, "preferences/noop");
-    seed_tracked_file(&conn, &root, "extracted/preferences/noop.md", page_id, &original);
+    seed_tracked_file(
+        &conn,
+        &root,
+        "extracted/preferences/noop.md",
+        page_id,
+        &original,
+    );
     let before_version: i64 = conn
-        .query_row("SELECT version FROM pages WHERE id = ?1", [page_id], |row| row.get(0))
+        .query_row(
+            "SELECT version FROM pages WHERE id = ?1",
+            [page_id],
+            |row| row.get(0),
+        )
         .unwrap();
     let before_rows: i64 = conn
-        .query_row("SELECT COUNT(*) FROM raw_imports WHERE page_id = ?1", [page_id], |row| {
-            row.get(0)
-        })
+        .query_row(
+            "SELECT COUNT(*) FROM raw_imports WHERE page_id = ?1",
+            [page_id],
+            |row| row.get(0),
+        )
         .unwrap();
     let before_file_state = file_state::get_file_state(&conn, 1, "extracted/preferences/noop.md")
         .unwrap()
         .unwrap();
 
-    let whitespace_only = "---\nslug: preferences/noop\n title: Noop\ntype: preference\n---\nbody  \n\n";
+    let whitespace_only =
+        "---\nslug: preferences/noop\n title: Noop\ntype: preference\n---\nbody  \n\n";
     let live_path = root.join("extracted").join("preferences").join("noop.md");
     fs::write(&live_path, whitespace_only).unwrap();
     let stat = file_state::stat_file(&live_path).unwrap();
@@ -292,12 +319,18 @@ fn whitespace_only_edit_is_true_noop() {
 
     assert_eq!(outcome, HandleExtractedEditOutcome::WhitespaceNoOp);
     let after_version: i64 = conn
-        .query_row("SELECT version FROM pages WHERE id = ?1", [page_id], |row| row.get(0))
+        .query_row(
+            "SELECT version FROM pages WHERE id = ?1",
+            [page_id],
+            |row| row.get(0),
+        )
         .unwrap();
     let after_rows: i64 = conn
-        .query_row("SELECT COUNT(*) FROM raw_imports WHERE page_id = ?1", [page_id], |row| {
-            row.get(0)
-        })
+        .query_row(
+            "SELECT COUNT(*) FROM raw_imports WHERE page_id = ?1",
+            [page_id],
+            |row| row.get(0),
+        )
         .unwrap();
     let after_file_state = file_state::get_file_state(&conn, 1, "extracted/preferences/noop.md")
         .unwrap()
@@ -364,7 +397,13 @@ fn history_on_disk_writes_sidecar_without_extra_live_page() {
     let original = preference_markdown("preferences/disk", "Disk", "disk marker original", None);
     put_page(&server, "preferences/disk", &original);
     let page_id = page_id(&conn, "preferences/disk");
-    seed_tracked_file(&conn, &root, "extracted/preferences/disk.md", page_id, &original);
+    seed_tracked_file(
+        &conn,
+        &root,
+        "extracted/preferences/disk.md",
+        page_id,
+        &original,
+    );
 
     let edited = preference_markdown("preferences/disk", "Disk", "disk marker edited", None);
     let live_path = root.join("extracted").join("preferences").join("disk.md");
@@ -397,9 +436,11 @@ fn history_on_disk_writes_sidecar_without_extra_live_page() {
     assert!(absolute_history_path.exists());
     assert!(is_history_sidecar_path(Path::new(&history_path)));
     let page_count: i64 = conn
-        .query_row("SELECT COUNT(*) FROM pages WHERE slug = 'preferences/disk'", [], |row| {
-            row.get(0)
-        })
+        .query_row(
+            "SELECT COUNT(*) FROM pages WHERE slug = 'preferences/disk'",
+            [],
+            |row| row.get(0),
+        )
         .unwrap();
     assert_eq!(page_count, 1);
 }
@@ -416,22 +457,26 @@ fn whitespace_helper_and_non_head_guard_cover_manual_edit_edges() {
     let original = preference_markdown("preferences/edge", "Edge", "body", None);
     put_page(&server, "preferences/edge", &original);
     let page_id = page_id(&conn, "preferences/edge");
-    seed_tracked_file(&conn, &root, "extracted/preferences/edge.md", page_id, &original);
+    seed_tracked_file(
+        &conn,
+        &root,
+        "extracted/preferences/edge.md",
+        page_id,
+        &original,
+    );
 
     let whitespace_only =
         "---\nslug: preferences/edge\ntitle: Edge\ntype: preference\n---\nbody  \n";
     let live_path = root.join("extracted").join("preferences").join("edge.md");
     fs::write(&live_path, whitespace_only).unwrap();
-    assert!(
-        is_extracted_whitespace_noop(
-            &conn,
-            1,
-            &root,
-            Path::new("extracted/preferences/edge.md"),
-            page_id,
-        )
-        .unwrap()
-    );
+    assert!(is_extracted_whitespace_noop(
+        &conn,
+        1,
+        &root,
+        Path::new("extracted/preferences/edge.md"),
+        page_id,
+    )
+    .unwrap());
 
     conn.execute(
         "INSERT INTO pages

--- a/website/src/content/docs/contributing/contributing.md
+++ b/website/src/content/docs/contributing/contributing.md
@@ -60,7 +60,7 @@ quaid/
 ├── docs/                     # User-facing documentation (you are here)
 │   ├── spec.md               # Full technical specification
 │   ├── getting-started.md    # New user / new contributor onboarding
-│   ├── roadmap.md            # Phased delivery plan and status
+│   ├── roadmap_v3.md         # Phased delivery plan and status
 │   └── contributing.md       # This file
 ├── openspec/                 # Structured change proposals
 │   └── changes/              # One directory per proposal

--- a/website/src/content/docs/how-to/upgrade.mdx
+++ b/website/src/content/docs/how-to/upgrade.mdx
@@ -23,7 +23,7 @@ no aliases, and no automatic migration.
 3. Update shell profile exports to `QUAID_DB`, `QUAID_MODEL`, `QUAID_CHANNEL`, etc.
 4. Pre-rename databases are schema-incompatible with `quaid` (`SCHEMA_VERSION` is now `6`). To recover data, use your pre-rename binary to export pages, then run `quaid init` and `quaid import`. If you no longer have that binary, consult the GitHub Release history for that project — this repository does not carry a migration tool.
 
-No shims, no aliases, no automatic migration. Full surface reference: [`docs/MIGRATION.md`](https://github.com/quaid-app/quaid/blob/main/docs/MIGRATION.md).
+No shims, no aliases, no automatic migration. Full surface reference: [`MIGRATION.md`](https://github.com/quaid-app/quaid/blob/main/MIGRATION.md).
 </Aside>
 
 ## Check what you have

--- a/website/src/content/docs/how-to/upgrade.mdx
+++ b/website/src/content/docs/how-to/upgrade.mdx
@@ -23,7 +23,7 @@ no aliases, and no automatic migration.
 3. Update shell profile exports to `QUAID_DB`, `QUAID_MODEL`, `QUAID_CHANNEL`, etc.
 4. Pre-rename databases are schema-incompatible with `quaid` (`SCHEMA_VERSION` is now `6`). To recover data, use your pre-rename binary to export pages, then run `quaid init` and `quaid import`. If you no longer have that binary, consult the GitHub Release history for that project — this repository does not carry a migration tool.
 
-No shims, no aliases, no automatic migration. Full surface reference: [`MIGRATION.md`](https://github.com/quaid-app/quaid/blob/main/MIGRATION.md).
+No shims, no aliases, no automatic migration. Full surface reference: [`docs/MIGRATION.md`](https://github.com/quaid-app/quaid/blob/main/docs/MIGRATION.md).
 </Aside>
 
 ## Check what you have

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -118,10 +118,10 @@ Three commands. No API keys. No cloud.
 # Initialize a memory
 quaid init ~/memory.db
 
-# Import your notes (idempotent — safe to re-run)
-quaid import ~/notes --db ~/memory.db
+# Attach your notes as a live-sync collection
+quaid collection add notes ~/notes --db ~/memory.db
 
-# Expose 17 tools to any MCP client over stdio (Unix/macOS/Linux; v0.9.6)
+# Expose Quaid's MCP tools over stdio (19 in `v0.17.0`; 22 on the `v0.18.0` branch)
 QUAID_DB=~/memory.db quaid serve
 ```
 

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -28,7 +28,7 @@ import GuideMetricCard from "../../components/docs/GuideMetricCard.astro";
 Then build your first memory and connect it to Claude Code:
 
 <Code code={`quaid init ~/memory.db
-quaid import ~/notes --db ~/memory.db
+quaid collection add notes ~/notes --db ~/memory.db
 QUAID_DB=~/memory.db quaid serve`} lang="bash" />
 
 **Three commands. No API keys. No cloud.** [Full install options →](/tutorials/install/)
@@ -54,7 +54,7 @@ QUAID_DB=~/memory.db quaid serve`} lang="bash" />
     href="/agents/quickstart/"
     linkText="Open the agent quickstart"
   >
-    <p>Seventeen <code>memory_*</code> tools over stdio JSON-RPC. Same surface humans use; same data, same contracts. Privacy-safe gap logging, OCC-protected writes, and a sensitivity contract that keeps raw queries from ever leaving the machine by accident.</p>
+    <p>Nineteen <code>memory_*</code> tools in the latest public release, with 22 on the <code>v0.18.0</code> branch. Same surface humans use; same data, same contracts. Privacy-safe gap logging, OCC-protected writes, and a sensitivity contract that keeps raw queries from ever leaving the machine by accident.</p>
   </AudienceCard>
 </div>
 
@@ -83,7 +83,7 @@ QUAID_DB=~/memory.db quaid serve`} lang="bash" />
 
 <div class="gb-guide-grid gb-guide-grid--three">
   <GuideMetricCard value="27" label="CLI commands" note="Read, write, graph, intelligence, collections, system." />
-  <GuideMetricCard value="17" label="MCP tools" note="Same surface, exposed to any MCP-compatible client." />
+  <GuideMetricCard value="19" label="Public MCP tools" note="The `v0.18.0` branch carries 22, including conversation capture." />
   <GuideMetricCard value="8" label="Embedded skills" note="Ingest, query, maintain, enrich, briefing, alerts, research, upgrade." />
   <GuideMetricCard value="1" label="Static binary" note="No daemon, no port, no Docker, no Python." />
   <GuideMetricCard value="0" label="API keys required" note="The model runs on your CPU. Nothing transits your network." />

--- a/website/src/content/docs/integrations/hermes.mdx
+++ b/website/src/content/docs/integrations/hermes.mdx
@@ -15,7 +15,7 @@ Quaid can function as a durable memory system for [Hermes Agent](https://github.
 - **Semantic retrieval.** Hermes can query "concepts" rather than just keywords.
 - **PARA alignment.** Organizes knowledge into Projects, Areas, Resources, and Archives.
 - **Episodic memory.** Use timelines to track how a project or decision evolved over time.
-- **Native tooling.** Quaid exposes 17 tools via MCP.
+- **Native tooling.** Quaid exposes 22 tools on the `v0.18.0` branch and 19 in the latest public release (`v0.17.0`).
 
 ## Setup
 

--- a/website/src/content/docs/tutorials/install.mdx
+++ b/website/src/content/docs/tutorials/install.mdx
@@ -60,7 +60,7 @@ The installer always grabs the latest release. To pin:
   | QUAID_VERSION=<published-tag> sh`}
 />
 
-Replace `<published-tag>` with a GitHub Release tag. If you need the unreleased `v0.12.0` branch state — including Batch 3 `quaid_id` write-back / `migrate-uuids` support for collection-backed vaults — build from source instead.
+Replace `<published-tag>` with a GitHub Release tag. GitHub Releases currently publishes `v0.17.0`; if you need the unreleased `v0.18.0` branch state — the 3 conversation-memory capture tools, conversation day-files, and supersede-aware retrieval defaults — build from source instead.
 
 ## What you got
 


### PR DESCRIPTION
## What this draft PR currently claims

Remote head `0309664` still carries only two pushed, verified slices:

- v0.18.0 release-truth prep: manifest parity, install/release-doc truth, website copy, and migration-link repairs
- Batch 1 of `slm-extraction-and-correction`: tasks 1.1-1.6 are checked off, landing the schema v9 foundation in `src/schema.sql` and `src/core/db.rs` (`correction_sessions`, extraction + fact-resolution defaults, schema-version enforcement, and v8 rejection coverage)

## Why this draft still uses the fresh head branch

`feat/slm-conversation-mem` already backed merged PR #153. This draft keeps `squad/105-v0180-release-truth` as the compare-clean head so reviewers only see the still-unmerged slice.

## What is intentionally not claimed on this pushed head

Follow-on local work for section 3, CLI tasks 4.1-4.3 / 4.5 / 4.6, the schema fail-closed revision, lifecycle proof fixes, and the 92.84% coverage push is **not** on this PR head yet.

## Why I did not push the broader branch

Do **not** fast-forward or force-push `feat/slm-conversation-mem` (or `origin/feat/slm-conversation-mem`) onto this PR head as-is. That line currently also carries unrelated `.squad` decision churn, deleted legacy docs (`MIGRATION.md`, `phase2_progress.md`), merged-main ancestry noise, and broader command/server/reconciler file movement than this draft claims.

**Next hygiene step:** start from `origin/squad/105-v0180-release-truth` in a clean worktree, cherry-pick only the coherent follow-on SLM/model commits, run `cargo test --locked`, then force-push this same head branch.

## Remaining work starts at

Section 2 of `openspec/changes/slm-extraction-and-correction/tasks.md` (the SLM runtime). This PR does not claim the runtime, model lifecycle, extraction CLI, worker, or correction dialogue yet.

## Explicit non-claims

- no Phi-3 / Gemma runtime yet
- no model-download or `quaid extraction` / `quaid model` CLI surface on this pushed head yet
- no extraction worker, fact-page writer, or correction dialogue tools yet
- no `memory_correct` / `memory_correct_continue` MCP tools yet
- no v0.18.0 tag or release cut yet
- no v0.19.0 tag or release cut yet

## Validation / current status

- GitHub currently reports `mergeStateStatus: BEHIND`, not `DIRTY`
- current remote-head checks: 11 successful, 1 failing (`CI/Coverage`), 1 skipped
- successful checks include `CI/Check`, `CI/Test`, `Docs CI/Check`, `CI/Offline Benchmarks`, release preflights, and `Squad CI/test`
- the unpublished follow-on coverage work is not claimed here until it is pushed cleanly

Related to #105, #135.
