### PR TITLE
fix: address beta-reported v0.22.0 regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to Quaid are tracked here. Pre-1.0, schema and
 response-shape changes may break compatibility between minor versions —
 each entry below calls out the migration implications.
 
+## v0.22.1 — beta regression fixes
+
+### Fixed
+
+- **Vault import / export parity.** `related:` frontmatter now accepts either a
+  scalar string or a YAML list, so Obsidian/DAB-style scalar relationships no
+  longer abort collection attach or create export deltas.
+- **PARA type inference.** Collection ingest now recognizes both singular and
+  plural PARA folder names (`project(s)`, `area(s)`, `resource(s)`,
+  `archive(s)`) after numeric-prefix stripping.
+- **MCP runtime shutdown.** `quaid serve` and foreground `quaid daemon run`
+  handle SIGTERM/SIGINT by dropping owned runtime workers and unregistering
+  their `serve_sessions` rows without touching unrelated processes.
+- **Embedding batch stability.** Bulk `quaid embed` scans pages in bounded
+  batches (default 32) and adds `--batch-size N` validation to reduce first-run
+  memory pressure on larger vaults while preserving idempotent reruns.
+
+### Migration
+
+- No schema migration. Existing v0.22.0 databases remain compatible.
+
 ## v0.22.0 — knowledge graph layer (pre-release v9 → v10)
 
 ### Schema

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2135,7 +2135,7 @@ dependencies = [
 
 [[package]]
 name = "quaid"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quaid"
-version = "0.22.0"
+version = "0.22.1"
 edition = "2021"
 description = "Local-first personal memory. SQLite + FTS5 + local vector embeddings. One static binary."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Most agent memory systems require a cloud service, a running database, or an API
 
 - **Local-first** — single SQLite file, no cloud dependency, works offline
 - **PARA-native** — organizes memory as a knowledge base (Projects, Areas, Resources, Archives), not a flat list of facts
-- **24 MCP tools, knowledge-graph path output, daemon runtime, `quaid daemon` lifecycle commands, `quaid status`, and an opt-in HTTP/SSE MCP transport in the current published release (`v0.22.0`)**
+- **24 MCP tools, knowledge-graph path output, daemon runtime, `quaid daemon` lifecycle commands, `quaid status`, and an opt-in HTTP/SSE MCP transport in the current published release (`v0.22.1`)**
 - **Hybrid retrieval** — FTS5 full-text + local BGE vector embeddings, combined via RRF
 - **Verified by benchmarks** — [193/215 (90%) on DAB](https://quaid-app.github.io/quaid-evals), P@5 on MSMARCO ahead of BM25 baseline
 
@@ -69,7 +69,7 @@ Add to your `.mcp.json`:
 }
 ```
 
-The current published release (`v0.22.0`) exposes 24 MCP tools over stdio, graph path output, and an opt-in HTTP/SSE transport via `quaid serve --http` or `quaid daemon run --http`.
+The current published release (`v0.22.1`) exposes 24 MCP tools over stdio, graph path output, and an opt-in HTTP/SSE transport via `quaid serve --http` or `quaid daemon run --http`.
 
 ---
 
@@ -86,13 +86,13 @@ Sets up `PATH` and `QUAID_DB` automatically. Use `QUAID_CHANNEL=online` for the 
 ### Download a binary
 
 ```bash
-VERSION="<published-tag>"   # for example: v0.22.0
+VERSION="<published-tag>"   # for example: v0.22.1
 PLATFORM="darwin-arm64"   # darwin-arm64 | darwin-x86_64 | linux-x86_64 | linux-aarch64
 curl -fsSL "https://github.com/quaid-app/quaid/releases/download/${VERSION}/quaid-${PLATFORM}-online" \
   -o quaid && chmod +x quaid && sudo mv quaid /usr/local/bin/
 ```
 
-Use a published tag here. GitHub Releases publish `v0.22.0`, including the knowledge graph layer, daemon runtime, and HTTP/SSE transport.
+Use a published tag here. GitHub Releases publish `v0.22.1`, including the knowledge graph layer, daemon runtime, and HTTP/SSE transport.
 
 ### Build from source
 
@@ -115,7 +115,7 @@ Two ideas borrowed from Andrej Karpathy's compiled knowledge model:
 
 **Timeline (below the line)** — append-only, never rewritten. What happened and when.
 
-Every page in Quaid has both. Agents read and write through Quaid's MCP surface via stdio — 24 tools in the current published release (`v0.22.0`) — with no REST API and no network dependency. An opt-in HTTP/SSE transport is also available via `quaid serve --http` or `quaid daemon run --http`.
+Every page in Quaid has both. Agents read and write through Quaid's MCP surface via stdio — 24 tools in the current published release (`v0.22.1`) — with no REST API and no network dependency. An opt-in HTTP/SSE transport is also available via `quaid serve --http` or `quaid daemon run --http`.
 
 **Hybrid retrieval:** FTS5 keyword search for exact recall (names, slugs, tags) combined with local BGE vector embeddings for semantic search. Set-union merge, exact-match short-circuit.
 
@@ -137,6 +137,7 @@ quaid ingest /path/to/note.md
 
 # Generate or refresh embeddings
 quaid embed
+quaid embed --stale --batch-size 32
 
 # Full-text search
 quaid search "stablecoin regulation"
@@ -164,7 +165,7 @@ quaid gaps
 # Start MCP server (stdio, default)
 quaid serve
 
-# Start MCP server with opt-in HTTP/SSE transport (available in v0.22.0)
+# Start MCP server with opt-in HTTP/SSE transport (available in v0.22.1)
 quaid serve --http --port 3112 --trust-loopback
 
 # Install background daemon (macOS launchd or Linux systemd)
@@ -185,7 +186,7 @@ quaid status
 
 ## MCP tools
 
-The current published release (`v0.22.0`) exposes 24 MCP tools over stdio, plus graph path output, daemon runtime, `quaid daemon` commands, `quaid status`, and opt-in HTTP/SSE transport:
+The current published release (`v0.22.1`) exposes 24 MCP tools over stdio, plus graph path output, daemon runtime, `quaid daemon` commands, `quaid status`, and opt-in HTTP/SSE transport:
 
 | Category | Tools |
 |----------|-------|

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started with Quaid
 
-> Quaid is a local-first personal AI memory layer: SQLite + FTS5 + local vector embeddings in one file. The current published release is `v0.22.0`, which ships the knowledge graph layer, graph path explanations, daemon runtime, `quaid daemon` lifecycle commands, `quaid status`, and an opt-in HTTP/SSE MCP transport.
+> Quaid is a local-first personal AI memory layer: SQLite + FTS5 + local vector embeddings in one file. The current published release is `v0.22.1`, which ships the knowledge graph layer, graph path explanations, daemon runtime, `quaid daemon` lifecycle commands, `quaid status`, and an opt-in HTTP/SSE MCP transport.
 
 ## What it does
 
@@ -15,9 +15,9 @@ You search it with full-text keywords and semantic queries. Any MCP-compatible A
 
 ## Status
 
-> **The current published release is `v0.22.0`.** It ships the knowledge graph layer, graph path explanations, structured frontmatter link/tag autowiring, `quaid graph extract-entities`, a detached background daemon (`quaid daemon run`, managed via launchd on macOS and systemd on Linux), `quaid daemon install|uninstall|start|stop|restart|status|logs`, `quaid status`, and an opt-in HTTP/SSE MCP transport (`quaid serve --http`). The 24-tool MCP surface is unchanged.
+> **The current published release is `v0.22.1`.** It ships the knowledge graph layer, graph path explanations, structured frontmatter link/tag autowiring, `quaid graph extract-entities`, a detached background daemon (`quaid daemon run`, managed via launchd on macOS and systemd on Linux), `quaid daemon install|uninstall|start|stop|restart|status|logs`, `quaid status`, and an opt-in HTTP/SSE MCP transport (`quaid serve --http`). The 24-tool MCP surface is unchanged.
 >
-> Published GitHub Release binaries and `install.sh` resolve to `v0.22.0`. See [roadmap_v3.md](roadmap_v3.md) for the full delivery plan.
+> Published GitHub Release binaries and `install.sh` resolve to `v0.22.1`. See [roadmap_v3.md](roadmap_v3.md) for the full delivery plan.
 
 ---
 
@@ -26,7 +26,7 @@ You search it with full-text keywords and semantic queries. Any MCP-compatible A
 | Method | Status |
 | ------ | ------ |
 | Build from source (`cargo build --release`) | ✅ Available now |
-| GitHub Release binary (macOS ARM/x86, Linux x86_64/ARM64) | ✅ Available — the latest published tag is `v0.22.0`, including the knowledge graph layer, daemon runtime, and HTTP/SSE transport |
+| GitHub Release binary (macOS ARM/x86, Linux x86_64/ARM64) | ✅ Available — the latest published tag is `v0.22.1`, including the knowledge graph layer, daemon runtime, and HTTP/SSE transport |
 | `npm install -g quaid` | ❌ Not yet published — use binary release or build from source |
 | One-command curl installer | ✅ Available — airgapped by default; set `QUAID_CHANNEL=online` for online |
 
@@ -67,7 +67,7 @@ cross build --release --target aarch64-unknown-linux-musl     # Linux ARM64 (ful
 
 ## Your first memory store
 
-> **Phase 1 commands** are implemented. **Phase 2 commands** (graph, check, gaps) are implemented. **Phase 3 commands** (validate, call, pipe, skills) are implemented. **Phase 5b commands** (daemon lifecycle, `quaid status`, HTTP/SSE transport) and the knowledge graph layer are available in `v0.22.0`; see [Status](#status) and [Install options](#install-options) above.
+> **Phase 1 commands** are implemented. **Phase 2 commands** (graph, check, gaps) are implemented. **Phase 3 commands** (validate, call, pipe, skills) are implemented. **Phase 5b commands** (daemon lifecycle, `quaid status`, HTTP/SSE transport) and the knowledge graph layer are available in `v0.22.1`; see [Status](#status) and [Install options](#install-options) above.
 
 > **Post-install note:** The shell installer (`scripts/install.sh`) automatically adds `PATH` and `QUAID_DB` to your shell profile. If you built from source or used the manual GitHub Releases download, add these to your profile yourself:
 > ```bash
@@ -89,9 +89,10 @@ This creates a new `memory.db` file with the full v8 schema — pages, embedding
 ```bash
 quaid collection add notes /path/to/notes/ --db ~/.quaid/memory.db
 quaid serve
+quaid embed --stale --batch-size 32
 ```
 
-`quaid collection add` performs the initial vault scan, records the collection, and writes pages into the database. On Unix/macOS/Linux, `quaid serve` keeps that collection in sync continuously. For one-off files outside a collection, use `quaid ingest /path/to/file.md`.
+`quaid collection add` performs the initial vault scan, records the collection, and writes pages into the database. On Unix/macOS/Linux, `quaid serve` keeps that collection in sync continuously. `quaid embed` scans pages in bounded batches by default; lower `--batch-size` on constrained machines. For one-off files outside a collection, use `quaid ingest /path/to/file.md`.
 
 > On Unix, you can persist missing `quaid_id` frontmatter during attach (`quaid collection add <name> <path> --write-quaid-id`) or backfill it later with `quaid collection migrate-uuids <name> [--dry-run]`. Same-root single-file `quaid put` can also authenticate a live `quaid serve` owner and proxy the write instead of refusing. For an OpenClaw setup, see [openclaw-harness.md](openclaw-harness.md).
 
@@ -186,7 +187,7 @@ The MCP server exposes tools over stdio JSON-RPC 2.0.
 
 **Collections + namespaces (3):** `memory_collections`, `memory_namespace_create`, `memory_namespace_destroy`
 
-The current published release (`v0.22.0`) exposes 24 tools and adds graph path output, daemon runtime, `quaid daemon` commands, `quaid status`, and opt-in HTTP/SSE transport. See [spec.md](spec.md#mcp-server) for tool signatures.
+The current published release (`v0.22.1`) exposes 24 tools and adds graph path output, daemon runtime, `quaid daemon` commands, `quaid status`, and opt-in HTTP/SSE transport. See [spec.md](spec.md#mcp-server) for tool signatures.
 
 ### Capture a conversation on this branch
 
@@ -196,7 +197,7 @@ quaid call memory_add_turn '{"session_id":"demo","role":"assistant","content":"G
 quaid call memory_close_session '{"session_id":"demo"}'
 ```
 
-Those calls append turns to `conversations/YYYY-MM-DD/<session-id>.md` and queue extraction work. The capture layer, extraction worker, fact-page write path, and benchmark/integration proofs are all available in the published `v0.22.0` release.
+Those calls append turns to `conversations/YYYY-MM-DD/<session-id>.md` and queue extraction work. The capture layer, extraction worker, fact-page write path, and benchmark/integration proofs are all available in the published `v0.22.1` release.
 
 ---
 
@@ -466,7 +467,7 @@ quaid skills doctor   # verify SHA-256 hashes, detect override shadowing
 
 ## vault-sync-engine: Collections and live-sync
 
-> These commands first shipped in `v0.9.6` and remain part of the published `v0.22.0` vault-sync surface, including same-root single-file `quaid put` proxying on Unix.
+> These commands first shipped in `v0.9.6` and remain part of the published `v0.22.1` vault-sync surface, including same-root single-file `quaid put` proxying on Unix.
 
 ### Attach a vault
 

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -34,6 +34,8 @@ children:
   - companies/brex
 related:
   - people/bob
+# or, for a single related page:
+# related: people/carol
 tags: [fintech, yc-w17]
 ---
 ```
@@ -46,7 +48,7 @@ Behavior:
 | `links:` string form | `related` | `frontmatter` | – |
 | `parent:` | `parent` | `frontmatter` | Single string |
 | `children:` | `child` | `frontmatter` | YAML list |
-| `related:` | `related` | `frontmatter` | YAML list |
+| `related:` | `related` | `frontmatter` | YAML string or list |
 | `tags:` | – | – | Populates `tags` table only |
 
 Slug normalization (`resolve_slug`) is applied to every target. Unresolved

--- a/docs/openclaw-harness.md
+++ b/docs/openclaw-harness.md
@@ -90,7 +90,7 @@ QUAID_DB=~/.quaid/memory.db quaid serve
 
 ## MCP tools
 
-The current published release (`v0.22.0`) exposes 24 MCP tools via `quaid serve` and adds the knowledge graph layer, daemon runtime, and opt-in HTTP/SSE transport. All tool names use the `memory_*` prefix.
+The current published release (`v0.22.1`) exposes 24 MCP tools via `quaid serve` and adds the knowledge graph layer, daemon runtime, and opt-in HTTP/SSE transport. All tool names use the `memory_*` prefix.
 
 ### `memory_query` vs `memory_search`
 

--- a/docs/operator-guide-daemon.md
+++ b/docs/operator-guide-daemon.md
@@ -124,6 +124,8 @@ You can run `quaid serve` while a daemon is installed; it will detect the live `
 
 If you stop the daemon (`quaid daemon stop`) while `quaid serve` is running, the next `quaid serve` invocation after the daemon's session-row sweep window (~15s) will auto-promote to `serve_host` and take over runtime ownership.
 
+Foreground runtimes (`quaid serve` and `quaid daemon run`) handle SIGTERM/SIGINT by stopping owned workers and unregistering their `serve_sessions` row. Use the platform service manager (`quaid daemon stop`) for installed daemons; use a direct signal only for foreground/manual processes.
+
 ---
 
 ## Troubleshooting

--- a/docs/roadmap_v3.md
+++ b/docs/roadmap_v3.md
@@ -9,7 +9,7 @@ aliases: [quaid-roadmap]
 # Quaid Product Roadmap
 
 **Last updated:** May 12, 2026
-**Latest public release:** v0.22.0
+**Latest public release:** v0.22.1
 **Current release lane:** v0.23.0
 **Benchmark baseline:** DAB v1 213/215 (99%), LoCoMo 0.1%, LongMemEval 0.0%, BEAM 0.0%
 
@@ -110,7 +110,7 @@ The single biggest gap vs Mem0/GBrain: Quaid stores raw conversation turns as do
 - No new MCP tools; the 24-tool surface is unchanged
 
 ### Release truth
-- First shipped in `v0.21.0`; GitHub Releases and `install.sh` now resolve to `v0.22.0`.
+- First shipped in `v0.21.0`; GitHub Releases and `install.sh` now resolve to `v0.22.1`.
 
 ---
 

--- a/openspec/changes/fix-beta-reported-regressions/.openspec.yaml
+++ b/openspec/changes/fix-beta-reported-regressions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-13

--- a/openspec/changes/fix-beta-reported-regressions/design.md
+++ b/openspec/changes/fix-beta-reported-regressions/design.md
@@ -1,0 +1,45 @@
+## Context
+
+The v0.22.0 knowledge graph release introduced structured frontmatter parsing and additional runtime work during ingest/search. A beta DAB v1.0 run reported regressions in import classification, import/export completeness, server shutdown cleanup, and embed stability. The patch must restore v0.21.0-compatible behavior while preserving v0.22.0 graph capabilities and default-off graph retrieval.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Restore PARA type distribution during collection ingest and round-trip export.
+- Accept recoverable scalar frontmatter forms used by real-world markdown, especially `related: some-slug`.
+- Make MCP shutdown deterministic for Quaid-owned worker processes after SIGTERM.
+- Bound embedding memory use for medium corpora with a conservative default and an override flag.
+- Ship as a patch release without a schema reset.
+
+**Non-Goals:**
+- Improve DAB §4 semantic/hybrid quality, BGE-small paraphrase behavior, or FTS contamination beyond the filed beta issues.
+- Turn graph retrieval expansion on by default.
+- Add durable `entity_pattern` link provenance beyond the v0.22.0 assertions-only scope.
+- Change MCP tool names, schemas, or response shapes.
+
+## Decisions
+
+1. **Treat frontmatter coercion at the parsing edge.** Normalize known relationship fields (`parent`, `children`, `related`) when syncing graph edges instead of rejecting the whole page. This keeps storage structured while making ingest tolerant of common scalar shorthand. Alternative considered: reject invalid fields and skip only graph autowire; rejected because collection attach still fails and round-trip completeness remains broken.
+
+2. **Keep page type inference independent from graph autowire.** Type derivation must read explicit frontmatter type first, then path/content heuristics, and graph processing must not overwrite a derived PARA type with the fallback `concept`. Alternative considered: special-case DAB paths only; rejected because the regression is a general import-classification bug.
+
+3. **Prefer graceful runtime cancellation over process-name cleanup.** Shutdown should notify runtime workers and wait briefly for owned children/threads before process exit. Tests should assert process cleanup by PID where possible rather than using broad `pkill`-style behavior. Alternative considered: force-kill any `quaid` process; rejected because it risks terminating unrelated user sessions.
+
+4. **Batch embed work at the command/runtime layer.** `quaid embed` should process pages in bounded chunks and expose `--batch-size`, defaulting conservatively. Alternative considered: rely on OS retry behavior; rejected because first-run SIGKILL is user-visible data-pipeline failure.
+
+## Risks / Trade-offs
+
+- Recovering scalar frontmatter could hide malformed data → Limit coercion to unambiguous string/list relationship fields and keep invalid complex values reported consistently.
+- Serialized or smaller embed batches may reduce throughput → Prefer successful bounded memory behavior over peak throughput; users can raise `--batch-size`.
+- Shutdown cleanup may expose pre-existing long-running worker assumptions → Use focused integration tests and preserve detached daemon semantics.
+- Some DAB delta=9 files may fail for additional malformed-frontmatter reasons → Add tests around the known `related` failure and inspect any remaining import/export skips before release.
+
+## Migration Plan
+
+No database migration is planned. The patch changes ingest/runtime behavior and adds tests. Existing v10 databases remain valid; users rerun collection sync or embed commands to benefit from fixed behavior.
+
+Rollback is a normal binary downgrade to v0.22.0, with the caveat that v0.22.0 retains the beta-reported bugs.
+
+## Open Questions
+
+- Whether issue #192 reproduces only for `quaid serve` stdio or also for daemon-hosted HTTP/SSE. Implementation should cover both Quaid-owned runtime shutdown paths where practical.

--- a/openspec/changes/fix-beta-reported-regressions/proposal.md
+++ b/openspec/changes/fix-beta-reported-regressions/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Beta DAB v1.0 validation for v0.22.0 regressed from v0.21.0, with confirmed failures in PARA type inference, frontmatter import tolerance, round-trip export completeness, MCP shutdown cleanup, and first-run embedding memory pressure. These issues block confidence in the knowledge graph release and need a patch release before additional graph work proceeds.
+
+## What Changes
+
+- Restore PARA page type inference so collection ingest preserves/derives project, area, resource, archive, and concept classifications instead of collapsing most imported pages to `concept`.
+- Make graph/frontmatter parsing tolerant of common scalar forms such as `related: some-slug`, coercing them to single-item lists instead of aborting collection attach.
+- Preserve import/export round-trip behavior for files with non-canonical but recoverable frontmatter, including exporting every ingested page.
+- Ensure `quaid serve` and MCP runtime shutdown terminate child/worker processes cleanly on SIGTERM.
+- Add bounded embedding batch behavior so `quaid embed` can process a 350-page corpus without first-run OOM/SIGKILL behavior.
+- Release v0.22.1 with documentation/changelog updates and close addressed beta issues.
+
+## Capabilities
+
+### New Capabilities
+- `mcp-server-shutdown`: MCP server shutdown and signal handling terminate all Quaid-owned runtime workers/processes.
+- `embedding-batch-processing`: Embedding commands process pages in bounded batches with an operator-visible batch-size control.
+
+### Modified Capabilities
+- `collections`: Collection import and page classification preserve PARA type inference across graph/frontmatter processing.
+- `frontmatter-link-autowiring`: Frontmatter graph fields accept scalar shorthand where unambiguous and do not reject otherwise importable pages.
+- `vault-sync`: Round-trip export/import remains complete for recoverable frontmatter and collection state.
+
+## Impact
+
+- Affected GitHub issues: #190 parent benchmark report; fixes #191, #192, #193, #194, and #195.
+- Affected code: markdown/frontmatter parsing, collection ingest/reconciliation, page type derivation, graph autowire, MCP/daemon shutdown, embedding command/runtime, release docs.
+- No schema version bump is expected unless investigation finds a persisted-state bug that cannot be repaired behaviorally.
+- No breaking CLI or MCP API changes are intended; any new embed batch flag must be backward-compatible with current defaults.

--- a/openspec/changes/fix-beta-reported-regressions/specs/collections/spec.md
+++ b/openspec/changes/fix-beta-reported-regressions/specs/collections/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Collection ingest preserves PARA type inference
+During collection add, sync, and watcher ingest, the system SHALL assign each page a stable type using explicit frontmatter first and then the existing PARA path/content inference. Graph/frontmatter autowire processing SHALL NOT overwrite a derived page type with the fallback `concept`.
+
+#### Scenario: PARA path types remain distributed
+- **WHEN** a collection contains pages under project, area, resource, and archive paths
+- **THEN** collection ingest stores pages with the corresponding `project`, `area`, `resource`, and `archive` types
+- **AND** pages without explicit or inferred PARA signals use `concept`
+
+#### Scenario: Explicit type wins over path fallback
+- **WHEN** a page frontmatter contains `type: project`
+- **THEN** the stored page type is `project` even if graph autowire finds relationship fields
+
+#### Scenario: Graph autowire does not collapse type
+- **WHEN** a page with inferred type `resource` also contains `links`, `parent`, `children`, `related`, or `tags` frontmatter
+- **THEN** graph/tag sync runs without changing the stored page type to `concept`

--- a/openspec/changes/fix-beta-reported-regressions/specs/embedding-batch-processing/spec.md
+++ b/openspec/changes/fix-beta-reported-regressions/specs/embedding-batch-processing/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Embed command processes pages in bounded batches
+The `quaid embed` command SHALL process pending pages in bounded batches instead of materializing or embedding the entire corpus in one unbounded operation. The default batch size SHALL be conservative enough for a 350-page BGE-small corpus on macOS arm64 and SHALL be configurable with `--batch-size N`.
+
+#### Scenario: Default batch completes medium corpus
+- **WHEN** `quaid embed` runs against a fresh 350-page corpus using the airgapped BGE-small model
+- **THEN** the command completes without an OS SIGKILL caused by unbounded first-run memory pressure
+- **AND** all non-empty pages have embeddings queued or written according to the existing embed contract
+
+#### Scenario: Operator overrides batch size
+- **WHEN** a user invokes `quaid embed --batch-size 25`
+- **THEN** the embed command processes at most 25 pages per batch
+- **AND** invalid values such as `0` are rejected with a clear CLI error before embedding starts
+
+### Requirement: Batch processing preserves idempotence
+Batching SHALL NOT change which pages are embedded, the persisted model metadata, or the behavior of rerunning `quaid embed` after a partial prior run.
+
+#### Scenario: Rerun after partial progress
+- **WHEN** a prior embed run wrote embeddings for some pages and exited before completing the corpus
+- **THEN** a subsequent `quaid embed` run skips already-current embeddings and completes remaining pages
+- **AND** no duplicate current embedding rows are produced

--- a/openspec/changes/fix-beta-reported-regressions/specs/frontmatter-link-autowiring/spec.md
+++ b/openspec/changes/fix-beta-reported-regressions/specs/frontmatter-link-autowiring/spec.md
@@ -1,0 +1,21 @@
+## MODIFIED Requirements
+
+### Requirement: Frontmatter `parent`, `children`, and `related` fields produce fixed relationship types
+The system SHALL parse `parent:` as a single string, `children:` as a list of strings, and `related:` as either a list of strings or a single string coerced to a one-item list. Each resolvable value SHALL produce a `links` row with `source_kind = 'frontmatter'`, `edge_weight = config.edge_weight_frontmatter`, and `relationship` equal to `'parent'`, `'child'`, or `'related'` respectively. Unresolvable values SHALL follow the existing unresolved-target gap behavior without aborting otherwise valid page ingest.
+
+#### Scenario: `parent` field produces a single typed edge
+- **WHEN** a page is written with frontmatter `parent: programs/yc-w17`
+- **THEN** a `links` row exists from the page to `programs/yc-w17` with `relationship = 'parent'` and `source_kind = 'frontmatter'`
+
+#### Scenario: `children` field produces one edge per entry
+- **WHEN** a page is written with frontmatter `children: [companies/brex, companies/scale]`
+- **THEN** the `links` table contains exactly two rows from that page with `relationship = 'child'` and `source_kind = 'frontmatter'`
+
+#### Scenario: Scalar `related` field is coerced to one edge
+- **WHEN** a page is written with frontmatter `related: karpathy-llm-wiki-workflow-breakdown`
+- **THEN** ingest treats it as `related: [karpathy-llm-wiki-workflow-breakdown]`
+- **AND** collection attach does not fail with a list-of-strings validation error
+
+#### Scenario: List `related` field remains supported
+- **WHEN** a page is written with frontmatter `related: [companies/brex, companies/scale]`
+- **THEN** the `links` table contains exactly two rows from that page with `relationship = 'related'` and `source_kind = 'frontmatter'`

--- a/openspec/changes/fix-beta-reported-regressions/specs/mcp-server-shutdown/spec.md
+++ b/openspec/changes/fix-beta-reported-regressions/specs/mcp-server-shutdown/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: MCP shutdown terminates owned runtime work
+When `quaid serve` receives SIGTERM or its stdio client disconnects, the system SHALL shut down all Quaid-owned runtime workers and child processes started for that server instance before the parent process exits. Shutdown SHALL NOT terminate unrelated Quaid processes that were not spawned or owned by the server instance.
+
+#### Scenario: SIGTERM leaves no owned children
+- **WHEN** a running `quaid serve` process receives SIGTERM
+- **THEN** the serve process exits within the shutdown grace period
+- **AND** every child process or worker process owned by that serve invocation has exited
+- **AND** unrelated Quaid daemon or CLI processes continue running
+
+#### Scenario: Stdio disconnect triggers the same cleanup
+- **WHEN** an MCP client closes stdin for `quaid serve`
+- **THEN** the server performs the same owned-runtime cleanup as SIGTERM before exiting
+
+### Requirement: Shutdown cleanup is observable in tests
+The system SHALL include an integration test that starts the MCP server, records its owned process tree or runtime handles, terminates the server, and verifies the owned work is gone without using broad process-name termination.
+
+#### Scenario: Test uses owned process identity
+- **WHEN** the shutdown regression test runs on a supported Unix platform
+- **THEN** it identifies the server and owned children by PID or runtime ownership
+- **AND** it fails if any owned process remains after SIGTERM

--- a/openspec/changes/fix-beta-reported-regressions/specs/vault-sync/spec.md
+++ b/openspec/changes/fix-beta-reported-regressions/specs/vault-sync/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Recoverable frontmatter does not reduce round-trip export completeness
+Collection ingest and export SHALL preserve every page whose frontmatter can be losslessly represented or safely normalized by known coercions. A recoverable field such as scalar `related` SHALL NOT cause collection attach, sync, or export to skip the page.
+
+#### Scenario: Scalar related page imports and exports
+- **WHEN** a collection contains a markdown page with frontmatter `related: some-slug`
+- **THEN** `quaid collection add` ingests the page
+- **AND** `quaid export` includes the page in the exported directory
+- **AND** the exported frontmatter remains parseable on re-import
+
+#### Scenario: Round-trip count preserves imported pages
+- **WHEN** a collection import reports N successfully ingested pages
+- **THEN** a round-trip export of that collection writes N page files unless a page is explicitly excluded by documented ignore/delete behavior
+
+#### Scenario: Invalid unrecoverable graph metadata is isolated
+- **WHEN** a page contains unrecoverable graph metadata in one optional frontmatter field but otherwise valid page content
+- **THEN** the system logs or reports the field-level problem using existing diagnostics
+- **AND** the page itself remains importable and exportable

--- a/openspec/changes/fix-beta-reported-regressions/tasks.md
+++ b/openspec/changes/fix-beta-reported-regressions/tasks.md
@@ -1,0 +1,26 @@
+## 1. Reproduce and Characterize
+
+- [ ] 1.1 Add focused fixtures/tests for scalar `related` frontmatter import and export.
+- [ ] 1.2 Add focused fixtures/tests for PARA type inference with graph frontmatter present.
+- [ ] 1.3 Add or update shutdown regression coverage for `quaid serve` SIGTERM cleanup.
+- [ ] 1.4 Add embed batching coverage for CLI validation and partial rerun/idempotence.
+
+## 2. Frontmatter, PARA, and Round-trip Fixes
+
+- [ ] 2.1 Update graph/frontmatter relationship parsing to coerce scalar `related` to a single-item list while preserving list behavior.
+- [ ] 2.2 Ensure invalid optional graph metadata is isolated to diagnostics and does not abort page ingest/export when the page is otherwise valid.
+- [ ] 2.3 Restore page type derivation so explicit and inferred PARA types survive collection ingest and graph/tag sync.
+- [ ] 2.4 Verify round-trip export writes every successfully ingested page in the regression fixtures.
+
+## 3. Runtime and Embedding Fixes
+
+- [ ] 3.1 Update MCP/serve shutdown to cancel owned runtime workers and wait for owned children without touching unrelated processes.
+- [ ] 3.2 Add `quaid embed --batch-size N` validation and conservative default batching.
+- [ ] 3.3 Refactor embedding execution to process pending pages in bounded batches and preserve rerun idempotence.
+
+## 4. Release and Issue Closure
+
+- [ ] 4.1 Update changelog/docs for v0.22.1 beta regression fixes.
+- [ ] 4.2 Run focused tests for changed areas, then full release validation.
+- [ ] 4.3 Open and merge a PR for the OpenSpec and implementation.
+- [ ] 4.4 Tag and publish v0.22.1, verify release assets, and comment/close issues #190-#195 as appropriate.

--- a/openspec/changes/fix-beta-reported-regressions/tasks.md
+++ b/openspec/changes/fix-beta-reported-regressions/tasks.md
@@ -1,26 +1,26 @@
 ## 1. Reproduce and Characterize
 
-- [ ] 1.1 Add focused fixtures/tests for scalar `related` frontmatter import and export.
-- [ ] 1.2 Add focused fixtures/tests for PARA type inference with graph frontmatter present.
-- [ ] 1.3 Add or update shutdown regression coverage for `quaid serve` SIGTERM cleanup.
-- [ ] 1.4 Add embed batching coverage for CLI validation and partial rerun/idempotence.
+- [x] 1.1 Add focused fixtures/tests for scalar `related` frontmatter import and export.
+- [x] 1.2 Add focused fixtures/tests for PARA type inference with graph frontmatter present.
+- [x] 1.3 Add or update shutdown regression coverage for `quaid serve` SIGTERM cleanup.
+- [x] 1.4 Add embed batching coverage for CLI validation and partial rerun/idempotence.
 
 ## 2. Frontmatter, PARA, and Round-trip Fixes
 
-- [ ] 2.1 Update graph/frontmatter relationship parsing to coerce scalar `related` to a single-item list while preserving list behavior.
-- [ ] 2.2 Ensure invalid optional graph metadata is isolated to diagnostics and does not abort page ingest/export when the page is otherwise valid.
-- [ ] 2.3 Restore page type derivation so explicit and inferred PARA types survive collection ingest and graph/tag sync.
-- [ ] 2.4 Verify round-trip export writes every successfully ingested page in the regression fixtures.
+- [x] 2.1 Update graph/frontmatter relationship parsing to coerce scalar `related` to a single-item list while preserving list behavior.
+- [x] 2.2 Ensure invalid optional graph metadata is isolated to diagnostics and does not abort page ingest/export when the page is otherwise valid.
+- [x] 2.3 Restore page type derivation so explicit and inferred PARA types survive collection ingest and graph/tag sync.
+- [x] 2.4 Verify round-trip export writes every successfully ingested page in the regression fixtures.
 
 ## 3. Runtime and Embedding Fixes
 
-- [ ] 3.1 Update MCP/serve shutdown to cancel owned runtime workers and wait for owned children without touching unrelated processes.
-- [ ] 3.2 Add `quaid embed --batch-size N` validation and conservative default batching.
-- [ ] 3.3 Refactor embedding execution to process pending pages in bounded batches and preserve rerun idempotence.
+- [x] 3.1 Update MCP/serve shutdown to cancel owned runtime workers and wait for owned children without touching unrelated processes.
+- [x] 3.2 Add `quaid embed --batch-size N` validation and conservative default batching.
+- [x] 3.3 Refactor embedding execution to process pending pages in bounded batches and preserve rerun idempotence.
 
 ## 4. Release and Issue Closure
 
-- [ ] 4.1 Update changelog/docs for v0.22.1 beta regression fixes.
-- [ ] 4.2 Run focused tests for changed areas, then full release validation.
+- [x] 4.1 Update changelog/docs for v0.22.1 beta regression fixes.
+- [x] 4.2 Run focused tests for changed areas, then full release validation.
 - [ ] 4.3 Open and merge a PR for the OpenSpec and implementation.
 - [ ] 4.4 Tag and publish v0.22.1, verify release assets, and comment/close issues #190-#195 as appropriate.

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -157,17 +157,20 @@ async fn run_foreground(db: Connection, http_config: Option<HttpConfig>) -> Resu
         runtime.session_id
     );
 
-    install_signal_handler(&runtime);
-
     if let Some(config) = http_config {
         let db_path_for_factory = db_path.clone();
         let factory =
             move || crate::core::db::open(&db_path_for_factory).map_err(anyhow::Error::from);
         // Block on the SSE listener; the supervisor + worker run in
         // their own threads owned by `runtime`.
-        if let Err(err) = crate::mcp::http::run_http(factory, config).await {
-            eprintln!("daemon_http_transport_failed error={err}");
-            return Ok(1);
+        tokio::select! {
+            result = crate::mcp::http::run_http(factory, config) => {
+                if let Err(err) = result {
+                    eprintln!("daemon_http_transport_failed error={err}");
+                    return Ok(1);
+                }
+            }
+            () = wait_for_runtime(&runtime) => {}
         }
     } else {
         // No transport: block until the supervisor thread joins (SIGTERM).
@@ -178,67 +181,39 @@ async fn run_foreground(db: Connection, http_config: Option<HttpConfig>) -> Resu
     Ok(0)
 }
 
-/// Install a SIGTERM/SIGINT handler that sets the runtime's stop flag.
-///
-/// Signal handling lives behind a one-off `tokio::spawn` so it doesn't
-/// block the foreground task. On non-Unix platforms this is a no-op —
-/// `quaid daemon run` is only supported on Unix today.
-#[allow(unused_variables, reason = "runtime is unused on non-Unix targets")]
-fn install_signal_handler(runtime: &vault_sync::ServeRuntime) {
-    #[cfg(unix)]
-    {
-        // We can't move the `Arc<AtomicBool>` out of `ServeRuntime`
-        // directly (the field is private), but the existing Drop impl
-        // already sets stop=true. The signal handler simply causes the
-        // process to begin tearing down by panicking the main task —
-        // which is too coarse. Instead, we rely on tokio's signal
-        // helpers to await the signal, then return from the foreground
-        // task naturally so Drop fires in order.
-        let stop_signaled = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let stop_clone = std::sync::Arc::clone(&stop_signaled);
-        tokio::spawn(async move {
-            if let Ok(mut sigterm) =
-                tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
-            {
-                if sigterm.recv().await.is_some() {
-                    stop_clone.store(true, std::sync::atomic::Ordering::SeqCst);
-                }
-            }
-        });
-        // SIGINT mirrors SIGTERM so a Ctrl-C from the operator behaves
-        // identically when running interactively.
-        let stop_clone2 = std::sync::Arc::clone(&stop_signaled);
-        tokio::spawn(async move {
-            if let Ok(mut sigint) =
-                tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())
-            {
-                if sigint.recv().await.is_some() {
-                    stop_clone2.store(true, std::sync::atomic::Ordering::SeqCst);
-                }
-            }
-        });
-    }
-}
-
 /// Block until the supervisor thread exits. Used when no MCP transport
 /// is open and we still need the foreground task to wait for shutdown.
 async fn wait_for_runtime(_runtime: &vault_sync::ServeRuntime) {
-    // The supervisor thread holds the workers; once SIGTERM hits the
-    // process and Drop runs on `runtime` we want to keep this future
-    // alive long enough for it to fire. The simplest correct behavior
-    // is to wait on SIGTERM ourselves and return.
     #[cfg(unix)]
     {
-        if let Ok(mut sigterm) =
-            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
-        {
-            let _ = sigterm.recv().await;
-            return;
+        let mut sigterm =
+            match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+                Ok(signal) => signal,
+                Err(_) => {
+                    std::future::pending::<()>().await;
+                    return;
+                }
+            };
+        let mut sigint =
+            match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt()) {
+                Ok(signal) => signal,
+                Err(_) => {
+                    let _ = sigterm.recv().await;
+                    return;
+                }
+            };
+
+        tokio::select! {
+            _ = sigterm.recv() => {}
+            _ = sigint.recv() => {}
         }
     }
-    // Fallback: block forever on a stalled future (the supervisor
-    // thread keeps the process alive; Ctrl-C tears the binary down).
-    std::future::pending::<()>().await;
+    #[cfg(not(unix))]
+    {
+        // Fallback: block forever on a stalled future (the supervisor
+        // thread keeps the process alive; Ctrl-C tears the binary down).
+        std::future::pending::<()>().await;
+    }
 }
 
 fn install_action(

--- a/src/commands/embed.rs
+++ b/src/commands/embed.rs
@@ -6,13 +6,32 @@
 use anyhow::Result;
 use rusqlite::Connection;
 
-use crate::commands::get::{get_page, get_page_by_key};
+use crate::commands::get::get_page_by_key;
 use crate::core::chunking::chunk_page;
 use crate::core::collections::OpKind;
 use crate::core::inference::{embed, embedding_to_blob};
 use crate::core::vault_sync;
 
+const DEFAULT_BATCH_SIZE: usize = 32;
+
+#[derive(Debug, Clone)]
+struct PageRef {
+    id: i64,
+    collection_id: i64,
+    slug: String,
+}
+
 pub fn run(db: &Connection, slug: Option<String>, all: bool, stale: bool) -> Result<()> {
+    run_with_batch(db, slug, all, stale, None)
+}
+
+pub fn run_with_batch(
+    db: &Connection,
+    slug: Option<String>,
+    all: bool,
+    stale: bool,
+    batch_size: Option<usize>,
+) -> Result<()> {
     // Modes are mutually exclusive: exactly one of <SLUG>, --all, or --stale.
     if slug.is_some() && (all || stale) {
         anyhow::bail!(
@@ -22,6 +41,8 @@ pub fn run(db: &Connection, slug: Option<String>, all: bool, stale: bool) -> Res
     if all && stale {
         anyhow::bail!("--all and --stale are mutually exclusive");
     }
+    let batch_size = batch_size.unwrap_or(DEFAULT_BATCH_SIZE);
+    anyhow::ensure!(batch_size > 0, "--batch-size must be greater than 0");
 
     let (model_name, vec_table) = active_model(db)?;
     anyhow::ensure!(
@@ -42,47 +63,56 @@ pub fn run(db: &Connection, slug: Option<String>, all: bool, stale: bool) -> Res
     } else {
         let mut embedded_pages = 0_usize;
         let mut embedded_chunks = 0_usize;
+        let mut last_page_id = 0_i64;
 
-        for slug in page_slugs(db)? {
-            let page = match get_page(db, &slug) {
-                Ok(p) => p,
-                Err(e) => {
+        loop {
+            let page_refs = page_refs_after(db, last_page_id, batch_size)?;
+            if page_refs.is_empty() {
+                break;
+            }
+
+            for page_ref in page_refs {
+                last_page_id = page_ref.id;
+                let page = match get_page_by_key(db, page_ref.collection_id, &page_ref.slug) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        eprintln!(
+                            "{}",
+                            format_embed_warning(
+                                &page_ref.slug,
+                                lookup_source_path_by_page_id(db, page_ref.id).as_deref(),
+                                &e
+                            )
+                        );
+                        continue;
+                    }
+                };
+                let chunks = chunk_page(&page);
+
+                if chunks.is_empty() {
+                    continue;
+                }
+
+                if !page_needs_refresh(db, page_ref.id, &model_name, &chunks)? {
+                    continue;
+                }
+
+                if let Err(e) =
+                    replace_page_embeddings(db, page_ref.id, &model_name, &vec_table, &chunks)
+                {
                     eprintln!(
                         "{}",
-                        format_embed_warning(&slug, lookup_source_path(db, &slug).as_deref(), &e)
+                        format_embed_warning(
+                            &page_ref.slug,
+                            lookup_source_path_by_page_id(db, page_ref.id).as_deref(),
+                            &e
+                        )
                     );
                     continue;
                 }
-            };
-            let page_id = match page_id(db, &slug) {
-                Ok(id) => id,
-                Err(e) => {
-                    eprintln!(
-                        "{}",
-                        format_embed_warning(&slug, lookup_source_path(db, &slug).as_deref(), &e)
-                    );
-                    continue;
-                }
-            };
-            let chunks = chunk_page(&page);
-
-            if chunks.is_empty() {
-                continue;
+                embedded_pages += 1;
+                embedded_chunks += chunks.len();
             }
-
-            if !page_needs_refresh(db, page_id, &model_name, &chunks)? {
-                continue;
-            }
-
-            if let Err(e) = replace_page_embeddings(db, page_id, &model_name, &vec_table, &chunks) {
-                eprintln!(
-                    "{}",
-                    format_embed_warning(&slug, lookup_source_path(db, &slug).as_deref(), &e)
-                );
-                continue;
-            }
-            embedded_pages += 1;
-            embedded_chunks += chunks.len();
         }
 
         (embedded_pages, embedded_chunks)
@@ -109,22 +139,23 @@ fn active_model(db: &Connection) -> Result<(String, String)> {
     .map_err(Into::into)
 }
 
-fn page_slugs(db: &Connection) -> Result<Vec<String>> {
-    let mut stmt = db.prepare("SELECT slug FROM pages ORDER BY slug")?;
-    let rows = stmt.query_map([], |row| row.get(0))?;
+fn page_refs_after(db: &Connection, last_page_id: i64, batch_size: usize) -> Result<Vec<PageRef>> {
+    let limit = i64::try_from(batch_size)?;
+    let mut stmt =
+        db.prepare("SELECT id, collection_id, slug FROM pages WHERE id > ?1 ORDER BY id LIMIT ?2")?;
+    let rows = stmt.query_map(rusqlite::params![last_page_id, limit], |row| {
+        Ok(PageRef {
+            id: row.get(0)?,
+            collection_id: row.get(1)?,
+            slug: row.get(2)?,
+        })
+    })?;
 
-    let mut slugs = Vec::new();
+    let mut page_refs = Vec::new();
     for row in rows {
-        slugs.push(row?);
+        page_refs.push(row?);
     }
-    Ok(slugs)
-}
-
-fn page_id(db: &Connection, slug: &str) -> Result<i64> {
-    db.query_row("SELECT id FROM pages WHERE slug = ?1", [slug], |row| {
-        row.get(0)
-    })
-    .map_err(Into::into)
+    Ok(page_refs)
 }
 
 fn page_id_by_key(db: &Connection, collection_id: i64, slug: &str) -> Result<i64> {
@@ -178,17 +209,14 @@ fn page_needs_refresh(
         }))
 }
 
-/// Best-effort lookup of the source file path for a given slug via the active
-/// raw_imports row. Returns `None` when no matching row can be found.
-fn lookup_source_path(db: &Connection, slug: &str) -> Option<String> {
+fn lookup_source_path_by_page_id(db: &Connection, page_id: i64) -> Option<String> {
     db.query_row(
-        "SELECT ri.file_path
-         FROM raw_imports ri
-         JOIN pages p ON p.id = ri.page_id
-         WHERE p.slug = ?1 AND ri.is_active = 1
-         ORDER BY ri.created_at DESC, ri.id DESC
+        "SELECT file_path
+         FROM raw_imports
+         WHERE page_id = ?1 AND is_active = 1
+         ORDER BY created_at DESC, id DESC
          LIMIT 1",
-        [slug],
+        [page_id],
         |row| row.get(0),
     )
     .ok()
@@ -354,6 +382,15 @@ mod tests {
             ],
         )
         .expect("insert page");
+    }
+
+    fn lookup_source_path_for_slug(conn: &Connection, slug: &str) -> Option<String> {
+        let page_id = conn
+            .query_row("SELECT id FROM pages WHERE slug = ?1", [slug], |row| {
+                row.get(0)
+            })
+            .ok()?;
+        lookup_source_path_by_page_id(conn, page_id)
     }
 
     #[test]
@@ -658,14 +695,14 @@ mod tests {
         )
         .expect("insert raw import row");
 
-        let result = lookup_source_path(&conn, "people/alice");
+        let result = lookup_source_path_for_slug(&conn, "people/alice");
         assert_eq!(
             result.as_deref(),
             Some("/notes/2024-01-meeting.md"),
             "should find file_path for frontmatter slug that differs from filename"
         );
 
-        let miss = lookup_source_path(&conn, "notes/2024-01-meeting");
+        let miss = lookup_source_path_for_slug(&conn, "notes/2024-01-meeting");
         assert_eq!(
             miss, None,
             "filename-derived slug should not match when only the resolved page slug exists"
@@ -686,7 +723,7 @@ mod tests {
         crate::commands::ingest::run(&conn, file_path.to_str().expect("utf8 path"), false)
             .expect("ingest file");
 
-        let result = lookup_source_path(&conn, "people/alice");
+        let result = lookup_source_path_for_slug(&conn, "people/alice");
         assert_eq!(
             result.as_deref(),
             file_path.to_str(),
@@ -721,7 +758,7 @@ mod tests {
             .expect("second ingest");
 
         assert_eq!(
-            lookup_source_path(&conn, "note").as_deref(),
+            lookup_source_path_for_slug(&conn, "note").as_deref(),
             second_path.to_str()
         );
     }
@@ -749,7 +786,7 @@ mod tests {
             .expect("reingest moved file");
 
         assert_eq!(
-            lookup_source_path(&conn, "note").as_deref(),
+            lookup_source_path_for_slug(&conn, "note").as_deref(),
             moved_path.to_str()
         );
     }

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use rusqlite::Connection;
 
 use crate::mcp::HttpConfig;
@@ -24,7 +24,10 @@ pub async fn run(db: Connection, http_config: Option<HttpConfig>) -> Result<()> 
     let _runtime = crate::core::vault_sync::start_serve_runtime(db_path.clone())?;
 
     match http_config {
-        None => crate::mcp::server::run_stdio(db).await,
+        None => {
+            drop(db);
+            run_stdio_until_shutdown(db_path).await
+        }
         Some(config) => {
             // The HTTP transport opens its own DB connection(s) per
             // incoming SSE session; the `db` we were handed by the
@@ -32,7 +35,84 @@ pub async fn run(db: Connection, http_config: Option<HttpConfig>) -> Result<()> 
             // returns. `db_path` is captured by value in the factory.
             drop(db);
             let factory = move || crate::core::db::open(&db_path).map_err(anyhow::Error::from);
-            crate::mcp::http::run_http(factory, config).await
+            run_http_until_shutdown(factory, config).await
         }
+    }
+}
+
+async fn run_stdio_until_shutdown(db_path: String) -> Result<()> {
+    #[cfg(unix)]
+    {
+        let (sender, receiver) = tokio::sync::oneshot::channel();
+        std::thread::Builder::new()
+            .name("quaid-mcp-stdio".to_owned())
+            .spawn(move || {
+                let result = run_stdio_blocking(db_path);
+                let _ = sender.send(result);
+            })
+            .map_err(|error| anyhow!("failed to spawn MCP stdio thread: {error}"))?;
+
+        tokio::select! {
+            result = receiver => result
+                .map_err(|_| anyhow!("MCP stdio thread terminated without reporting a result"))?,
+            () = shutdown_signal() => Ok(()),
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let db = crate::core::db::open(&db_path)?;
+        crate::mcp::server::run_stdio(db).await
+    }
+}
+
+#[cfg(unix)]
+fn run_stdio_blocking(db_path: String) -> Result<()> {
+    let db = crate::core::db::open(&db_path)?;
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| anyhow!("failed to create MCP stdio runtime: {error}"))?
+        .block_on(crate::mcp::server::run_stdio(db))
+}
+
+async fn run_http_until_shutdown<F>(factory: F, config: HttpConfig) -> Result<()>
+where
+    F: Fn() -> Result<Connection> + Send + Sync + 'static,
+{
+    #[cfg(unix)]
+    {
+        tokio::select! {
+            result = crate::mcp::http::run_http(factory, config) => result,
+            () = shutdown_signal() => Ok(()),
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        crate::mcp::http::run_http(factory, config).await
+    }
+}
+
+#[cfg(unix)]
+async fn shutdown_signal() {
+    let mut sigterm = match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+    {
+        Ok(signal) => signal,
+        Err(_) => {
+            std::future::pending::<()>().await;
+            return;
+        }
+    };
+    let mut sigint = match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())
+    {
+        Ok(signal) => signal,
+        Err(_) => {
+            let _ = sigterm.recv().await;
+            return;
+        }
+    };
+
+    tokio::select! {
+        _ = sigterm.recv() => {}
+        _ = sigint.recv() => {}
     }
 }

--- a/src/core/conversation/file_edit.rs
+++ b/src/core/conversation/file_edit.rs
@@ -601,7 +601,7 @@ fn strip_numeric_prefix(name: &str) -> &str {
     while index < bytes.len() && bytes[index].is_ascii_digit() {
         index += 1;
     }
-    if index > 0 && index < bytes.len() && bytes[index] == b'.' {
+    if index > 0 && index < bytes.len() && matches!(bytes[index], b'.' | b'-' | b'_') {
         index += 1;
         while index < bytes.len() && bytes[index].is_ascii_whitespace() {
             index += 1;

--- a/src/core/links.rs
+++ b/src/core/links.rs
@@ -220,10 +220,14 @@ fn expand_list_relationship_field(
             }
             Ok(())
         }
+        JsonValue::String(raw) => {
+            edges.push(make_string_edge(field, raw, relationship)?);
+            Ok(())
+        }
         JsonValue::Null => Ok(()),
         other => Err(FrontmatterParseError::InvalidShape {
             field: field.to_string(),
-            expected: "list of strings".to_string(),
+            expected: "list of strings or string".to_string(),
             found: shape_label(other),
         }),
     }
@@ -710,6 +714,37 @@ pub fn sync_page_graph_artifacts(
     timeline: &str,
 ) -> Result<(), DerivedEdgeError> {
     let edges = expand_frontmatter_edges(frontmatter)?;
+    sync_frontmatter_edges(conn, page_id, collection_id, &edges)?;
+    sync_wikilink_edges(conn, page_id, collection_id, compiled_truth, timeline)?;
+    let tags = expand_frontmatter_tags(frontmatter);
+    sync_page_tags(conn, page_id, &tags)?;
+    Ok(())
+}
+
+/// Best-effort graph artifact sync for collection reconciliation.
+///
+/// Collection attach/sync must not drop an otherwise valid markdown page just
+/// because optional graph frontmatter is malformed. When frontmatter edge
+/// parsing fails, this logs the field-level diagnostic, clears stale
+/// frontmatter-derived edges for the page, and still syncs wikilinks and tags.
+pub fn sync_page_graph_artifacts_tolerant(
+    conn: &Connection,
+    page_id: i64,
+    collection_id: i64,
+    frontmatter: &Frontmatter,
+    compiled_truth: &str,
+    timeline: &str,
+    diagnostic_context: &str,
+) -> Result<(), DerivedEdgeError> {
+    let edges = match expand_frontmatter_edges(frontmatter) {
+        Ok(edges) => edges,
+        Err(err) => {
+            eprintln!(
+                "WARN: malformed_frontmatter_graph_input context={diagnostic_context} error={err}"
+            );
+            Vec::new()
+        }
+    };
     sync_frontmatter_edges(conn, page_id, collection_id, &edges)?;
     sync_wikilink_edges(conn, page_id, collection_id, compiled_truth, timeline)?;
     let tags = expand_frontmatter_tags(frontmatter);

--- a/src/core/links.rs
+++ b/src/core/links.rs
@@ -106,11 +106,17 @@ pub fn expand_frontmatter_edges(
     }
 
     if let Some(value) = frontmatter.get("children") {
-        expand_list_relationship_field("children", CHILD_RELATIONSHIP, value, &mut edges)?;
+        expand_list_relationship_field("children", CHILD_RELATIONSHIP, value, &mut edges, false)?;
     }
 
     if let Some(value) = frontmatter.get("related") {
-        expand_list_relationship_field("related", DEFAULT_LINK_RELATIONSHIP, value, &mut edges)?;
+        expand_list_relationship_field(
+            "related",
+            DEFAULT_LINK_RELATIONSHIP,
+            value,
+            &mut edges,
+            true,
+        )?;
     }
 
     Ok(edges)
@@ -204,6 +210,7 @@ fn expand_list_relationship_field(
     relationship: &str,
     value: &JsonValue,
     edges: &mut Vec<FrontmatterLink>,
+    allow_scalar: bool,
 ) -> Result<(), FrontmatterParseError> {
     match value {
         JsonValue::Array(items) => {
@@ -220,7 +227,7 @@ fn expand_list_relationship_field(
             }
             Ok(())
         }
-        JsonValue::String(raw) => {
+        JsonValue::String(raw) if allow_scalar => {
             edges.push(make_string_edge(field, raw, relationship)?);
             Ok(())
         }

--- a/src/core/reconciler.rs
+++ b/src/core/reconciler.rs
@@ -2750,8 +2750,6 @@ fn apply_reingest(
     let absolute_path = root_path.join(relative_path);
     let raw_bytes = fs::read(&absolute_path)?;
     let parsed = parse_vault_file(&raw_bytes, &absolute_path, root_path)?;
-    links::validate_graph_frontmatter(&parsed.frontmatter)
-        .map_err(|err| ReconcileError::Other(format!("apply_reingest: {err}")))?;
     let current_page =
         load_existing_page_identity(conn, collection_id, existing_page_id, &parsed.slug)?;
 
@@ -2929,13 +2927,15 @@ fn apply_reingest(
         &raw_bytes,
     )?;
     raw_imports::enqueue_embedding_job(&tx, page_id)?;
-    links::sync_page_graph_artifacts(
+    let diagnostic_context = absolute_path.to_string_lossy();
+    links::sync_page_graph_artifacts_tolerant(
         &tx,
         page_id,
         collection_id,
         &parsed.frontmatter,
         &parsed.compiled_truth,
         &parsed.timeline,
+        diagnostic_context.as_ref(),
     )
     .map_err(|err| ReconcileError::Other(format!("apply_reingest: {err}")))?;
     tx.commit()?;
@@ -3043,10 +3043,10 @@ fn infer_type_from_path(file_path: &Path, root_path: &Path) -> Option<String> {
     let normalized = strip_numeric_prefix(&folder).to_lowercase();
 
     match normalized.as_str() {
-        "projects" => Some("project".to_string()),
-        "areas" => Some("area".to_string()),
-        "resources" => Some("resource".to_string()),
-        "archives" => Some("archive".to_string()),
+        "project" | "projects" => Some("project".to_string()),
+        "area" | "areas" => Some("area".to_string()),
+        "resource" | "resources" => Some("resource".to_string()),
+        "archive" | "archives" => Some("archive".to_string()),
         "journal" | "journals" => Some("journal".to_string()),
         "people" => Some("person".to_string()),
         "companies" | "orgs" => Some("company".to_string()),

--- a/src/core/reconciler.rs
+++ b/src/core/reconciler.rs
@@ -3061,7 +3061,7 @@ fn strip_numeric_prefix(name: &str) -> &str {
         index += 1;
     }
 
-    if index > 0 && index < bytes.len() && bytes[index] == b'.' {
+    if index > 0 && index < bytes.len() && matches!(bytes[index], b'.' | b'-' | b'_') {
         index += 1;
         while index < bytes.len() && bytes[index].is_ascii_whitespace() {
             index += 1;
@@ -6101,12 +6101,13 @@ mod tests {
         assert_eq!(strip_numeric_prefix("01. Folder"), "Folder");
         assert_eq!(strip_numeric_prefix("123. Area"), "Area");
         assert_eq!(strip_numeric_prefix("9. Thing"), "Thing");
+        assert_eq!(strip_numeric_prefix("1-projects"), "projects");
+        assert_eq!(strip_numeric_prefix("2_areas"), "areas");
     }
 
     #[test]
     fn strip_numeric_prefix_leaves_non_numeric_name_unchanged() {
         assert_eq!(strip_numeric_prefix("Projects"), "Projects");
-        assert_eq!(strip_numeric_prefix("01-not-standard"), "01-not-standard");
         assert_eq!(strip_numeric_prefix(""), "");
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -144,6 +144,9 @@ enum Commands {
         all: bool,
         #[arg(long)]
         stale: bool,
+        /// Maximum number of pages to scan per batch for bulk embedding
+        #[arg(long)]
+        batch_size: Option<usize>,
     },
     /// Create a typed temporal link between pages
     Link {
@@ -444,7 +447,12 @@ async fn main() -> Result<()> {
         } => commands::export::run(&db, &path, raw, import_id),
         Commands::Extraction { action } => commands::extraction::run(&db, action),
         Commands::Extract(args) => commands::extract::run(&db, args),
-        Commands::Embed { slug, all, stale } => commands::embed::run(&db, slug, all, stale),
+        Commands::Embed {
+            slug,
+            all,
+            stale,
+            batch_size,
+        } => commands::embed::run_with_batch(&db, slug, all, stale, batch_size),
         Commands::Link {
             from,
             to,

--- a/tests/cli_collection_add.rs
+++ b/tests/cli_collection_add.rs
@@ -18,6 +18,7 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 
 use quaid::commands::collection::{run, CollectionAction, CollectionAddArgs};
+use quaid::core::migrate::export_dir;
 
 #[path = "common/collection_fixtures.rs"]
 mod fixtures;
@@ -174,6 +175,131 @@ fn add_attaches_collection_and_cleans_short_lived_lease_residue() {
         )
         .unwrap();
     assert_eq!(page_count, 1);
+}
+
+#[cfg(unix)]
+#[test]
+fn add_preserves_para_type_inference_for_singular_and_plural_folders() {
+    let (_dir, conn) = open_test_db_file();
+    let root = tempfile::TempDir::new().unwrap();
+    let cases = [
+        ("1. Projects/alpha.md", "project"),
+        ("2. Area/health.md", "area"),
+        ("3. Resource/rust.md", "resource"),
+        ("4. Archive/done.md", "archive"),
+    ];
+    for (relative_path, _expected_type) in cases {
+        let path = root.path().join(relative_path);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, "---\ntitle: Note\n---\nhello\n").unwrap();
+    }
+
+    run(
+        &conn,
+        CollectionAction::Add(CollectionAddArgs {
+            name: "work".to_owned(),
+            path: root.path().to_path_buf(),
+            read_only: false,
+            writable: false,
+            write_quaid_id: false,
+            namespace: None,
+        }),
+        true,
+    )
+    .unwrap();
+
+    for (relative_path, expected_type) in cases {
+        let slug = relative_path.trim_end_matches(".md");
+        let page_type: String = conn
+            .query_row("SELECT type FROM pages WHERE slug = ?1", [slug], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(page_type, expected_type, "type for {slug}");
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn add_and_export_preserve_page_with_scalar_related_frontmatter() {
+    let (_dir, conn) = open_test_db_file();
+    let root = tempfile::TempDir::new().unwrap();
+    fs::write(
+        root.path().join("target.md"),
+        "---\ntitle: Target\n---\nhello\n",
+    )
+    .unwrap();
+    fs::write(
+        root.path().join("source.md"),
+        "---\ntitle: Source\nrelated: target\n---\nhello\n",
+    )
+    .unwrap();
+
+    run(
+        &conn,
+        CollectionAction::Add(CollectionAddArgs {
+            name: "work".to_owned(),
+            path: root.path().to_path_buf(),
+            read_only: false,
+            writable: false,
+            write_quaid_id: false,
+            namespace: None,
+        }),
+        true,
+    )
+    .unwrap();
+
+    let page_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM pages", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(page_count, 2);
+
+    let export_root = tempfile::TempDir::new().unwrap();
+    let exported = export_dir(&conn, export_root.path()).unwrap();
+    assert_eq!(exported, 2);
+    assert!(export_root.path().join("source.md").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn add_and_export_preserve_page_with_invalid_optional_graph_frontmatter() {
+    let (_dir, conn) = open_test_db_file();
+    let root = tempfile::TempDir::new().unwrap();
+    fs::write(
+        root.path().join("source.md"),
+        "---\ntitle: Source\nchildren: 42\ntags: [kept]\n---\nhello\n",
+    )
+    .unwrap();
+
+    run(
+        &conn,
+        CollectionAction::Add(CollectionAddArgs {
+            name: "work".to_owned(),
+            path: root.path().to_path_buf(),
+            read_only: false,
+            writable: false,
+            write_quaid_id: false,
+            namespace: None,
+        }),
+        true,
+    )
+    .unwrap();
+
+    let page_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM pages", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(page_count, 1);
+    let tag_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM tags WHERE tag = 'kept'", [], |row| {
+            row.get(0)
+        })
+        .unwrap();
+    assert_eq!(tag_count, 1);
+
+    let export_root = tempfile::TempDir::new().unwrap();
+    let exported = export_dir(&conn, export_root.path()).unwrap();
+    assert_eq!(exported, 1);
+    assert!(export_root.path().join("source.md").exists());
 }
 
 #[cfg(unix)]

--- a/tests/cli_embed_batching.rs
+++ b/tests/cli_embed_batching.rs
@@ -1,0 +1,60 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    reason = "integration tests panic on setup failure"
+)]
+
+use quaid::commands::embed::run_with_batch;
+use quaid::core::db;
+use rusqlite::Connection;
+use uuid::Uuid;
+
+fn open_test_db() -> Connection {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("memory.db");
+    let conn = db::open(db_path.to_str().unwrap()).unwrap();
+    std::mem::forget(dir);
+    conn
+}
+
+fn insert_page(conn: &Connection, slug: &str) {
+    conn.execute(
+        "INSERT INTO pages
+             (slug, uuid, type, title, summary, compiled_truth, timeline, frontmatter, wing, room, version)
+         VALUES (?1, ?2, 'concept', ?1, '', ?3, '', '{}', '', '', 1)",
+        rusqlite::params![
+            slug,
+            Uuid::now_v7().to_string(),
+            format!("## State\n{slug} has enough content to embed.")
+        ],
+    )
+    .unwrap();
+}
+
+#[test]
+fn run_with_batch_rejects_zero_batch_size_before_embedding() {
+    let conn = open_test_db();
+    let error = run_with_batch(&conn, None, true, false, Some(0)).unwrap_err();
+    assert!(error.to_string().contains("batch-size"));
+}
+
+#[test]
+fn run_with_batch_embeds_all_pages_and_rerun_is_idempotent() {
+    let conn = open_test_db();
+    for index in 0..12 {
+        insert_page(&conn, &format!("notes/page-{index:02}"));
+    }
+
+    run_with_batch(&conn, None, true, false, Some(5)).unwrap();
+    let first_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM page_embeddings", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(first_count, 12);
+
+    run_with_batch(&conn, None, true, false, Some(5)).unwrap();
+    let second_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM page_embeddings", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(second_count, first_count);
+}

--- a/tests/frontmatter_edge_expansion.rs
+++ b/tests/frontmatter_edge_expansion.rs
@@ -186,6 +186,18 @@ fn links_field_must_be_a_list_not_a_scalar() {
 }
 
 #[test]
+fn children_field_must_be_a_list_not_a_scalar() {
+    let frontmatter = fm("children: companies/brex\n");
+    let err = expand_frontmatter_edges(&frontmatter).expect_err("scalar children must reject");
+    assert!(matches!(err, FrontmatterParseError::InvalidShape { .. }));
+    let msg = err.to_string();
+    assert!(
+        msg.contains("children"),
+        "actionable field name in error: {msg}"
+    );
+}
+
+#[test]
 fn object_link_missing_target_is_rejected() {
     let frontmatter = fm("links:\n  - type: founded\n");
     let err = expand_frontmatter_edges(&frontmatter).expect_err("missing target must reject");

--- a/tests/frontmatter_edge_expansion.rs
+++ b/tests/frontmatter_edge_expansion.rs
@@ -138,6 +138,16 @@ fn related_field_produces_related_edges_for_each_entry() {
 }
 
 #[test]
+fn scalar_related_field_is_coerced_to_one_related_edge() {
+    let frontmatter = fm("related: karpathy-llm-wiki-workflow-breakdown\n");
+    let edges = expand_frontmatter_edges(&frontmatter).expect("scalar related parses");
+    assert_eq!(
+        edges,
+        vec![link("karpathy-llm-wiki-workflow-breakdown", "related")]
+    );
+}
+
+#[test]
 fn fixed_fields_normalize_targets_via_resolve_slug() {
     let frontmatter = fm("parent: 'Programs/YC W17'\n");
     let edges = expand_frontmatter_edges(&frontmatter).expect("edges parse");

--- a/tests/mcp_server_shutdown.rs
+++ b/tests/mcp_server_shutdown.rs
@@ -1,0 +1,113 @@
+#![cfg(unix)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    reason = "integration tests panic on setup failure"
+)]
+
+mod common;
+#[path = "common/subprocess.rs"]
+mod common_subprocess;
+
+use std::process::{Child, Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use rusqlite::Connection;
+
+fn wait_for_session(db_path: &std::path::Path) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        let conn = Connection::open(db_path).unwrap();
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM serve_sessions", [], |row| row.get(0))
+            .unwrap();
+        if count > 0 {
+            return;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    panic!("serve session was not registered before timeout");
+}
+
+fn wait_for_exit(child: &mut Child) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        if child.try_wait().unwrap().is_some() {
+            return;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    let _ = child.kill();
+    panic!("quaid runtime did not exit after SIGTERM");
+}
+
+fn init_db(dir: &tempfile::TempDir) -> std::path::PathBuf {
+    let db_path = dir.path().join("memory.db");
+    let init = Command::new(common::quaid_bin())
+        .arg("init")
+        .arg(&db_path)
+        .output()
+        .unwrap();
+    assert!(
+        init.status.success(),
+        "init failed: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+    db_path
+}
+
+fn spawn_quaid(db_path: &std::path::Path, args: &[&str]) -> Child {
+    let mut command = Command::new(common::quaid_bin());
+    common_subprocess::configure_test_command(&mut command);
+    command
+        .arg("--db")
+        .arg(db_path)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap()
+}
+
+fn terminate_child(child: &Child) {
+    rustix::process::kill_process(
+        rustix::process::Pid::from_child(child),
+        rustix::process::Signal::Term,
+    )
+    .unwrap();
+}
+
+fn assert_no_sessions(db_path: &std::path::Path) {
+    let conn = Connection::open(db_path).unwrap();
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM serve_sessions", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(count, 0);
+}
+
+#[test]
+fn serve_sigterm_unregisters_runtime_session() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = init_db(&dir);
+    let mut child = spawn_quaid(&db_path, &["serve"]);
+
+    wait_for_session(&db_path);
+    terminate_child(&child);
+    wait_for_exit(&mut child);
+    assert_no_sessions(&db_path);
+}
+
+#[test]
+fn daemon_run_sigterm_unregisters_runtime_session() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = init_db(&dir);
+    let mut child = spawn_quaid(&db_path, &["daemon", "run"]);
+
+    wait_for_session(&db_path);
+    terminate_child(&child);
+    wait_for_exit(&mut child);
+    assert_no_sessions(&db_path);
+}

--- a/website/src/content/docs/explanation/embedding-models.mdx
+++ b/website/src/content/docs/explanation/embedding-models.mdx
@@ -87,4 +87,4 @@ Out of scope. The whole point of Quaid is that the memory doesn't talk to the ne
 
 ## Stale embeddings
 
-When `memory_put` updates a page, the embedding job queue (`embedding_jobs`) re-chunks and re-embeds whatever changed. If you suspect drift — a model upgrade, a chunking-strategy change, an aborted batch — `quaid embed --stale` re-embeds only chunks whose `content_hash` no longer matches; `quaid embed --all` rebuilds everything.
+When `memory_put` updates a page, the embedding job queue (`embedding_jobs`) re-chunks and re-embeds whatever changed. If you suspect drift — a model upgrade, a chunking-strategy change, an aborted batch — `quaid embed --stale` re-embeds only chunks whose `content_hash` no longer matches; `quaid embed --all` rebuilds everything. Bulk embed scans pages in bounded batches (default 32); use `--batch-size N` to reduce peak memory on constrained machines.

--- a/website/src/content/docs/explanation/embedding-models.mdx
+++ b/website/src/content/docs/explanation/embedding-models.mdx
@@ -87,4 +87,4 @@ Out of scope. The whole point of Quaid is that the memory doesn't talk to the ne
 
 ## Stale embeddings
 
-When `memory_put` updates a page, the embedding job queue (`embedding_jobs`) re-chunks and re-embeds whatever changed. If you suspect drift — a model upgrade, a chunking-strategy change, an aborted batch — `quaid embed --stale` re-embeds only chunks whose `content_hash` no longer matches; `quaid embed --all` rebuilds everything. Bulk embed scans pages in bounded batches (default 32); use `--batch-size N` to reduce peak memory on constrained machines.
+When `memory_put` updates a page, the embedding job queue (`embedding_jobs`) re-chunks and re-embeds whatever changed. If you suspect drift — a model upgrade, a chunking-strategy change, an aborted batch — `quaid embed --stale` re-embeds only chunks whose `content_hash` no longer matches; `quaid embed --all` scans every page and skips chunks that are already current. Bulk embed scans pages in bounded batches (default 32); use `--batch-size N` to reduce peak memory on constrained machines.

--- a/website/src/content/docs/how-to/import-obsidian.mdx
+++ b/website/src/content/docs/how-to/import-obsidian.mdx
@@ -15,7 +15,7 @@ quaid init ~/memory.db
 quaid import ~/Documents/Obsidian --db ~/memory.db
 ```
 
-`import` walks the directory, infers `type` from a PARA-style folder layout (`projects/`, `areas/`, `resources/`, `archives/`) when frontmatter doesn't declare it, and writes one page per `.md` file. SHA-256 idempotency means re-running on the same content is a no-op.
+`import` walks the directory, infers `type` from a PARA-style folder layout (`project(s)/`, `area(s)/`, `resource(s)/`, `archive(s)/`) when frontmatter doesn't declare it, and writes one page per `.md` file. Numeric prefixes such as `1-projects/` are stripped before inference. SHA-256 idempotency means re-running on the same content is a no-op.
 
 ## Validate without writing
 
@@ -44,7 +44,7 @@ See [Manage collections](/how-to/collections/) for the full vault-sync surface.
 
 - `title` — required (falls back to first H1, then filename).
 - `type` — required (or inferable from path).
-- `tags`, `summary`, `links` — preserved.
+- `tags`, `summary`, `links`, `related` — preserved. `related` may be a single string or a YAML list.
 
 Unknown fields are stored verbatim in `pages.frontmatter` and round-tripped on export.
 

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -54,7 +54,7 @@ QUAID_DB=~/memory.db quaid serve`} lang="bash" />
     href="/agents/quickstart/"
     linkText="Open the agent quickstart"
   >
-    <p>Twenty-four <code>memory_*</code> tools, knowledge-graph path output, daemon lifecycle commands (<code>quaid daemon</code>), <code>quaid status</code>, and an opt-in HTTP/SSE MCP transport — all available in the current published release (<code>v0.22.0</code>). Same surface humans use; same data, same contracts. Privacy-safe gap logging, OCC-protected writes, and a sensitivity contract that keeps raw queries from ever leaving the machine by accident.</p>
+    <p>Twenty-four <code>memory_*</code> tools, knowledge-graph path output, daemon lifecycle commands (<code>quaid daemon</code>), <code>quaid status</code>, and an opt-in HTTP/SSE MCP transport — all available in the current published release (<code>v0.22.1</code>). Same surface humans use; same data, same contracts. Privacy-safe gap logging, OCC-protected writes, and a sensitivity contract that keeps raw queries from ever leaving the machine by accident.</p>
   </AudienceCard>
 </div>
 
@@ -80,9 +80,9 @@ QUAID_DB=~/memory.db quaid serve`} lang="bash" />
 
 <div class="gb-guide-grid gb-guide-grid--three">
   <GuideMetricCard value="27" label="CLI commands" note="Read, write, graph, intelligence, collections, system." />
-  <GuideMetricCard value="24" label="Public MCP tools" note="Available in the current published release (`v0.22.0`)." />
+  <GuideMetricCard value="24" label="Public MCP tools" note="Available in the current published release (`v0.22.1`)." />
   <GuideMetricCard value="8" label="Embedded skills" note="Ingest, query, maintain, enrich, briefing, alerts, research, upgrade." />
-  <GuideMetricCard value="1" label="Static binary" note="No Docker, no Python, no cloud. Background daemon (`quaid daemon install`) available in `v0.22.0`." />
+  <GuideMetricCard value="1" label="Static binary" note="No Docker, no Python, no cloud. Background daemon (`quaid daemon install`) available in `v0.22.1`." />
   <GuideMetricCard value="0" label="API keys required" note="The model runs on your CPU. Nothing transits your network." />
 </div>
 
@@ -123,7 +123,7 @@ quaid init ~/memory.db
 # Attach your notes as a live-sync collection
 quaid collection add notes ~/notes --db ~/memory.db
 
-# Expose Quaid's 24 MCP tools over stdio (v0.22.0; opt-in HTTP/SSE transport via --http flag)
+# Expose Quaid's 24 MCP tools over stdio (v0.22.1; opt-in HTTP/SSE transport via --http flag)
 QUAID_DB=~/memory.db quaid serve
 ```
 

--- a/website/src/content/docs/integrations/hermes.mdx
+++ b/website/src/content/docs/integrations/hermes.mdx
@@ -15,7 +15,7 @@ Quaid can function as a durable memory system for [Hermes Agent](https://github.
 - **Semantic retrieval.** Hermes can query "concepts" rather than just keywords.
 - **PARA alignment.** Organizes knowledge into Projects, Areas, Resources, and Archives.
 - **Episodic memory.** Use timelines to track how a project or decision evolved over time.
-- **Native tooling.** Quaid exposes 24 `memory_*` tools in the current published release (`v0.22.0`), plus graph path output, `quaid daemon` lifecycle commands, `quaid status`, and an opt-in HTTP/SSE MCP transport.
+- **Native tooling.** Quaid exposes 24 `memory_*` tools in the current published release (`v0.22.1`), plus graph path output, `quaid daemon` lifecycle commands, `quaid status`, and an opt-in HTTP/SSE MCP transport.
 
 ## Setup
 

--- a/website/src/content/docs/integrations/openclaw.mdx
+++ b/website/src/content/docs/integrations/openclaw.mdx
@@ -56,7 +56,7 @@ Quaid can function as a persistent memory layer for OpenClaw agents. It gives Op
    quaid collection add memory ~/.openclaw/workspace/memory
    ```
 
-   The file watcher runs automatically inside `quaid serve`. A persistent background daemon is available via `quaid daemon install` in `v0.22.0` (the current published release).
+   The file watcher runs automatically inside `quaid serve`. A persistent background daemon is available via `quaid daemon install` in `v0.22.1` (the current published release).
 
 4. ### Generate embeddings
    ```bash

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -104,7 +104,7 @@ Single-file ingestion with SHA-256 idempotency. Re-running on the same file is a
 
 ### `import <PATH>`
 
-Batch import a markdown directory. Page types are inferred from a PARA-style folder layout (`projects/`, `areas/`, `resources/`, `archives/`).
+Batch import a markdown directory. Page types are inferred from a PARA-style folder layout (`project(s)/`, `area(s)/`, `resource(s)/`, `archive(s)/`) after stripping numeric prefixes such as `1-projects/`.
 
 | Flag | Type | Default |
 | ---- | ---- | ------- |
@@ -129,11 +129,13 @@ Generate or refresh embeddings.
 | ---- | ---- | ------- |
 | `--all` | flag | false |
 | `--stale` | flag | false |
+| `--batch-size <N>` | usize | 32 |
 
 ```bash
 quaid embed people/alice          # one page
 quaid embed --stale                # only re-embed pages whose chunks changed
 quaid embed --all                  # rebuild every embedding
+quaid embed --all --batch-size 16  # scan pages in smaller batches
 ```
 
 ## Graph — links and backlinks

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -134,7 +134,7 @@ Generate or refresh embeddings.
 ```bash
 quaid embed people/alice          # one page
 quaid embed --stale                # only re-embed pages whose chunks changed
-quaid embed --all                  # rebuild every embedding
+quaid embed --all                  # scan every page; skip current chunks
 quaid embed --all --batch-size 16  # scan pages in smaller batches
 ```
 

--- a/website/src/content/docs/reference/mcp.mdx
+++ b/website/src/content/docs/reference/mcp.mdx
@@ -8,9 +8,9 @@ guide:
 
 `quaid serve` exposes a stdio MCP server that speaks JSON-RPC 2.0. Twenty-four `memory_*` tools cover the read, write, graph, intelligence, conversation memory, and namespace surfaces. This page is the canonical catalog.
 
-> **Version note.** The 24-tool stdio surface, graph path output, HTTP/SSE transport, and `quaid daemon` lifecycle commands are all available in the current published release (`v0.22.0`).
+> **Version note.** The 24-tool stdio surface, graph path output, HTTP/SSE transport, and `quaid daemon` lifecycle commands are all available in the current published release (`v0.22.1`).
 
-The default transport is stdio. Any MCP-compatible client (Claude Code, Cursor, custom rmcp clients) can connect by spawning `quaid serve` and exchanging JSON-RPC over stdin/stdout. An opt-in HTTP/SSE transport is also available via `quaid serve --http` or `quaid daemon run --http` in `v0.22.0`. See [Connect Claude Code](/tutorials/connect-claude-code/) for a worked example.
+The default transport is stdio. Any MCP-compatible client (Claude Code, Cursor, custom rmcp clients) can connect by spawning `quaid serve` and exchanging JSON-RPC over stdin/stdout. An opt-in HTTP/SSE transport is also available via `quaid serve --http` or `quaid daemon run --http` in `v0.22.1`. See [Connect Claude Code](/tutorials/connect-claude-code/) for a worked example.
 
 > **Platform note.** `quaid serve` and all MCP tools are cross-platform. Live vault-sync watcher threads (automatic reconcile on file edits) start only on Unix (macOS / Linux) and are simply not started on Windows — MCP tool calls continue to work normally on all platforms.
 

--- a/website/src/content/docs/reference/page-types.mdx
+++ b/website/src/content/docs/reference/page-types.mdx
@@ -70,7 +70,7 @@ The compiled-truth section (above the line) represents the current state of the 
 | `action_item` | Trackable to-dos with an owner | `actions` |
 | `journal` | Daily journal entries | `journal` |
 
-`quaid import` infers `type` from a PARA-style folder layout (`projects/`, `areas/`, etc.) when no explicit type is set in frontmatter.
+`quaid import` infers `type` from PARA-style singular or plural folders (`project(s)/`, `area(s)/`, etc.) after stripping numeric prefixes when no explicit type is set in frontmatter.
 
 ## Type-specific conventions
 

--- a/website/src/content/docs/tutorials/install.mdx
+++ b/website/src/content/docs/tutorials/install.mdx
@@ -60,7 +60,7 @@ The installer always grabs the latest release. To pin:
   | QUAID_VERSION=<published-tag> sh`}
 />
 
-Replace `<published-tag>` with a GitHub Release tag. GitHub Releases currently publish `v0.22.0`, including the knowledge graph layer, daemon runtime, and HTTP/SSE transport.
+Replace `<published-tag>` with a GitHub Release tag. GitHub Releases currently publish `v0.22.1`, including the knowledge graph layer, daemon runtime, and HTTP/SSE transport.
 
 ## What you got
 


### PR DESCRIPTION
## Summary
- propose fixes for beta-reported regressions from issues #190-#195
- scope covers PARA type inference, scalar frontmatter tolerance, round-trip completeness, MCP shutdown cleanup, and embed batching

## Status
- OpenSpec proposal/design/spec/tasks created and validated
- implementation in progress

## Validation
- openspec validate fix-beta-reported-regressions --strict