### PR TITLE
fix: normalise rope_scaling object in Phi-3.5 Mini SLM config (closes #205)

### DIFF
--- a/src/core/conversation/slm.rs
+++ b/src/core/conversation/slm.rs
@@ -214,11 +214,10 @@ impl SlmRunner {
                 });
             }
         }
-        let config: Phi3Config =
-            serde_json::from_str(&config_text).map_err(|error| SlmError::Config {
-                path: config_path.display().to_string(),
-                message: error.to_string(),
-            })?;
+        let config = parse_phi3_config(&config_text).map_err(|error| SlmError::Config {
+            path: config_path.display().to_string(),
+            message: error.to_string(),
+        })?;
 
         let tokenizer_path = model_dir.join("tokenizer.json");
         let tokenizer =
@@ -420,6 +419,28 @@ impl LazySlmRunner {
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .runtime_disabled
     }
+}
+
+fn parse_phi3_config(config_text: &str) -> serde_json::Result<Phi3Config> {
+    let mut config_value: JsonValue = serde_json::from_str(config_text)?;
+    normalize_phi3_rope_scaling(&mut config_value);
+    serde_json::from_value(config_value)
+}
+
+fn normalize_phi3_rope_scaling(config: &mut JsonValue) {
+    let Some(rope_scaling) = config.get_mut("rope_scaling") else {
+        return;
+    };
+    let JsonValue::Object(rope_scaling_object) = rope_scaling else {
+        return;
+    };
+    let normalized = rope_scaling_object
+        .get("type")
+        .and_then(JsonValue::as_str)
+        .map_or(JsonValue::Null, |rope_type| {
+            JsonValue::String(rope_type.to_string())
+        });
+    *rope_scaling = normalized;
 }
 
 /// Parse the model's raw output into the typed

--- a/tests/slm_runtime.rs
+++ b/tests/slm_runtime.rs
@@ -30,6 +30,19 @@ fn slm_runner_generates_deterministic_output_from_tiny_fixture() {
 }
 
 #[test]
+fn slm_runner_accepts_object_valued_rope_scaling_config() {
+    let temp = tempfile::tempdir().expect("create temp dir");
+    let _guard = EnvGuard::set("QUAID_MODEL_CACHE_DIR", temp.path().display().to_string());
+    seed_tiny_phi3_cache("phi-3.5-mini");
+    write_object_valued_rope_scaling("phi-3.5-mini");
+
+    let mut runner = SlmRunner::load("phi-3.5-mini").expect("load tiny phi3 model");
+    let output = runner.infer("hello", 1).expect("run deterministic infer");
+
+    assert_eq!(output, "world");
+}
+
+#[test]
 fn parse_response_strips_json_fence_and_preserves_fact_shape() {
     let parsed = parse_response(
         "```json\n{\"facts\":[{\"kind\":\"preference\",\"about\":\"language\",\"summary\":\"Rust is preferred\"}]}\n```",
@@ -253,6 +266,25 @@ fn manifest_entry(path: &str, full_path: &std::path::Path) -> serde_json::Value 
         "sha256": format!("{:x}", Sha256::digest(bytes)),
         "verified_from_source": false
     })
+}
+
+fn write_object_valued_rope_scaling(alias: &str) {
+    let cache_dir = cache_dir_for_alias(alias).unwrap();
+    let config_path = cache_dir.join("config.json");
+    let config_text = std::fs::read_to_string(&config_path).unwrap();
+    let mut config: serde_json::Value = serde_json::from_str(&config_text).unwrap();
+    config["rope_scaling"] = serde_json::json!({
+        "long_factor": [1.0],
+        "short_factor": [1.0],
+        "type": "longrope"
+    });
+    std::fs::write(&config_path, serde_json::to_vec_pretty(&config).unwrap()).unwrap();
+
+    let manifest_path = cache_dir.join("manifest.json");
+    let manifest_text = std::fs::read_to_string(&manifest_path).unwrap();
+    let mut manifest: serde_json::Value = serde_json::from_str(&manifest_text).unwrap();
+    manifest["files"][0] = manifest_entry("config.json", &config_path);
+    std::fs::write(manifest_path, serde_json::to_vec_pretty(&manifest).unwrap()).unwrap();
 }
 
 fn floats_to_bytes(values: &[f32]) -> Vec<u8> {


### PR DESCRIPTION
## Problem

Phi-3.5 Mini `config.json` uses a nested object for `rope_scaling`:
```json
"rope_scaling": {
    "long_factor": [...],
    "short_factor": [...],
    "type": "longrope"
}
```

But `Phi3Config` deserialises `rope_scaling` as a `String`. This caused the extraction worker to silently fail with:
```
SLM error: slm config invalid: invalid type: map, expected a string at line 27 column 18
```

Blocking all conversation memory extraction on v0.22.2 - LME benchmark scores 0.0 because extraction never runs.

## Fix

Add a `normalize_phi3_rope_scaling` step that extracts the `type` string from the object before serde deserialises the config. Handles both the old string format and the new object format.

## Test

Added test in `tests/slm_runtime.rs` that writes an object-valued rope_scaling config and verifies the SLM runner initialises without error.

Closes #205