### PR TITLE
fix: make conversation turn parsing delimiter-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to Quaid are tracked here. Pre-1.0, schema and
 response-shape changes may break compatibility between minor versions —
 each entry below calls out the migration implications.
 
+## v0.22.2 — conversation turn delimiter fix
+
+### Fixed
+
+- **Conversation capture stability.** `memory_add_turn` and
+  `memory_close_session` now handle conversation content that contains Markdown
+  horizontal rules (`---`). New conversation day-files use an unambiguous
+  Quaid turn boundary marker while the parser remains compatible with existing
+  legacy turn files.
+
+### Migration
+
+- No schema migration. Existing v0.22.x databases remain compatible.
+
 ## v0.22.1 — beta regression fixes
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2135,7 +2135,7 @@ dependencies = [
 
 [[package]]
 name = "quaid"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quaid"
-version = "0.22.1"
+version = "0.22.2"
 edition = "2021"
 description = "Local-first personal memory. SQLite + FTS5 + local vector embeddings. One static binary."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Most agent memory systems require a cloud service, a running database, or an API
 
 - **Local-first** — single SQLite file, no cloud dependency, works offline
 - **PARA-native** — organizes memory as a knowledge base (Projects, Areas, Resources, Archives), not a flat list of facts
-- **24 MCP tools, knowledge-graph path output, daemon runtime, `quaid daemon` lifecycle commands, `quaid status`, and an opt-in HTTP/SSE MCP transport in the current published release (`v0.22.1`)**
+- **24 MCP tools, knowledge-graph path output, daemon runtime, `quaid daemon` lifecycle commands, `quaid status`, and an opt-in HTTP/SSE MCP transport in the current published release (`v0.22.2`)**
 - **Hybrid retrieval** — FTS5 full-text + local BGE vector embeddings, combined via RRF
 - **Verified by benchmarks** — [193/215 (90%) on DAB](https://quaid-app.github.io/quaid-evals), P@5 on MSMARCO ahead of BM25 baseline
 
@@ -97,7 +97,7 @@ Add to your `.mcp.json`:
 }
 ```
 
-The current published release (`v0.22.1`) exposes 24 MCP tools over stdio, graph path output, and an opt-in HTTP/SSE transport via `quaid serve --http` or `quaid daemon run --http`.
+The current published release (`v0.22.2`) exposes 24 MCP tools over stdio, graph path output, and an opt-in HTTP/SSE transport via `quaid serve --http` or `quaid daemon run --http`.
 
 ---
 
@@ -114,13 +114,13 @@ Sets up `PATH` and `QUAID_DB` automatically. Use `QUAID_CHANNEL=online` for the 
 ### Download a binary
 
 ```bash
-VERSION="<published-tag>"   # for example: v0.22.1
+VERSION="<published-tag>"   # for example: v0.22.2
 PLATFORM="darwin-arm64"   # darwin-arm64 | darwin-x86_64 | linux-x86_64 | linux-aarch64
 curl -fsSL "https://github.com/quaid-app/quaid/releases/download/${VERSION}/quaid-${PLATFORM}-online" \
   -o quaid && chmod +x quaid && sudo mv quaid /usr/local/bin/
 ```
 
-Use a published tag here. GitHub Releases publish `v0.22.1`, including the knowledge graph layer, daemon runtime, and HTTP/SSE transport.
+Use a published tag here. GitHub Releases publish `v0.22.2`, including the knowledge graph layer, daemon runtime, and HTTP/SSE transport.
 
 ### Build from source
 
@@ -143,7 +143,7 @@ Two ideas borrowed from Andrej Karpathy's compiled knowledge model:
 
 **Timeline (below the line)** — append-only, never rewritten. What happened and when.
 
-Every page in Quaid has both. Agents read and write through Quaid's MCP surface via stdio — 24 tools in the current published release (`v0.22.1`) — with no REST API and no network dependency. An opt-in HTTP/SSE transport is also available via `quaid serve --http` or `quaid daemon run --http`.
+Every page in Quaid has both. Agents read and write through Quaid's MCP surface via stdio — 24 tools in the current published release (`v0.22.2`) — with no REST API and no network dependency. An opt-in HTTP/SSE transport is also available via `quaid serve --http` or `quaid daemon run --http`.
 
 **Hybrid retrieval:** FTS5 keyword search for exact recall (names, slugs, tags) combined with local BGE vector embeddings for semantic search. Set-union merge, exact-match short-circuit.
 
@@ -193,7 +193,7 @@ quaid gaps
 # Start MCP server (stdio, default)
 quaid serve
 
-# Start MCP server with opt-in HTTP/SSE transport (available in v0.22.1)
+# Start MCP server with opt-in HTTP/SSE transport (available in v0.22.2)
 quaid serve --http --port 3112 --trust-loopback
 
 # Install background daemon (macOS launchd or Linux systemd)
@@ -214,7 +214,7 @@ quaid status
 
 ## MCP tools
 
-The current published release (`v0.22.1`) exposes 24 MCP tools over stdio, plus graph path output, daemon runtime, `quaid daemon` commands, `quaid status`, and opt-in HTTP/SSE transport:
+The current published release (`v0.22.2`) exposes 24 MCP tools over stdio, plus graph path output, daemon runtime, `quaid daemon` commands, `quaid status`, and opt-in HTTP/SSE transport:
 
 | Category | Tools |
 |----------|-------|

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started with Quaid
 
-> Quaid is a local-first personal AI memory layer: SQLite + FTS5 + local vector embeddings in one file. The current published release is `v0.22.1`, which ships the knowledge graph layer, graph path explanations, daemon runtime, `quaid daemon` lifecycle commands, `quaid status`, and an opt-in HTTP/SSE MCP transport.
+> Quaid is a local-first personal AI memory layer: SQLite + FTS5 + local vector embeddings in one file. The current published release is `v0.22.2`, which ships the knowledge graph layer, graph path explanations, daemon runtime, `quaid daemon` lifecycle commands, `quaid status`, and an opt-in HTTP/SSE MCP transport.
 
 ## What it does
 
@@ -15,9 +15,9 @@ You search it with full-text keywords and semantic queries. Any MCP-compatible A
 
 ## Status
 
-> **The current published release is `v0.22.1`.** It ships the knowledge graph layer, graph path explanations, structured frontmatter link/tag autowiring, `quaid graph extract-entities`, a detached background daemon (`quaid daemon run`, managed via launchd on macOS and systemd on Linux), `quaid daemon install|uninstall|start|stop|restart|status|logs`, `quaid status`, and an opt-in HTTP/SSE MCP transport (`quaid serve --http`). The 24-tool MCP surface is unchanged.
+> **The current published release is `v0.22.2`.** It ships the knowledge graph layer, graph path explanations, structured frontmatter link/tag autowiring, `quaid graph extract-entities`, a detached background daemon (`quaid daemon run`, managed via launchd on macOS and systemd on Linux), `quaid daemon install|uninstall|start|stop|restart|status|logs`, `quaid status`, and an opt-in HTTP/SSE MCP transport (`quaid serve --http`). The 24-tool MCP surface is unchanged.
 >
-> Published GitHub Release binaries and `install.sh` resolve to `v0.22.1`. See [roadmap_v3.md](roadmap_v3.md) for the full delivery plan.
+> Published GitHub Release binaries and `install.sh` resolve to `v0.22.2`. See [roadmap_v3.md](roadmap_v3.md) for the full delivery plan.
 
 ---
 
@@ -26,7 +26,7 @@ You search it with full-text keywords and semantic queries. Any MCP-compatible A
 | Method | Status |
 | ------ | ------ |
 | Build from source (`cargo build --release`) | ✅ Available now |
-| GitHub Release binary (macOS ARM/x86, Linux x86_64/ARM64) | ✅ Available — the latest published tag is `v0.22.1`, including the knowledge graph layer, daemon runtime, and HTTP/SSE transport |
+| GitHub Release binary (macOS ARM/x86, Linux x86_64/ARM64) | ✅ Available — the latest published tag is `v0.22.2`, including the knowledge graph layer, daemon runtime, and HTTP/SSE transport |
 | `npm install -g quaid` | ❌ Not yet published — use binary release or build from source |
 | One-command curl installer | ✅ Available — airgapped by default; set `QUAID_CHANNEL=online` for online |
 
@@ -67,7 +67,7 @@ cross build --release --target aarch64-unknown-linux-musl     # Linux ARM64 (ful
 
 ## Your first memory store
 
-> **Phase 1 commands** are implemented. **Phase 2 commands** (graph, check, gaps) are implemented. **Phase 3 commands** (validate, call, pipe, skills) are implemented. **Phase 5b commands** (daemon lifecycle, `quaid status`, HTTP/SSE transport) and the knowledge graph layer are available in `v0.22.1`; see [Status](#status) and [Install options](#install-options) above.
+> **Phase 1 commands** are implemented. **Phase 2 commands** (graph, check, gaps) are implemented. **Phase 3 commands** (validate, call, pipe, skills) are implemented. **Phase 5b commands** (daemon lifecycle, `quaid status`, HTTP/SSE transport) and the knowledge graph layer are available in `v0.22.2`; see [Status](#status) and [Install options](#install-options) above.
 
 > **Post-install note:** The shell installer (`scripts/install.sh`) automatically adds `PATH` and `QUAID_DB` to your shell profile. If you built from source or used the manual GitHub Releases download, add these to your profile yourself:
 > ```bash
@@ -187,7 +187,7 @@ The MCP server exposes tools over stdio JSON-RPC 2.0.
 
 **Collections + namespaces (3):** `memory_collections`, `memory_namespace_create`, `memory_namespace_destroy`
 
-The current published release (`v0.22.1`) exposes 24 tools and adds graph path output, daemon runtime, `quaid daemon` commands, `quaid status`, and opt-in HTTP/SSE transport. See [spec.md](spec.md#mcp-server) for tool signatures.
+The current published release (`v0.22.2`) exposes 24 tools and adds graph path output, daemon runtime, `quaid daemon` commands, `quaid status`, and opt-in HTTP/SSE transport. See [spec.md](spec.md#mcp-server) for tool signatures.
 
 ### Capture a conversation on this branch
 
@@ -197,7 +197,7 @@ quaid call memory_add_turn '{"session_id":"demo","role":"assistant","content":"G
 quaid call memory_close_session '{"session_id":"demo"}'
 ```
 
-Those calls append turns to `conversations/YYYY-MM-DD/<session-id>.md` and queue extraction work. The capture layer, extraction worker, fact-page write path, and benchmark/integration proofs are all available in the published `v0.22.1` release.
+Those calls append turns to `conversations/YYYY-MM-DD/<session-id>.md` and queue extraction work. The capture layer accepts ordinary Markdown content, including horizontal rules (`---`) inside turn text, while using an internal Quaid marker between turn blocks. The capture layer, extraction worker, fact-page write path, and benchmark/integration proofs are all available in the published `v0.22.2` release.
 
 ---
 
@@ -467,7 +467,7 @@ quaid skills doctor   # verify SHA-256 hashes, detect override shadowing
 
 ## vault-sync-engine: Collections and live-sync
 
-> These commands first shipped in `v0.9.6` and remain part of the published `v0.22.1` vault-sync surface, including same-root single-file `quaid put` proxying on Unix.
+> These commands first shipped in `v0.9.6` and remain part of the published `v0.22.2` vault-sync surface, including same-root single-file `quaid put` proxying on Unix.
 
 ### Attach a vault
 

--- a/docs/openclaw-harness.md
+++ b/docs/openclaw-harness.md
@@ -90,7 +90,7 @@ QUAID_DB=~/.quaid/memory.db quaid serve
 
 ## MCP tools
 
-The current published release (`v0.22.1`) exposes 24 MCP tools via `quaid serve` and adds the knowledge graph layer, daemon runtime, and opt-in HTTP/SSE transport. All tool names use the `memory_*` prefix.
+The current published release (`v0.22.2`) exposes 24 MCP tools via `quaid serve` and adds the knowledge graph layer, daemon runtime, and opt-in HTTP/SSE transport. All tool names use the `memory_*` prefix.
 
 ### `memory_query` vs `memory_search`
 

--- a/docs/roadmap_v3.md
+++ b/docs/roadmap_v3.md
@@ -9,7 +9,7 @@ aliases: [quaid-roadmap]
 # Quaid Product Roadmap
 
 **Last updated:** May 12, 2026
-**Latest public release:** v0.22.1
+**Latest public release:** v0.22.2
 **Current release lane:** v0.23.0
 **Benchmark baseline:** DAB v1 213/215 (99%), LoCoMo 0.1%, LongMemEval 0.0%, BEAM 0.0%
 
@@ -110,7 +110,7 @@ The single biggest gap vs Mem0/GBrain: Quaid stores raw conversation turns as do
 - No new MCP tools; the 24-tool surface is unchanged
 
 ### Release truth
-- First shipped in `v0.21.0`; GitHub Releases and `install.sh` now resolve to `v0.22.1`.
+- First shipped in `v0.21.0`; GitHub Releases and `install.sh` now resolve to `v0.22.2`.
 
 ---
 

--- a/src/core/conversation/format.rs
+++ b/src/core/conversation/format.rs
@@ -6,8 +6,8 @@
 //! On-disk conversation Markdown format.
 //!
 //! Defines the canonical YAML-frontmatter + `## Turn N · role ·
-//! timestamp` body shape that every conversation day-file uses, plus
-//! the path scheme that lays them out as
+//! timestamp` body shape that every conversation day-file uses, plus an
+//! unambiguous marker between turn blocks and the path scheme that lays them out as
 //! `[<namespace>/]conversations/<date>/<session>.md`. Provides both
 //! directions of the round-trip — `parse` / `parse_str` and
 //! `render` / `render_turn_block` — so writers and readers stay
@@ -31,6 +31,8 @@ use crate::core::{collections, namespace};
 
 const HEADING_SEPARATOR: &str = " · ";
 const METADATA_FENCE_OPEN: &str = "```json turn-metadata";
+pub(crate) const TURN_BOUNDARY: &str = "<!-- quaid-turn-boundary -->";
+const LEGACY_TURN_BOUNDARY: &str = "---";
 
 /// Errors surfaced by conversation parse/render and path helpers.
 #[derive(Debug, Error)]
@@ -195,7 +197,9 @@ pub fn render(file: &ConversationFile) -> String {
 
     for (index, turn) in file.turns.iter().enumerate() {
         if index > 0 {
-            out.push_str("\n---\n\n");
+            out.push('\n');
+            out.push_str(TURN_BOUNDARY);
+            out.push_str("\n\n");
         }
         out.push_str(&render_turn_block(turn));
     }
@@ -496,16 +500,36 @@ fn parse_turn_block(
     }
 
     let mut end = start + 1;
-    let mut in_code_fence = false;
+    let mut code_fence: Option<CodeFence> = None;
     while end < lines.len() {
         let line = lines[end].trim_end();
-        if line.starts_with("```") {
-            in_code_fence = !in_code_fence;
-        }
-        if !in_code_fence && line == "---" {
+        if let Some(open_fence) = code_fence {
+            if code_fence_marker(line).is_some_and(|closing_fence| closing_fence.closes(open_fence))
+            {
+                code_fence = None;
+            }
+        } else if let Some(open_fence) = code_fence_marker(line) {
+            code_fence = Some(open_fence);
+        } else if is_turn_boundary(lines, end) {
             break;
         }
         end += 1;
+    }
+
+    fn is_turn_boundary(lines: &[String], index: usize) -> bool {
+        let line = lines[index].trim_end();
+        line == TURN_BOUNDARY
+            || (line == LEGACY_TURN_BOUNDARY && followed_by_turn_heading(lines, index + 1))
+    }
+
+    fn followed_by_turn_heading(lines: &[String], mut index: usize) -> bool {
+        while index < lines.len() && lines[index].trim().is_empty() {
+            index += 1;
+        }
+        lines
+            .get(index)
+            .map(|line| line.trim_end().starts_with("## Turn "))
+            .unwrap_or(false)
     }
 
     let mut block_lines = lines[start + 1..end].to_vec();
@@ -530,6 +554,32 @@ fn parse_turn_block(
         },
         next_index,
     ))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct CodeFence {
+    marker: u8,
+    len: usize,
+}
+
+impl CodeFence {
+    fn closes(self, open: Self) -> bool {
+        self.marker == open.marker && self.len >= open.len
+    }
+}
+
+fn code_fence_marker(line: &str) -> Option<CodeFence> {
+    let trimmed = line.trim_start();
+    let marker = trimmed.as_bytes().first().copied()?;
+    if marker != b'`' && marker != b'~' {
+        return None;
+    }
+    let len = trimmed
+        .as_bytes()
+        .iter()
+        .take_while(|byte| **byte == marker)
+        .count();
+    (len >= 3).then_some(CodeFence { marker, len })
 }
 
 fn split_content_and_metadata(

--- a/src/core/conversation/turn_writer.rs
+++ b/src/core/conversation/turn_writer.rs
@@ -376,7 +376,9 @@ fn write_new_file(
 
 fn append_turn_block(full_path: &Path, turn: &Turn) -> Result<(), TurnWriteError> {
     let mut file = OpenOptions::new().append(true).open(full_path)?;
-    file.write_all(b"\n---\n\n")?;
+    writeln!(file)?;
+    writeln!(file, "{}", format::TURN_BOUNDARY)?;
+    writeln!(file)?;
     file.write_all(format::render_turn_block(turn).as_bytes())?;
     file.sync_all()?;
     Ok(())

--- a/tests/conversation_turn_capture.rs
+++ b/tests/conversation_turn_capture.rs
@@ -112,6 +112,115 @@ fn parse_render_round_trip_preserves_turn_metadata_and_cursor() {
 }
 
 #[test]
+fn parse_legacy_turns_preserves_horizontal_rules_inside_content() {
+    let rendered = concat!(
+        "---\n",
+        "type: conversation\n",
+        "session_id: session-1\n",
+        "date: 2026-05-03\n",
+        "started_at: 2026-05-03T09:14:22Z\n",
+        "status: open\n",
+        "last_extracted_at: null\n",
+        "last_extracted_turn: 0\n",
+        "---\n\n",
+        "## Turn 1 · user · 2026-05-03T09:14:22Z\n\n",
+        "This turn contains a Markdown rule.\n",
+        "---\n",
+        "It is still part of the first turn.\n\n",
+        "---\n\n",
+        "## Turn 2 · assistant · 2026-05-03T09:14:23Z\n\n",
+        "second turn\n"
+    );
+
+    let parsed = parse_str(rendered).unwrap();
+
+    assert_eq!(parsed.turns.len(), 2);
+    assert_eq!(
+        parsed.turns[0].content,
+        "This turn contains a Markdown rule.\n---\nIt is still part of the first turn."
+    );
+    assert!(render(&parsed).contains("<!-- quaid-turn-boundary -->"));
+}
+
+#[test]
+fn parse_legacy_turns_ignores_boundary_shapes_inside_nested_code_fences() {
+    let rendered = concat!(
+        "---\n",
+        "type: conversation\n",
+        "session_id: session-1\n",
+        "date: 2026-05-03\n",
+        "started_at: 2026-05-03T09:14:22Z\n",
+        "status: open\n",
+        "last_extracted_at: null\n",
+        "last_extracted_turn: 0\n",
+        "---\n\n",
+        "## Turn 1 · user · 2026-05-03T09:14:22Z\n\n",
+        "````markdown\n",
+        "```yaml\n",
+        "---\n\n",
+        "## Turn 2 · assistant · 2026-05-03T09:14:23Z\n\n",
+        "not a real turn\n",
+        "```\n",
+        "````\n\n",
+        "---\n\n",
+        "## Turn 2 · assistant · 2026-05-03T09:14:24Z\n\n",
+        "real second turn\n"
+    );
+
+    let parsed = parse_str(rendered).unwrap();
+
+    assert_eq!(parsed.turns.len(), 2);
+    assert!(parsed.turns[0].content.contains("not a real turn"));
+    assert_eq!(parsed.turns[1].content, "real second turn");
+}
+
+#[test]
+fn memory_add_turn_handles_many_turns_with_horizontal_rules_in_content() {
+    let vault_root = tempfile::TempDir::new().unwrap();
+    let (_db_dir, _db_path, server) = open_turn_server(vault_root.path());
+
+    for ordinal in 1_i64..=50 {
+        let content = format!(
+            "Turn {ordinal}: benchmark transcript segment\n---\ncontent after horizontal rule"
+        );
+        let result = server
+            .memory_add_turn(MemoryAddTurnInput {
+                session_id: "horizontal-rule-session".to_string(),
+                role: "user".to_string(),
+                content,
+                timestamp: Some(format!("2026-05-03T09:{ordinal:02}:00Z")),
+                metadata: None,
+                namespace: None,
+            })
+            .unwrap();
+        let payload: serde_json::Value = serde_json::from_str(&extract_text(&result)).unwrap();
+        let expected_turn_id = format!("horizontal-rule-session:{ordinal}");
+        assert_eq!(payload["turn_id"].as_str(), Some(expected_turn_id.as_str()));
+    }
+
+    let close_result = server
+        .memory_close_session(MemoryCloseSessionInput {
+            session_id: "horizontal-rule-session".to_string(),
+            namespace: None,
+        })
+        .unwrap();
+    let close_payload: serde_json::Value =
+        serde_json::from_str(&extract_text(&close_result)).unwrap();
+    assert!(close_payload["closed_at"].as_str().is_some());
+
+    let parsed = parse(
+        &vault_root
+            .path()
+            .join("conversations")
+            .join("2026-05-03")
+            .join("horizontal-rule-session.md"),
+    )
+    .unwrap();
+    assert_eq!(parsed.turns.len(), 50);
+    assert!(parsed.turns[49].content.contains("---\ncontent after"));
+}
+
+#[test]
 fn append_turn_is_durable_before_return_and_continues_ordinals_across_days() {
     let vault_root = tempfile::TempDir::new().unwrap();
     let (_db_dir, _db_path, conn) = open_turn_db(vault_root.path());

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -54,7 +54,7 @@ QUAID_DB=~/memory.db quaid serve`} lang="bash" />
     href="/agents/quickstart/"
     linkText="Open the agent quickstart"
   >
-    <p>Twenty-four <code>memory_*</code> tools, knowledge-graph path output, daemon lifecycle commands (<code>quaid daemon</code>), <code>quaid status</code>, and an opt-in HTTP/SSE MCP transport — all available in the current published release (<code>v0.22.1</code>). Same surface humans use; same data, same contracts. Privacy-safe gap logging, OCC-protected writes, and a sensitivity contract that keeps raw queries from ever leaving the machine by accident.</p>
+    <p>Twenty-four <code>memory_*</code> tools, knowledge-graph path output, daemon lifecycle commands (<code>quaid daemon</code>), <code>quaid status</code>, and an opt-in HTTP/SSE MCP transport — all available in the current published release (<code>v0.22.2</code>). Same surface humans use; same data, same contracts. Privacy-safe gap logging, OCC-protected writes, and a sensitivity contract that keeps raw queries from ever leaving the machine by accident.</p>
   </AudienceCard>
 </div>
 
@@ -80,9 +80,9 @@ QUAID_DB=~/memory.db quaid serve`} lang="bash" />
 
 <div class="gb-guide-grid gb-guide-grid--three">
   <GuideMetricCard value="27" label="CLI commands" note="Read, write, graph, intelligence, collections, system." />
-  <GuideMetricCard value="24" label="Public MCP tools" note="Available in the current published release (`v0.22.1`)." />
+  <GuideMetricCard value="24" label="Public MCP tools" note="Available in the current published release (`v0.22.2`)." />
   <GuideMetricCard value="8" label="Embedded skills" note="Ingest, query, maintain, enrich, briefing, alerts, research, upgrade." />
-  <GuideMetricCard value="1" label="Static binary" note="No Docker, no Python, no cloud. Background daemon (`quaid daemon install`) available in `v0.22.1`." />
+  <GuideMetricCard value="1" label="Static binary" note="No Docker, no Python, no cloud. Background daemon (`quaid daemon install`) available in `v0.22.2`." />
   <GuideMetricCard value="0" label="API keys required" note="The model runs on your CPU. Nothing transits your network." />
 </div>
 
@@ -123,7 +123,7 @@ quaid init ~/memory.db
 # Attach your notes as a live-sync collection
 quaid collection add notes ~/notes --db ~/memory.db
 
-# Expose Quaid's 24 MCP tools over stdio (v0.22.1; opt-in HTTP/SSE transport via --http flag)
+# Expose Quaid's 24 MCP tools over stdio (v0.22.2; opt-in HTTP/SSE transport via --http flag)
 QUAID_DB=~/memory.db quaid serve
 ```
 

--- a/website/src/content/docs/integrations/hermes.mdx
+++ b/website/src/content/docs/integrations/hermes.mdx
@@ -15,7 +15,7 @@ Quaid can function as a durable memory system for [Hermes Agent](https://github.
 - **Semantic retrieval.** Hermes can query "concepts" rather than just keywords.
 - **PARA alignment.** Organizes knowledge into Projects, Areas, Resources, and Archives.
 - **Episodic memory.** Use timelines to track how a project or decision evolved over time.
-- **Native tooling.** Quaid exposes 24 `memory_*` tools in the current published release (`v0.22.1`), plus graph path output, `quaid daemon` lifecycle commands, `quaid status`, and an opt-in HTTP/SSE MCP transport.
+- **Native tooling.** Quaid exposes 24 `memory_*` tools in the current published release (`v0.22.2`), plus graph path output, `quaid daemon` lifecycle commands, `quaid status`, and an opt-in HTTP/SSE MCP transport.
 
 ## Setup
 

--- a/website/src/content/docs/integrations/openclaw.mdx
+++ b/website/src/content/docs/integrations/openclaw.mdx
@@ -56,7 +56,7 @@ Quaid can function as a persistent memory layer for OpenClaw agents. It gives Op
    quaid collection add memory ~/.openclaw/workspace/memory
    ```
 
-   The file watcher runs automatically inside `quaid serve`. A persistent background daemon is available via `quaid daemon install` in `v0.22.1` (the current published release).
+   The file watcher runs automatically inside `quaid serve`. A persistent background daemon is available via `quaid daemon install` in `v0.22.2` (the current published release).
 
 4. ### Generate embeddings
    ```bash

--- a/website/src/content/docs/reference/mcp.mdx
+++ b/website/src/content/docs/reference/mcp.mdx
@@ -8,9 +8,9 @@ guide:
 
 `quaid serve` exposes a stdio MCP server that speaks JSON-RPC 2.0. Twenty-four `memory_*` tools cover the read, write, graph, intelligence, conversation memory, and namespace surfaces. This page is the canonical catalog.
 
-> **Version note.** The 24-tool stdio surface, graph path output, HTTP/SSE transport, and `quaid daemon` lifecycle commands are all available in the current published release (`v0.22.1`).
+> **Version note.** The 24-tool stdio surface, graph path output, HTTP/SSE transport, and `quaid daemon` lifecycle commands are all available in the current published release (`v0.22.2`).
 
-The default transport is stdio. Any MCP-compatible client (Claude Code, Cursor, custom rmcp clients) can connect by spawning `quaid serve` and exchanging JSON-RPC over stdin/stdout. An opt-in HTTP/SSE transport is also available via `quaid serve --http` or `quaid daemon run --http` in `v0.22.1`. See [Connect Claude Code](/tutorials/connect-claude-code/) for a worked example.
+The default transport is stdio. Any MCP-compatible client (Claude Code, Cursor, custom rmcp clients) can connect by spawning `quaid serve` and exchanging JSON-RPC over stdin/stdout. An opt-in HTTP/SSE transport is also available via `quaid serve --http` or `quaid daemon run --http` in `v0.22.2`. See [Connect Claude Code](/tutorials/connect-claude-code/) for a worked example.
 
 > **Platform note.** `quaid serve` and all MCP tools are cross-platform. Live vault-sync watcher threads (automatic reconcile on file edits) start only on Unix (macOS / Linux) and are simply not started on Windows — MCP tool calls continue to work normally on all platforms.
 
@@ -268,7 +268,7 @@ No parameters. Returns one entry per attached collection with state, ignore-patt
 
 ## Conversation memory tools
 
-These tools store and process conversation turns. Turns are batched under a `session_id`; closing a session queues the conversation for knowledge extraction into pages.
+These tools store and process conversation turns. Turns are batched under a `session_id`; closing a session queues the conversation for knowledge extraction into pages. Turn content may contain ordinary Markdown horizontal rules (`---`); Quaid uses an internal turn boundary marker so content delimiters are not confused with stored turn separators.
 
 ### `memory_add_turn`
 

--- a/website/src/content/docs/tutorials/install.mdx
+++ b/website/src/content/docs/tutorials/install.mdx
@@ -60,7 +60,7 @@ The installer always grabs the latest release. To pin:
   | QUAID_VERSION=<published-tag> sh`}
 />
 
-Replace `<published-tag>` with a GitHub Release tag. GitHub Releases currently publish `v0.22.1`, including the knowledge graph layer, daemon runtime, and HTTP/SSE transport.
+Replace `<published-tag>` with a GitHub Release tag. GitHub Releases currently publish `v0.22.2`, including the knowledge graph layer, daemon runtime, and HTTP/SSE transport.
 
 ## What you got
 


### PR DESCRIPTION
Fixes #200.

This changes conversation day-files to use an unambiguous Quaid turn boundary marker for new writes while preserving support for legacy Markdown --- separators when they are followed by another turn heading. It also adds regression coverage for 50-turn memory_add_turn sessions whose content contains Markdown horizontal rules.

Validation so far:
- cargo test --test conversation_turn_capture