### PR TITLE
chore: bump version to v0.20.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quaid"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 description = "Local-first personal memory. SQLite + FTS5 + local vector embeddings. One static binary."
 license = "MIT"


### PR DESCRIPTION
Aligning Cargo.toml with the v0.20.0 release to fix failing CI/CD release action.