### PR TITLE
Feat/playground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ each entry below calls out the migration implications.
 
 ### Fixed
 
+- **First-run collection defaults.** Fresh `quaid init` now provisions a writable
+  default collection at `~/.quaid/vault`, so MCP conversation capture can write
+  turns before any manual `collection add`. Existing databases with configured
+  write-target roots are preserved; legacy unconfigured defaults are repaired on
+  open.
 - **Synthetic benchmark fallback.** `make bench` / DAB-oriented benchmark flows
   now generate the synthetic corpus automatically when the DAB corpus is absent,
   so fresh clones no longer fail before the benchmark harness can run.
@@ -17,7 +22,8 @@ each entry below calls out the migration implications.
 
 ### Migration
 
-- No schema migration. Existing v0.22.x databases remain compatible.
+- No schema migration. Existing v0.22.x databases remain compatible; only
+  unconfigured default write-target states are conditionally bootstrapped.
 
 ## v0.22.2 — conversation turn delimiter fix
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2135,7 +2135,7 @@ dependencies = [
 
 [[package]]
 name = "quaid"
-version = "0.22.3"
+version = "0.22.4"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -2143,6 +2143,7 @@ dependencies = [
  "candle-transformers",
  "clap",
  "dirs",
+ "filetime",
  "globset",
  "hex",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quaid"
-version = "0.22.3"
+version = "0.22.4"
 edition = "2021"
 description = "Local-first personal memory. SQLite + FTS5 + local vector embeddings. One static binary."
 license = "MIT"
@@ -33,7 +33,10 @@ safetensors = "0.4"
 tokenizers = "0.20"
 
 # Model download for the online channel
-reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"], optional = true }
+reqwest = { version = "0.12", default-features = false, features = [
+    "blocking",
+    "rustls-tls",
+], optional = true }
 
 # MCP server (stdio + opt-in SSE/HTTP transport, JSON-RPC 2.0)
 rmcp = { version = "0.1", features = ["transport-sse-server"] }
@@ -76,11 +79,15 @@ libc = "0.2"
 rustix = { version = "0.38", features = ["fs", "process"] }
 
 [dev-dependencies]
+filetime = "0.2"
 tempfile = "3"
 serial_test = "3"
 
 [build-dependencies]
-reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = [
+    "blocking",
+    "rustls-tls",
+] }
 sha2 = "0.10"
 
 [features]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,28 @@
-.PHONY: bench bench-no-build bench-setup
+.PHONY: bench bench-no-build bench-setup build build-debug build-online build-cross
 
+# Build targets
+build-debug:
+	cargo build
+
+build:
+	cargo build --release
+
+build-online:
+	cargo build --release --no-default-features --features bundled,online-model
+
+build-cross-darwin-arm64:
+	cross build --release --target aarch64-apple-darwin
+
+build-cross-darwin-x64:
+	cross build --release --target x86_64-apple-darwin
+
+build-cross-linux-x64:
+	cross build --release --target x86_64-unknown-linux-musl
+
+build-cross-linux-arm64:
+	cross build --release --target aarch64-unknown-linux-musl
+
+# Benchmark targets
 # Fast feedback loop: build + 20 queries (~30s on M1/M3)
 bench:
 	./scripts/mini-bench.sh

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -30,6 +30,22 @@ The complete new surface. Pre-rename names have no supported presence in this re
 | No-profile flag env var | `QUAID_NO_PROFILE` |
 | GitHub repository | `quaid-app/quaid` |
 
+### Model cache manifest v1
+
+Current releases write `manifest_version = 1` plus file size and mtime metadata
+for downloaded extraction model caches. Legacy manifests without these fields
+remain readable. Quaid upgrades them lazily the next time you run
+`quaid model status`, `quaid model pull`, or local extraction cache validation.
+
+If a cache cannot be repaired from trusted source pins, run:
+
+```bash
+quaid model clean <alias> --force
+quaid model pull <alias>
+```
+
+See [`docs/model-cache.md`](model-cache.md) for status and cleanup operations.
+
 ### MCP tools (all 17)
 
 | Tool |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -83,6 +83,7 @@ quaid init ~/.quaid/memory.db
 ```
 
 This creates a new `memory.db` file with the full current schema (`v10` in the current published release) — including pages, embeddings, links, assertions, knowledge gaps, collections, raw imports, extraction queue state, and graph configuration.
+It also creates the default writable collection root at `~/.quaid/vault` and marks that collection as the write target, so MCP conversation capture and simple write flows work before you attach any other vault.
 
 ### 2. Attach a markdown directory or ingest a single file
 
@@ -93,6 +94,8 @@ quaid embed --stale --batch-size 32
 ```
 
 `quaid collection add` performs the initial vault scan, records the collection, and writes pages into the database. On Unix/macOS/Linux, `quaid serve` keeps that collection in sync continuously. `quaid embed` scans pages in bounded batches by default; lower `--batch-size` on constrained machines. For one-off files outside a collection, use `quaid ingest /path/to/file.md`.
+
+Existing databases keep their configured write-target collection root. To use a custom root on a new install, run `quaid collection add <name> <path> --writable` after `quaid init`; that collection becomes the explicit write target without rewriting any already-configured root.
 
 > On Unix, you can persist missing `quaid_id` frontmatter during attach (`quaid collection add <name> <path> --write-quaid-id`) or backfill it later with `quaid collection migrate-uuids <name> [--dry-run]`. Same-root single-file `quaid put` can also authenticate a live `quaid serve` owner and proxy the write instead of refusing. For an OpenClaw setup, see [openclaw-harness.md](openclaw-harness.md).
 

--- a/docs/model-cache.md
+++ b/docs/model-cache.md
@@ -1,0 +1,62 @@
+# Model Cache Operations
+
+Quaid stores downloaded extraction and embedding models under the shared model
+cache root:
+
+- `QUAID_MODEL_CACHE_DIR` when set
+- otherwise `~/.quaid/models`
+
+Use `quaid model status` to inspect cache health without starting a download.
+By default, status uses fast manifest and file metadata checks. Add `--verify`
+when you want full hash verification:
+
+```bash
+quaid model status
+quaid model status phi-3.5-mini --verify
+quaid model status small --verify
+```
+
+Status reports each known cache entry as one of:
+
+- `complete`: required files and metadata are present
+- `missing`: an alias-specific cache path is absent
+- `incomplete`: required files or manifest metadata are missing
+- `corrupted`: manifest or hash validation failed
+- `stale-temp`: a temporary download path is old enough to remove
+- `active-temp`: a temporary download still has a fresh heartbeat or mtime
+
+Use `quaid model clean --list` before deleting anything:
+
+```bash
+quaid model clean --list
+```
+
+Use `--all` to remove stale temporary paths and invalid partial caches. Complete
+verified caches are preserved by broad cleanup.
+
+```bash
+quaid model clean --all
+quaid model clean --all --force
+```
+
+Use an alias-specific clean when you intentionally want to remove a complete
+cache and re-pull it:
+
+```bash
+quaid model clean phi-3.5-mini
+quaid model clean phi-3.5-mini --force
+```
+
+Temporary extraction downloads write a `.downloading` heartbeat while files are
+streaming. Quaid treats temporary paths as active while the heartbeat or path
+mtime is fresh. The stale threshold defaults to 6 hours and can be overridden
+with:
+
+```bash
+QUAID_STALE_MODEL_CACHE_TTL_SECS=3600 quaid model clean --list
+```
+
+If a download fails, Quaid removes its temporary files or directories
+automatically. If cleanup itself fails because of permissions or a locked file,
+the error message includes the path and the matching `quaid model clean`
+command to run after the process exits.

--- a/docs/operator-guide-daemon.md
+++ b/docs/operator-guide-daemon.md
@@ -122,6 +122,8 @@ quaid serve --http --port 3112 --trust-loopback
 
 You can run `quaid serve` while a daemon is installed; it will detect the live `daemon` session and register itself as a transport-only `serve` session — no watchers, no extraction worker, no double-spawn. The daemon owns the runtime; `serve` is just the MCP transport for your IDE/agent.
 
+Fresh databases created by `quaid init` include a writable default collection rooted at `~/.quaid/vault`. That lets daemon-owned MCP tools such as `memory_add_turn` write immediately on a clean install. Existing databases with a non-empty write-target root are preserved as-is; only legacy unconfigured default states are repaired to the home-directory default.
+
 If you stop the daemon (`quaid daemon stop`) while `quaid serve` is running, the next `quaid serve` invocation after the daemon's session-row sweep window (~15s) will auto-promote to `serve_host` and take over runtime ownership.
 
 Foreground runtimes (`quaid serve` and `quaid daemon run`) handle SIGTERM/SIGINT by stopping owned workers and unregistering their `serve_sessions` row. Use the platform service manager (`quaid daemon stop`) for installed daemons; use a direct signal only for foreground/manual processes.
@@ -170,6 +172,15 @@ An older binary (one that predates the `serve_sessions.session_type` widening) r
 
 ### Logs are empty
 `quaid daemon logs` requires the daemon to have written at least one line since install. Run `quaid daemon stop && quaid daemon start` to bounce it and force a `daemon_ready` line into the log.
+
+### Disable first-run default root bootstrap
+If a regression appears in the conditional default collection bootstrap, roll back by disabling the `ensure_default_collection` repair path in the binary and configuring an explicit write target manually:
+
+```bash
+quaid collection add memory /path/to/vault --writable --db ~/.quaid/memory.db
+```
+
+Databases that already have a non-empty write-target root do not need changes during rollback.
 
 ### `quaid daemon install` fails on Windows
 Windows isn't supported in v1. You can still run `quaid daemon run` directly under your preferred supervisor (`nssm`, Task Scheduler, etc.) — the foreground entry point itself is platform-agnostic.

--- a/openspec/changes/improve-model-caching/.openspec.yaml
+++ b/openspec/changes/improve-model-caching/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-16

--- a/openspec/changes/improve-model-caching/design.md
+++ b/openspec/changes/improve-model-caching/design.md
@@ -1,0 +1,167 @@
+## Context
+
+### Current State
+Model lifecycle management is handled in `src/core/conversation/model_lifecycle.rs`. The system:
+- Downloads models from HuggingFace to temporary directories (`.{cache_key}-download-{timestamp}-{uuid}`)
+- Verifies SHA-256 hashes during download
+- Renames temporary directories to final cache locations on success
+- Creates `manifest.json` with file paths and hashes for validation
+- Runs `scavenge_stale_download_dirs()` before each download to clean directories older than 6 hours
+- Downloads timeout after 300 seconds per file, but entire multi-file downloads can take much longer
+
+### The Problem
+1. **Incomplete downloads**: Network interruptions during multi-file downloads leave partial caches in temp directories
+2. **Orphaned temp dirs**: Scavenge only runs before downloads, so stale directories accumulate if users don't download frequently
+3. **Silent failures**: No manifest validation means Quaid assumes incomplete caches are actually complete and skips re-download
+4. **Limited observability**: Download progress is reported but failures are not clearly logged
+
+### Constraints
+- Must be backward compatible (don't break existing cache format)
+- Must work in airgapped mode (embedded model builds)
+- Must not require external commands or dependencies
+- Must handle concurrent Quaid instances (single-writer guarantee via SQLite)
+
+## Goals / Non-Goals
+
+**Goals:**
+- Eliminate orphaned incomplete model caches through guaranteed cleanup on download failures
+- Enable manual cache cleanup via `quaid cache clean` command
+- Add manifest validation for existing cached models so users can recover from stale caches without re-download
+- Improve download failure observability with clear logging and error reporting
+- Make stale directory scavenging more aggressive and on-demand
+
+**Non-Goals:**
+- Change model download sources or CDN strategy
+- Modify model selection/alias resolution logic
+- Add distributed cache (e.g., shared model registry)
+- Implement model-specific garbage collection policies
+
+## Decisions
+
+### D1: Guaranteed Cleanup on Download Failure
+
+**Decision**: Wrap all download operations in a try-finally pattern that unconditionally removes the temp directory on any error.
+
+**Current State**: Error paths call `fs::remove_dir_all(&temp_dir)` manually, but may not catch all errors (e.g., during rename, after partial success).
+
+**Change**: After download completes (successfully or with error), always attempt cleanup:
+```rust
+let result = download_files(&temp_dir);
+match fs::rename(&temp_dir, &cache_dir) {
+    Ok(_) => Ok(cache_dir),
+    Err(e) if cache_dir.is_dir() && verify_cache_manifest(...).is_ok() => {
+        let _ = fs::remove_dir_all(&temp_dir);  // Remove temp, cache won already
+        Ok(cache_dir)
+    }
+    Err(e) => {
+        let _ = fs::remove_dir_all(&temp_dir);  // Always clean temp on rename failure
+        Err(...)
+    }
+}
+```
+
+**Rationale**: Ensures temp directories never accumulate from failures.
+
+**Alternatives Considered**:
+- Use guard types (RAII) - adds complexity to download code flow
+- Schedule cleanup in background - deferred cleanup is harder to reason about
+- ✓ Try-finally cleanup - simple, explicit, guaranteed
+
+### D2: New `quaid cache clean` Command
+
+**Decision**: Add a new CLI command under `src/commands/cache.rs` that lists and removes stale/incomplete model directories.
+
+**Subcommands**:
+- `quaid cache clean --list` - Show stale directories that would be removed (dry-run)
+- `quaid cache clean --all` - Remove all stale directories
+- `quaid cache clean <alias>` - Remove cache for specific model alias
+- `quaid cache status` - Show cache health (completeness, manifest validity)
+
+**Implementation**: 
+- Reuse `scavenge_stale_download_dirs()` logic but make it on-demand
+- Scan `~/.quaid/models/` and identify:
+  - Temp directories: `.*-download-.*` pattern (always stale)
+  - Incomplete caches: exist but missing manifest or failed validation
+  - Aged caches: older than TTL (6 hours for temps, optional for full caches)
+- Report what will be removed with sizes
+- Require confirmation before deletion (unless `--force`)
+
+**Rationale**: Gives users explicit control and visibility into cache health without waiting for the next download.
+
+**Alternatives Considered**:
+- Auto-cleanup on startup - disruptive, slow startup
+- Keep stale cleanup before-download only - leaves manual intervention only option
+- ✓ On-demand CLI command - explicit, safe, debuggable
+
+### D3: Manifest Validation for Existing Caches
+
+**Decision**: Add `cache-validation` capability that checks existing caches and auto-generates missing manifests.
+
+**Flow**:
+1. When cache is first used, check if `manifest.json` exists
+2. If missing, compute SHA-256 for all cache files and create manifest
+3. If exists but invalid, report error and recommend re-download
+
+**Benefits**:
+- Users with partially-downloaded caches (from previous incomplete downloads) can recover
+- No re-download required if files are actually complete
+- Manifest acts as proof of cache completeness
+
+**Implementation**:
+- New function `ensure_cache_manifest(cache_dir, alias)` called before model load
+- Scans all files in cache_dir, computes hashes, validates against expected set for alias
+- Creates manifest only if all files present and hashes match
+
+**Alternatives Considered**:
+- Require re-download if manifest missing - wasteful for users with complete caches
+- ✓ Lazy manifest generation - recovers existing good caches automatically
+
+### D4: Improved Logging and Observability
+
+**Decision**: Add debug/trace logging throughout download lifecycle and model the error states clearly.
+
+**Where**:
+- Pre-download: log cache validation results, temp directory status
+- During download: log each file start, progress checkpoints, errors
+- Post-download: log manifest creation, rename success/failure, cleanup success/failure
+- Error reporting: Include file size, download duration, hash mismatches
+
+**Rationale**: Makes it easier to debug download issues and understand why a cache was invalidated.
+
+**Implementation**: Use existing `ProgressReporter` trait but extend with more granular logging at trace level.
+
+### D5: Stale Directory Scavenging Strategy
+
+**Decision**: Keep pre-download scavenging but add optional on-demand cleanup via `quaid cache clean`.
+
+**Rationale**:
+- Pre-download scavenging is lightweight and automatic (wins for most users)
+- On-demand cleanup via CLI is explicit and useful for operators and troubleshooting
+- Don't aggressively clean on every command (too much FS I/O)
+- 6-hour TTL is reasonable for temp directories
+
+**Alternative**: Reduce TTL to 1 hour (more aggressive) - rejected as too aggressive for large models
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|------|-----------|
+| Cleanup removes in-progress downloads if two Quaid instances run simultaneously | Quaid has single-writer design; concurrent reads are OK. Document that only one instance should download at a time. Add check for `.downloading` lock files. |
+| Manifest validation has false negatives (missing files but marked complete) | Verify manifest immediately after creation, reject if any file hashes mismatch. Add integration test for incomplete downloads. |
+| `quaid cache clean` is too aggressive and removes user's intended caches | Add `--list` dry-run first, require `--force` for destructive operations, warn about non-stale caches. |
+| User confusion about when to run `cache clean` | Add troubleshooting section to operator guide explaining download failure symptoms and recovery. |
+| Download failures not immediately visible if user doesn't check logs | Improve progress reporter to surface errors to stdout/stderr even in non-verbose mode. |
+
+## Migration Plan
+
+1. **Phase 1 (PR)**: Add guaranteed cleanup on download errors + improved logging
+2. **Phase 2 (PR)**: Add `cache-validation` capability (lazy manifest generation)
+3. **Phase 3 (PR)**: Add `quaid cache clean` command with subcommands
+4. **Deployment**: Changes are fully backward compatible; no data migration needed
+5. **Rollback**: None required; old code path remains if cleanup fails
+
+## Open Questions
+
+1. Should we add metrics/telemetry for download failures and incomplete caches? (Suggested: yes, helps identify patterns)
+2. Should `cache clean` also validate and repair manifests for existing caches, or only remove stale ones? (Suggested: separate `cache validate` subcommand)
+3. What's the maximum age for a non-temp cache before it's considered stale? (Suggested: no auto-removal, only manual)

--- a/openspec/changes/improve-model-caching/design.md
+++ b/openspec/changes/improve-model-caching/design.md
@@ -1,167 +1,238 @@
 ## Context
 
 ### Current State
-Model lifecycle management is handled in `src/core/conversation/model_lifecycle.rs`. The system:
-- Downloads models from HuggingFace to temporary directories (`.{cache_key}-download-{timestamp}-{uuid}`)
-- Verifies SHA-256 hashes during download
-- Renames temporary directories to final cache locations on success
-- Creates `manifest.json` with file paths and hashes for validation
-- Runs `scavenge_stale_download_dirs()` before each download to clean directories older than 6 hours
-- Downloads timeout after 300 seconds per file, but entire multi-file downloads can take much longer
+
+Quaid has two online model cache paths under `QUAID_MODEL_CACHE_DIR` or
+`~/.quaid/models`:
+
+- Extraction SLM cache: `src/core/conversation/model_lifecycle.rs`
+  downloads Hugging Face model files into a temporary directory named
+  `.{cache_key}-download-{timestamp}-{uuid}`, writes `manifest.json`, verifies
+  it, then renames the temporary directory to the final cache directory.
+- Embedding model cache: `src/core/inference.rs` downloads
+  `config.json`, `tokenizer.json`, and `model.safetensors` directly into the
+  final cache directory using per-file temporary names like
+  `{file}.download-{uuid}`. It verifies pinned hashes for known embedding
+  models but has no manifest and no shared cleanup/status surface.
+
+The extraction path already cleans many failures, but cleanup is manual and can
+be bypassed by Rust early returns before `install_result` is handled. The
+embedding path can leave per-file temporary downloads when network, write, or
+hash verification fails.
 
 ### The Problem
-1. **Incomplete downloads**: Network interruptions during multi-file downloads leave partial caches in temp directories
-2. **Orphaned temp dirs**: Scavenge only runs before downloads, so stale directories accumulate if users don't download frequently
-3. **Silent failures**: No manifest validation means Quaid assumes incomplete caches are actually complete and skips re-download
-4. **Limited observability**: Download progress is reported but failures are not clearly logged
+
+1. **Leaked partial downloads**: Network, disk, hash, metadata, or early-return
+   errors can leave temporary directories/files behind.
+2. **Legacy complete caches are treated as invalid**: Extraction caches without
+   a manifest are removed and re-downloaded even when files are complete and
+   source-verifiable.
+3. **No unified cache inspection**: Users can pull a model but cannot ask Quaid
+   which model caches are complete, incomplete, corrupted, or stale.
+4. **Ambiguous progress/errors**: Download progress exists, but failures need
+   more actionable context and recovery instructions.
 
 ### Constraints
-- Must be backward compatible (don't break existing cache format)
-- Must work in airgapped mode (embedded model builds)
-- Must not require external commands or dependencies
-- Must handle concurrent Quaid instances (single-writer guarantee via SQLite)
+
+- No new external dependencies.
+- Must preserve existing cache contents and read legacy versionless manifests.
+- Must work in airgapped builds; network repair is only available in the online
+  build.
+- Must not silently accept a cache unless the expected file set and digests are
+  known from source pins, embedding model pins, an existing manifest, or fresh
+  download metadata.
+- Must tolerate concurrent Quaid processes without corrupting the final cache.
 
 ## Goals / Non-Goals
 
 **Goals:**
-- Eliminate orphaned incomplete model caches through guaranteed cleanup on download failures
-- Enable manual cache cleanup via `quaid cache clean` command
-- Add manifest validation for existing cached models so users can recover from stale caches without re-download
-- Improve download failure observability with clear logging and error reporting
-- Make stale directory scavenging more aggressive and on-demand
+
+- Remove partial extraction temp directories and embedding temp files on all
+  download failure paths controlled by Quaid.
+- Add `quaid model status` and `quaid model clean` to inspect and clean model
+  caches without opening `memory.db`.
+- Safely generate or upgrade manifests for complete, source-verifiable caches.
+- Keep normal cache-hit validation fast while preserving an explicit full hash
+  verification path.
+- Make download failures and cleanup outcomes understandable from CLI output.
 
 **Non-Goals:**
-- Change model download sources or CDN strategy
-- Modify model selection/alias resolution logic
-- Add distributed cache (e.g., shared model registry)
-- Implement model-specific garbage collection policies
+
+- Change model download sources or Hugging Face mirror strategy.
+- Change model alias resolution semantics.
+- Add remote telemetry or metrics collection.
+- Add a distributed/shared model registry.
+- Automatically remove complete verified caches by age.
 
 ## Decisions
 
-### D1: Guaranteed Cleanup on Download Failure
+### D1: Scope-Bound Cleanup Guards
 
-**Decision**: Wrap all download operations in a try-finally pattern that unconditionally removes the temp directory on any error.
+**Decision**: Use small RAII cleanup guards for temporary download paths:
 
-**Current State**: Error paths call `fs::remove_dir_all(&temp_dir)` manually, but may not catch all errors (e.g., during rename, after partial success).
+- Extraction SLM downloads use a temp-directory guard that removes the temp
+  directory on `Drop` unless explicitly disarmed after a successful rename or
+  after another process wins the race and leaves a valid final cache.
+- Embedding downloads use a temp-file guard that removes `{file}.download-*` on
+  `Drop` unless the file was successfully renamed or another process already
+  produced a valid destination.
 
-**Change**: After download completes (successfully or with error), always attempt cleanup:
-```rust
-let result = download_files(&temp_dir);
-match fs::rename(&temp_dir, &cache_dir) {
-    Ok(_) => Ok(cache_dir),
-    Err(e) if cache_dir.is_dir() && verify_cache_manifest(...).is_ok() => {
-        let _ = fs::remove_dir_all(&temp_dir);  // Remove temp, cache won already
-        Ok(cache_dir)
-    }
-    Err(e) => {
-        let _ = fs::remove_dir_all(&temp_dir);  // Always clean temp on rename failure
-        Err(...)
-    }
-}
-```
-
-**Rationale**: Ensures temp directories never accumulate from failures.
+**Rationale**: Rust has no `try/finally`. A manual cleanup block after the
+download call is easy to bypass with `?`, especially around metadata selection
+or hash verification. A guard keeps idiomatic `?` propagation while making
+cleanup the default.
 
 **Alternatives Considered**:
-- Use guard types (RAII) - adds complexity to download code flow
-- Schedule cleanup in background - deferred cleanup is harder to reason about
-- ✓ Try-finally cleanup - simple, explicit, guaranteed
 
-### D2: New `quaid cache clean` Command
+- Manual "try-finally" cleanup blocks: rejected because current code already
+  demonstrates how early returns can bypass them.
+- Background cleanup thread: rejected because this is a CLI/runtime library and
+  deferred cleanup is harder to test.
+- RAII guard: selected because it is local, dependency-free, and idiomatic Rust.
 
-**Decision**: Add a new CLI command under `src/commands/cache.rs` that lists and removes stale/incomplete model directories.
+### D2: Reuse the `quaid model` Command Surface
+
+**Decision**: Extend `src/commands/model.rs` instead of adding a new top-level
+`quaid cache` command.
 
 **Subcommands**:
-- `quaid cache clean --list` - Show stale directories that would be removed (dry-run)
-- `quaid cache clean --all` - Remove all stale directories
-- `quaid cache clean <alias>` - Remove cache for specific model alias
-- `quaid cache status` - Show cache health (completeness, manifest validity)
 
-**Implementation**: 
-- Reuse `scavenge_stale_download_dirs()` logic but make it on-demand
-- Scan `~/.quaid/models/` and identify:
-  - Temp directories: `.*-download-.*` pattern (always stale)
-  - Incomplete caches: exist but missing manifest or failed validation
-  - Aged caches: older than TTL (6 hours for temps, optional for full caches)
-- Report what will be removed with sizes
-- Require confirmation before deletion (unless `--force`)
+- `quaid model pull <alias>`: existing extraction SLM pull behavior.
+- `quaid model status [alias] [--verbose] [--verify]`: show cache health.
+- `quaid model clean --list [alias]`: dry-run cleanup preview.
+- `quaid model clean --all [--force]`: remove stale/incomplete model cache
+  artifacts, never complete verified caches.
+- `quaid model clean <alias> --force`: remove artifacts associated with a
+  specific model alias, including the complete cache for that alias.
 
-**Rationale**: Gives users explicit control and visibility into cache health without waiting for the next download.
+**Rationale**: The CLI already says `quaid model` manages cached local models,
+and existing specs/documentation already reference `quaid model pull`. Adding a
+separate top-level `cache` group would split one workflow across two surfaces.
 
-**Alternatives Considered**:
-- Auto-cleanup on startup - disruptive, slow startup
-- Keep stale cleanup before-download only - leaves manual intervention only option
-- ✓ On-demand CLI command - explicit, safe, debuggable
+### D3: Cache Inventory Covers Both Layouts
 
-### D3: Manifest Validation for Existing Caches
+**Decision**: Add shared inventory helpers that scan the model cache root and
+classify entries by cache family and health.
 
-**Decision**: Add `cache-validation` capability that checks existing caches and auto-generates missing manifests.
+The scanner SHALL detect:
 
-**Flow**:
-1. When cache is first used, check if `manifest.json` exists
-2. If missing, compute SHA-256 for all cache files and create manifest
-3. If exists but invalid, report error and recommend re-download
+- Extraction temp directories matching `.{cache_key}-download-*`.
+- Embedding temp files matching `*.download-*` inside known embedding cache
+  directories.
+- Complete cache directories with valid manifests or known embedding files.
+- Incomplete directories with missing required files.
+- Corrupted caches with hash or manifest mismatches.
 
-**Benefits**:
-- Users with partially-downloaded caches (from previous incomplete downloads) can recover
-- No re-download required if files are actually complete
-- Manifest acts as proof of cache completeness
+Normal `clean --all` removes only stale temp artifacts and incomplete/corrupted
+cache directories. Complete verified caches are shown but kept unless the user
+targets a specific alias with `--force`.
 
-**Implementation**:
-- New function `ensure_cache_manifest(cache_dir, alias)` called before model load
-- Scans all files in cache_dir, computes hashes, validates against expected set for alias
-- Creates manifest only if all files present and hashes match
+### D4: Manifest Compatibility and Safe Repair
 
-**Alternatives Considered**:
-- Require re-download if manifest missing - wasteful for users with complete caches
-- ✓ Lazy manifest generation - recovers existing good caches automatically
+**Decision**: Introduce a versioned manifest format while accepting legacy
+versionless manifests.
 
-### D4: Improved Logging and Observability
+New manifests SHALL include:
 
-**Decision**: Add debug/trace logging throughout download lifecycle and model the error states clearly.
+- `manifest_version: 1`
+- `requested_alias`
+- `repo_id`
+- `revision`
+- `created_at_unix`
+- file entries with `path`, `sha256`, `size_bytes`, `modified_unix`, and
+  `verified_from_source`
 
-**Where**:
-- Pre-download: log cache validation results, temp directory status
-- During download: log each file start, progress checkpoints, errors
-- Post-download: log manifest creation, rename success/failure, cleanup success/failure
-- Error reporting: Include file size, download duration, hash mismatches
+Legacy manifests without `manifest_version`, `created_at_unix`,
+`size_bytes`, or `modified_unix` SHALL remain valid if their existing fields and
+hashes validate. When a legacy manifest is verified, Quaid MAY upgrade it to v1.
 
-**Rationale**: Makes it easier to debug download issues and understand why a cache was invalidated.
+Lazy manifest generation is allowed only when the expected file list and
+expected digests are known:
 
-**Implementation**: Use existing `ProgressReporter` trait but extend with more granular logging at trace level.
+- Curated extraction aliases from source pins.
+- Known embedding models from `ModelConfig` pinned hashes.
+- Freshly downloaded custom models where metadata/checksums were obtained
+  during that pull.
 
-### D5: Stale Directory Scavenging Strategy
+Custom/unpinned model caches without a manifest SHALL fail closed unless Quaid
+can validate them against trusted metadata. Quaid SHALL NOT generate a manifest
+by hashing whatever files happen to be present, because that can mark a partial
+cache as complete.
 
-**Decision**: Keep pre-download scavenging but add optional on-demand cleanup via `quaid cache clean`.
+### D5: Fast Validation With Explicit Full Verification
 
-**Rationale**:
-- Pre-download scavenging is lightweight and automatic (wins for most users)
-- On-demand cleanup via CLI is explicit and useful for operators and troubleshooting
-- Don't aggressively clean on every command (too much FS I/O)
-- 6-hour TTL is reasonable for temp directories
+**Decision**: Separate fast cache-hit validation from full hash verification.
 
-**Alternative**: Reduce TTL to 1 hour (more aggressive) - rejected as too aggressive for large models
+Fast validation checks manifest structure, path safety, file existence, file
+size, and file modified time. Full verification recomputes SHA-256/git-blob
+digests and is required after downloads, during manifest generation/upgrade, and
+when the user runs `quaid model status --verify`.
+
+If fast validation detects a size or mtime mismatch, the cache becomes
+suspect and Quaid runs full verification before accepting it. If full
+verification fails, the cache is corrupted and model load fails closed.
+
+**Rationale**: Re-hashing multi-gigabyte models on every cache hit or status
+command can be slower than the command the user is trying to run. The manifest
+still protects against silent corruption when files change.
+
+### D6: Progress and Error Observability Without New Logging Dependencies
+
+**Decision**: Use the existing `ProgressReporter` and returned error messages
+for user-visible observability. Do not add `tracing`, `log`, or `RUST_LOG`
+requirements in this change.
+
+The console reporter should show:
+
+- Planned alias, repo, revision, file count, and total bytes when known.
+- Per-file start, throttled progress, speed, and ETA when byte totals are known.
+- Per-file hash verification completion.
+- Final download summary.
+
+Errors should include the model alias, file name, URL when relevant, bytes
+received when known, expected vs actual hash for integrity failures, affected
+paths, and the recommended recovery command.
+
+### D7: Stale Cleanup Uses TTL Plus Heartbeat
+
+**Decision**: Keep the six-hour default stale TTL but make it configurable via
+`QUAID_STALE_MODEL_CACHE_TTL_SECS`. Downloads write or refresh a lightweight
+`.downloading` marker in temp directories and update it during progress. Cleanup
+skips temp artifacts with a recent marker, even if the directory timestamp is
+older than the TTL.
+
+If cleanup cannot remove a path because the OS reports it is in use or access is
+denied, Quaid reports the failure and leaves the path for a later cleanup
+attempt. It does not claim success.
 
 ## Risks / Trade-offs
 
 | Risk | Mitigation |
-|------|-----------|
-| Cleanup removes in-progress downloads if two Quaid instances run simultaneously | Quaid has single-writer design; concurrent reads are OK. Document that only one instance should download at a time. Add check for `.downloading` lock files. |
-| Manifest validation has false negatives (missing files but marked complete) | Verify manifest immediately after creation, reject if any file hashes mismatch. Add integration test for incomplete downloads. |
-| `quaid cache clean` is too aggressive and removes user's intended caches | Add `--list` dry-run first, require `--force` for destructive operations, warn about non-stale caches. |
-| User confusion about when to run `cache clean` | Add troubleshooting section to operator guide explaining download failure symptoms and recovery. |
-| Download failures not immediately visible if user doesn't check logs | Improve progress reporter to surface errors to stdout/stderr even in non-verbose mode. |
+|------|------------|
+| Cleanup removes an active slow download | Skip artifacts with a recent `.downloading` heartbeat; never remove recent temp paths by default. |
+| Manifest generation accidentally blesses a partial cache | Generate manifests only from trusted expected file lists and expected digests. |
+| Full hash validation is expensive | Use fast validation for normal cache hits and require full validation for repair, pull completion, mismatch suspicion, and `--verify`. |
+| `model clean --all` removes data users expected to keep | `--all` removes stale/incomplete artifacts only; complete verified caches require alias-specific `--force`. |
+| Existing legacy manifests fail after adding version fields | Read versionless manifests as legacy v0 and upgrade only after successful verification. |
+| Two processes download the same model | Final rename remains race-safe: if another process creates a verified final cache first, discard local temp and return cache hit. |
 
 ## Migration Plan
 
-1. **Phase 1 (PR)**: Add guaranteed cleanup on download errors + improved logging
-2. **Phase 2 (PR)**: Add `cache-validation` capability (lazy manifest generation)
-3. **Phase 3 (PR)**: Add `quaid cache clean` command with subcommands
-4. **Deployment**: Changes are fully backward compatible; no data migration needed
-5. **Rollback**: None required; old code path remains if cleanup fails
+1. Add cleanup guards and improved error/progress context for extraction SLM and
+   embedding downloads.
+2. Add manifest v1 structs/readers while accepting legacy manifests.
+3. Add cache inventory, status, and cleanup helpers.
+4. Add `quaid model status` and `quaid model clean`.
+5. Update docs and migration notes.
 
-## Open Questions
+No SQLite migration is required. Old cache directories remain valid if they can
+be verified.
 
-1. Should we add metrics/telemetry for download failures and incomplete caches? (Suggested: yes, helps identify patterns)
-2. Should `cache clean` also validate and repair manifests for existing caches, or only remove stale ones? (Suggested: separate `cache validate` subcommand)
-3. What's the maximum age for a non-temp cache before it's considered stale? (Suggested: no auto-removal, only manual)
+## Resolved Questions
+
+1. **Should this add telemetry?** No. This change keeps observability local via
+   status output, progress output, and error messages.
+2. **Should cleanup repair manifests?** No. Status may validate and repair when
+   safe; cleanup removes stale/incomplete artifacts.
+3. **Should complete caches expire by age?** No. Only temp artifacts use TTL.
+   Complete verified caches are removed only when explicitly targeted.

--- a/openspec/changes/improve-model-caching/proposal.md
+++ b/openspec/changes/improve-model-caching/proposal.md
@@ -1,33 +1,36 @@
 ## Why
 
-Users experience unnecessary re-downloads of large language models (e.g., phi-3.5-mini at 6GB+) every time they enable extraction or start Quaid in online mode, even when the model is fully cached locally. This is caused by three interrelated failures in model lifecycle management: (1) incomplete downloads from network interruptions are not cleaned up, (2) stale temporary download directories persist indefinitely because cleanup only runs before download attempts, and (3) without a manifest file, Quaid cannot validate cached models and assumes they're incomplete.
+Users can lose time and disk space when online model downloads fail or when a complete cache cannot be trusted. Extraction SLM caches already use temporary directories plus `manifest.json`, but some early-return paths can still leave temporary directories behind and legacy complete caches without manifests are discarded instead of repaired. Online embedding model caches use per-file temporary downloads and no manifest, so failures can leave `*.download-*` files in otherwise valid cache directories.
+
+The fix needs to cover both cache layouts that live under `QUAID_MODEL_CACHE_DIR` / `~/.quaid/models`: extraction SLM caches managed by `src/core/conversation/model_lifecycle.rs`, and online embedding caches managed by `src/core/inference.rs`.
 
 ## What Changes
 
-- Add a `quaid cache clean` command to manually remove incomplete/stale model caches
-- Improve error handling to guarantee temporary download directories are always cleaned on failures
-- Add better logging and progress reporting for model downloads so interruptions are visible
-- Refactor stale directory scavenging to be more aggressive and run on-demand
-- Add cache validation that creates/updates manifest files for already-cached models
+- Extend the existing `quaid model` command with `status` and `clean` subcommands for model cache inspection and cleanup
+- Add scope-bound cleanup guards for temporary download directories/files so Rust `?` early returns cannot leak partial downloads
+- Add cache inventory helpers that understand both extraction SLM temp directories and embedding temp files
+- Add backward-compatible manifest validation/upgrade for complete caches, without trusting arbitrary partial file sets
+- Improve user-facing progress and error reporting through the existing progress/error channels so interruptions are visible
+- Refactor stale cache scavenging so it is reusable by automatic pre-download cleanup and manual `quaid model clean`
 - Document model caching behavior and troubleshooting in operator guide
 
 ## Capabilities
 
 ### New Capabilities
 
-- `cache-cleanup`: Explicit command (`quaid cache clean`) to remove stale/incomplete model caches with safety checks and verbose reporting
-- `cache-validation`: Automatic cache integrity checks and manifest generation for existing cached models without requiring re-download
-- `download-resilience`: Guaranteed cleanup of temporary directories on any download failure to prevent orphaned incomplete caches
-- `download-observability`: Enhanced logging and progress reporting for model downloads, including network errors and timeouts
+- `cache-cleanup`: Explicit command (`quaid model clean`) to remove stale/incomplete model caches with safety checks and verbose reporting
+- `cache-validation`: Automatic cache integrity checks plus safe manifest generation/upgrade for complete, source-verifiable cached models without requiring re-download
+- `download-resilience`: Cleanup guards for temporary directories/files on download failures to prevent orphaned incomplete caches
+- `download-observability`: Enhanced progress and error reporting for model downloads, including network errors, partial downloads, and cleanup failures
 
 ### Modified Capabilities
 
-- `model-lifecycle`: Existing model download/cache system now includes robust error handling, explicit cleanup, and better observability
+- `model-lifecycle`: Existing model download/cache systems now include robust error handling, explicit cleanup, cache status, and repairable manifests
 
 ## Impact
 
-- Affected code: `src/core/conversation/model_lifecycle.rs`, `src/commands/` (new cache command)
-- Affected APIs: New CLI command `quaid cache clean`
+- Affected code: `src/core/conversation/model_lifecycle.rs`, `src/core/inference.rs`, `src/commands/model.rs`, docs and integration tests
+- Affected APIs: New CLI subcommands under existing `quaid model`: `status` and `clean`
 - Dependencies: No new external dependencies
-- User-facing: Reduces model download time by 2-4x for users with stale caches; adds safety mechanism to prevent cache corruption from interrupted downloads
-- Telemetry: Can now track download failure rates and incomplete cache incidents
+- User-facing: Avoids unnecessary re-downloads for complete legacy caches, makes stale cache cleanup explicit, and gives actionable recovery steps after interrupted downloads
+- Telemetry: No new telemetry. Operators get human-readable status output and clearer command errors

--- a/openspec/changes/improve-model-caching/proposal.md
+++ b/openspec/changes/improve-model-caching/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Users experience unnecessary re-downloads of large language models (e.g., phi-3.5-mini at 6GB+) every time they enable extraction or start Quaid in online mode, even when the model is fully cached locally. This is caused by three interrelated failures in model lifecycle management: (1) incomplete downloads from network interruptions are not cleaned up, (2) stale temporary download directories persist indefinitely because cleanup only runs before download attempts, and (3) without a manifest file, Quaid cannot validate cached models and assumes they're incomplete.
+
+## What Changes
+
+- Add a `quaid cache clean` command to manually remove incomplete/stale model caches
+- Improve error handling to guarantee temporary download directories are always cleaned on failures
+- Add better logging and progress reporting for model downloads so interruptions are visible
+- Refactor stale directory scavenging to be more aggressive and run on-demand
+- Add cache validation that creates/updates manifest files for already-cached models
+- Document model caching behavior and troubleshooting in operator guide
+
+## Capabilities
+
+### New Capabilities
+
+- `cache-cleanup`: Explicit command (`quaid cache clean`) to remove stale/incomplete model caches with safety checks and verbose reporting
+- `cache-validation`: Automatic cache integrity checks and manifest generation for existing cached models without requiring re-download
+- `download-resilience`: Guaranteed cleanup of temporary directories on any download failure to prevent orphaned incomplete caches
+- `download-observability`: Enhanced logging and progress reporting for model downloads, including network errors and timeouts
+
+### Modified Capabilities
+
+- `model-lifecycle`: Existing model download/cache system now includes robust error handling, explicit cleanup, and better observability
+
+## Impact
+
+- Affected code: `src/core/conversation/model_lifecycle.rs`, `src/commands/` (new cache command)
+- Affected APIs: New CLI command `quaid cache clean`
+- Dependencies: No new external dependencies
+- User-facing: Reduces model download time by 2-4x for users with stale caches; adds safety mechanism to prevent cache corruption from interrupted downloads
+- Telemetry: Can now track download failure rates and incomplete cache incidents

--- a/openspec/changes/improve-model-caching/specs/cache-cleanup/spec.md
+++ b/openspec/changes/improve-model-caching/specs/cache-cleanup/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+### Requirement: User can list stale model caches
+Users SHALL be able to preview which stale or incomplete model caches would be removed without actually removing them.
+
+#### Scenario: List stale directories
+- **WHEN** user runs `quaid cache clean --list`
+- **THEN** system displays all temporary download directories (age-based staleness check) and incomplete caches (missing manifest/failed validation), with their paths and sizes
+
+#### Scenario: List specific model cache
+- **WHEN** user runs `quaid cache clean --list phi-3.5-mini`
+- **THEN** system displays all caches related to phi-3.5-mini (both temp and complete directories)
+
+#### Scenario: Empty list when no stale caches
+- **WHEN** user runs `quaid cache clean --list` but no stale caches exist
+- **THEN** system prints "No stale caches found" and exits successfully
+
+### Requirement: User can remove stale model caches
+Users SHALL be able to remove incomplete, broken, or temporary model caches to free up disk space and recover from download failures.
+
+#### Scenario: Remove with confirmation
+- **WHEN** user runs `quaid cache clean --all`
+- **THEN** system prompts for confirmation with a summary of what will be removed
+- **AND** if user confirms, removes all identified stale directories
+
+#### Scenario: Force removal without confirmation
+- **WHEN** user runs `quaid cache clean --all --force`
+- **THEN** system immediately removes all stale caches without prompting
+
+#### Scenario: Remove specific model cache
+- **WHEN** user runs `quaid cache clean phi-3.5-mini --force`
+- **THEN** system removes the cache directory for phi-3.5-mini only
+
+#### Scenario: Partial failures don't stop cleanup
+- **WHEN** system is removing multiple stale directories and one fails to delete
+- **THEN** system continues removing others and reports which directories failed at the end
+
+### Requirement: User receives clear cache cleanup reporting
+Users SHALL receive clear feedback about what was removed, what failed, and cache health statistics after cleanup.
+
+#### Scenario: Success report shows freed space
+- **WHEN** cache cleanup completes successfully
+- **THEN** system reports: number of directories removed, total disk space freed, paths of removed directories
+
+#### Scenario: Partial failure report identifies problems
+- **WHEN** some directories fail to remove
+- **THEN** system reports successful removals and lists failed directories with error reasons (permission denied, in use, etc.)
+
+### Requirement: Safety guards prevent accidental data loss
+The system SHALL implement safety mechanisms to prevent users from accidentally removing non-stale caches.
+
+#### Scenario: Non-stale caches excluded by default
+- **WHEN** user runs `quaid cache clean --all` without `--force`
+- **THEN** system only removes stale temp directories and incomplete caches, not recent/complete caches
+
+#### Scenario: User shown what is not being removed
+- **WHEN** user runs `quaid cache clean --list`
+- **THEN** output clearly distinguishes between "stale (will be removed)" and "active/complete (will be kept)"

--- a/openspec/changes/improve-model-caching/specs/cache-cleanup/spec.md
+++ b/openspec/changes/improve-model-caching/specs/cache-cleanup/spec.md
@@ -1,58 +1,81 @@
 ## ADDED Requirements
 
-### Requirement: User can list stale model caches
-Users SHALL be able to preview which stale or incomplete model caches would be removed without actually removing them.
+### Requirement: User can inspect model cache cleanup candidates
+Users SHALL be able to preview stale, incomplete, or corrupted model cache
+artifacts without removing them.
 
-#### Scenario: List stale directories
-- **WHEN** user runs `quaid cache clean --list`
-- **THEN** system displays all temporary download directories (age-based staleness check) and incomplete caches (missing manifest/failed validation), with their paths and sizes
+#### Scenario: List cleanup candidates
+- **WHEN** user runs `quaid model clean --list`
+- **THEN** system displays cleanup candidates from the model cache root, including extraction temp directories, embedding temp files, incomplete caches, and corrupted caches
+- **AND** output includes path, cache family, reason, age, and size
+- **AND** no files or directories are removed
 
-#### Scenario: List specific model cache
-- **WHEN** user runs `quaid cache clean --list phi-3.5-mini`
-- **THEN** system displays all caches related to phi-3.5-mini (both temp and complete directories)
+#### Scenario: List specific model cache candidates
+- **WHEN** user runs `quaid model clean --list phi-3.5-mini`
+- **THEN** system displays cleanup candidates associated with `phi-3.5-mini`
+- **AND** complete verified caches associated with the alias are shown as kept unless explicitly targeted for removal
 
-#### Scenario: Empty list when no stale caches
-- **WHEN** user runs `quaid cache clean --list` but no stale caches exist
-- **THEN** system prints "No stale caches found" and exits successfully
+#### Scenario: Empty list when no cleanup candidates exist
+- **WHEN** user runs `quaid model clean --list` but no stale, incomplete, or corrupted artifacts exist
+- **THEN** system prints "No model cache cleanup candidates found" and exits successfully
 
-### Requirement: User can remove stale model caches
-Users SHALL be able to remove incomplete, broken, or temporary model caches to free up disk space and recover from download failures.
+### Requirement: User can remove stale and broken model cache artifacts
+Users SHALL be able to remove incomplete, corrupted, or stale temporary model
+cache artifacts to free disk space and recover from download failures.
 
 #### Scenario: Remove with confirmation
-- **WHEN** user runs `quaid cache clean --all`
+- **WHEN** user runs `quaid model clean --all`
 - **THEN** system prompts for confirmation with a summary of what will be removed
-- **AND** if user confirms, removes all identified stale directories
+- **AND** if user confirms, removes all eligible stale/incomplete/corrupted artifacts
+- **AND** complete verified caches are not removed
 
 #### Scenario: Force removal without confirmation
-- **WHEN** user runs `quaid cache clean --all --force`
-- **THEN** system immediately removes all stale caches without prompting
+- **WHEN** user runs `quaid model clean --all --force`
+- **THEN** system immediately removes eligible stale/incomplete/corrupted artifacts without prompting
+- **AND** complete verified caches are still not removed
 
 #### Scenario: Remove specific model cache
-- **WHEN** user runs `quaid cache clean phi-3.5-mini --force`
-- **THEN** system removes the cache directory for phi-3.5-mini only
+- **WHEN** user runs `quaid model clean phi-3.5-mini --force`
+- **THEN** system removes cache artifacts associated with `phi-3.5-mini`
+- **AND** because the alias is explicit and `--force` is present, the complete verified cache for that alias MAY be removed
 
-#### Scenario: Partial failures don't stop cleanup
-- **WHEN** system is removing multiple stale directories and one fails to delete
-- **THEN** system continues removing others and reports which directories failed at the end
+#### Scenario: Partial failures do not stop cleanup
+- **WHEN** system is removing multiple cleanup candidates and one fails to delete
+- **THEN** system continues removing other requested candidates
+- **AND** reports failed paths with error reasons at the end
+- **AND** exits non-zero
 
-### Requirement: User receives clear cache cleanup reporting
-Users SHALL receive clear feedback about what was removed, what failed, and cache health statistics after cleanup.
+### Requirement: Cleanup safety guards prevent accidental data loss
+The system SHALL implement safety mechanisms that prevent broad cleanup from
+removing complete verified model caches.
 
-#### Scenario: Success report shows freed space
-- **WHEN** cache cleanup completes successfully
-- **THEN** system reports: number of directories removed, total disk space freed, paths of removed directories
+#### Scenario: Complete caches excluded from broad cleanup
+- **WHEN** user runs `quaid model clean --all --force`
+- **THEN** system removes stale/incomplete/corrupted artifacts only
+- **AND** keeps complete verified caches
 
-#### Scenario: Partial failure report identifies problems
-- **WHEN** some directories fail to remove
-- **THEN** system reports successful removals and lists failed directories with error reasons (permission denied, in use, etc.)
+#### Scenario: Active downloads are skipped
+- **WHEN** cleanup sees a temporary download artifact with a recent `.downloading` heartbeat or recent modified time
+- **THEN** system marks it as active and skips removal
 
-### Requirement: Safety guards prevent accidental data loss
-The system SHALL implement safety mechanisms to prevent users from accidentally removing non-stale caches.
-
-#### Scenario: Non-stale caches excluded by default
-- **WHEN** user runs `quaid cache clean --all` without `--force`
-- **THEN** system only removes stale temp directories and incomplete caches, not recent/complete caches
+#### Scenario: Expired temporary artifacts are eligible
+- **WHEN** cleanup sees a temporary download artifact older than the configured stale TTL and without a recent heartbeat
+- **THEN** system marks it as stale and eligible for removal
 
 #### Scenario: User shown what is not being removed
-- **WHEN** user runs `quaid cache clean --list`
-- **THEN** output clearly distinguishes between "stale (will be removed)" and "active/complete (will be kept)"
+- **WHEN** user runs `quaid model clean --list`
+- **THEN** output clearly distinguishes between "would remove" and "kept"
+
+### Requirement: Cache cleanup respects configured cache root
+The system SHALL only inspect and remove paths inside the resolved model cache
+root.
+
+#### Scenario: Custom model cache root
+- **WHEN** `QUAID_MODEL_CACHE_DIR` is set and user runs `quaid model clean --list`
+- **THEN** system inspects only that directory tree
+- **AND** does not inspect `~/.quaid/models`
+
+#### Scenario: Path traversal is rejected
+- **WHEN** a manifest or cache entry contains an absolute path or parent-directory traversal
+- **THEN** system reports the entry as invalid
+- **AND** cleanup does not follow that path outside the cache root

--- a/openspec/changes/improve-model-caching/specs/cache-validation/spec.md
+++ b/openspec/changes/improve-model-caching/specs/cache-validation/spec.md
@@ -1,61 +1,89 @@
 ## ADDED Requirements
 
-### Requirement: System validates existing model caches
-The system SHALL automatically validate cached models and detect incomplete or corrupted caches.
+### Requirement: System validates model caches before use
+The system SHALL validate cached models and reject incomplete or corrupted
+caches instead of silently using them.
 
 #### Scenario: Manifest found and valid
-- **WHEN** a cached model is accessed
-- **THEN** system checks manifest.json exists and verifies all referenced files are present with correct SHA-256 hashes
+- **WHEN** a cached extraction model is accessed and `manifest.json` exists
+- **THEN** system validates the manifest structure, path safety, expected alias/repo/revision, and file presence
+- **AND** system accepts the cache only if validation succeeds
 
-#### Scenario: Manifest missing but files complete
-- **WHEN** a cached model exists without manifest.json but all expected files are present with correct hashes
-- **THEN** system generates manifest.json automatically without requiring re-download
+#### Scenario: Fast validation detects changed file metadata
+- **WHEN** a manifest records file size or modified time and an on-disk file no longer matches those values
+- **THEN** system treats the cache as suspect
+- **AND** performs full hash verification before accepting the cache
+
+#### Scenario: Hash verification fails
+- **WHEN** full verification finds a SHA-256 or source-pin mismatch
+- **THEN** system reports cache corruption and recommends cleanup plus re-pull
+- **AND** system does not use the corrupted cache
+
+#### Scenario: Manifest references unsafe path
+- **WHEN** `manifest.json` references an absolute path or parent-directory traversal
+- **THEN** system rejects the manifest
+- **AND** system does not open the referenced path
+
+### Requirement: System safely generates or upgrades manifests
+The system SHALL generate or upgrade manifest files only when it can prove the
+cache's expected file set and digests from trusted model metadata.
+
+#### Scenario: Legacy manifest remains valid
+- **WHEN** a cached model has a versionless legacy manifest with valid existing fields and hashes
+- **THEN** system accepts the cache
+- **AND** MAY upgrade the manifest to version 1 after full verification
+
+#### Scenario: Manifest missing but curated extraction files complete
+- **WHEN** a curated extraction model cache exists without `manifest.json` and all source-pinned files are present with correct digests
+- **THEN** system generates `manifest.json` automatically without requiring re-download
+
+#### Scenario: Manifest missing but known embedding files complete
+- **WHEN** a known embedding model cache exists without `manifest.json` and all pinned embedding files are present with correct digests
+- **THEN** system generates or records equivalent manifest metadata without requiring re-download
 
 #### Scenario: Manifest missing and files incomplete
-- **WHEN** a cached model exists without manifest.json and is missing some expected files
-- **THEN** system marks cache as incomplete and recommends re-download via `quaid model pull`
+- **WHEN** a cache exists without `manifest.json` and one or more expected files are missing
+- **THEN** system marks cache as incomplete and recommends `quaid model clean <alias> --force` followed by `quaid model pull <alias>` when pull is supported
 
-#### Scenario: Manifest invalid - hash mismatch
-- **WHEN** manifest.json exists but file hashes don't match actual files
-- **THEN** system reports validation failure and recommends cache cleanup + re-download
+#### Scenario: Manifest missing for untrusted custom cache
+- **WHEN** a custom or unpinned model cache exists without `manifest.json` and trusted expected digests are unavailable
+- **THEN** system fails closed
+- **AND** system does not generate a manifest by hashing the files that happen to be present
 
-#### Scenario: Manifest invalid - missing files
-- **WHEN** manifest.json exists but references files that don't exist on disk
-- **THEN** system reports cache corruption and recommends removal via `quaid cache clean`
+### Requirement: Manifest format is stable and backward compatible
+Manifest files SHALL use a versioned format while preserving compatibility with
+existing versionless manifests.
 
-### Requirement: System reports cache health
-Users SHALL be able to query cache status and validation results for debugging and monitoring.
+#### Scenario: New manifest includes version
+- **WHEN** system creates a new manifest
+- **THEN** it includes `manifest_version: 1`
 
-#### Scenario: Check cache status
-- **WHEN** user runs `quaid cache status`
-- **THEN** system lists all cached models with status (complete/incomplete/corrupted), manifest validity, and last modified time
+#### Scenario: New manifest includes required metadata
+- **WHEN** system creates a new manifest
+- **THEN** it contains `requested_alias`, `repo_id`, `revision`, `created_at_unix`, and file entries with `path`, `sha256`, `size_bytes`, `modified_unix`, and `verified_from_source`
+
+#### Scenario: Versionless manifest is treated as legacy
+- **WHEN** system reads a manifest without `manifest_version`
+- **THEN** it treats the manifest as legacy version 0
+- **AND** validates all legacy fields before accepting it
+
+### Requirement: User can query model cache health
+Users SHALL be able to query cache status and validation results for debugging
+and monitoring.
+
+#### Scenario: Check all cache status
+- **WHEN** user runs `quaid model status`
+- **THEN** system lists recognized cached models and temporary artifacts with status, file count, size, manifest state, and last modified time
 
 #### Scenario: Check specific model cache
-- **WHEN** user runs `quaid cache status phi-3.5-mini`
-- **THEN** system displays cache directory path, manifest status, file count, total size, and validation results
+- **WHEN** user runs `quaid model status phi-3.5-mini`
+- **THEN** system displays cache directory path, manifest status, file count, total size, and validation result for matching cache entries
 
 #### Scenario: Verbose cache inspection
-- **WHEN** user runs `quaid cache status --verbose`
-- **THEN** system displays individual file paths, sizes, and SHA-256 hashes from manifest
+- **WHEN** user runs `quaid model status --verbose`
+- **THEN** system displays individual file paths, sizes, and manifest hashes where available
 
-### Requirement: Cache validation is non-blocking
-Cache validation failures SHALL not prevent model usage if alternative paths exist, but SHALL be logged and reported.
-
-#### Scenario: Validation failure doesn't block load
-- **WHEN** cache validation fails for a model
-- **THEN** system logs the failure and either uses a fallback cache or errors with clear recovery instructions
-
-#### Scenario: Lazy manifest generation succeeds silently
-- **WHEN** manifest is auto-generated for a previously-cached model
-- **THEN** system logs at trace level but doesn't surface as a warning or error
-
-### Requirement: Manifest format is stable and versioned
-Manifest files SHALL use a consistent format that survives model lifecycle upgrades.
-
-#### Scenario: Manifest includes version
-- **WHEN** manifest.json is created
-- **THEN** it includes a `manifest_version` field for future format changes
-
-#### Scenario: Manifest includes all required metadata
-- **WHEN** manifest.json is read
-- **THEN** it contains: requested_alias, repo_id, revision, file list with paths and SHA-256 hashes, timestamp
+#### Scenario: Explicit full verification
+- **WHEN** user runs `quaid model status --verify`
+- **THEN** system performs full hash verification before reporting verified/corrupted status
+- **AND** output indicates that full verification was performed

--- a/openspec/changes/improve-model-caching/specs/cache-validation/spec.md
+++ b/openspec/changes/improve-model-caching/specs/cache-validation/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: System validates existing model caches
+The system SHALL automatically validate cached models and detect incomplete or corrupted caches.
+
+#### Scenario: Manifest found and valid
+- **WHEN** a cached model is accessed
+- **THEN** system checks manifest.json exists and verifies all referenced files are present with correct SHA-256 hashes
+
+#### Scenario: Manifest missing but files complete
+- **WHEN** a cached model exists without manifest.json but all expected files are present with correct hashes
+- **THEN** system generates manifest.json automatically without requiring re-download
+
+#### Scenario: Manifest missing and files incomplete
+- **WHEN** a cached model exists without manifest.json and is missing some expected files
+- **THEN** system marks cache as incomplete and recommends re-download via `quaid model pull`
+
+#### Scenario: Manifest invalid - hash mismatch
+- **WHEN** manifest.json exists but file hashes don't match actual files
+- **THEN** system reports validation failure and recommends cache cleanup + re-download
+
+#### Scenario: Manifest invalid - missing files
+- **WHEN** manifest.json exists but references files that don't exist on disk
+- **THEN** system reports cache corruption and recommends removal via `quaid cache clean`
+
+### Requirement: System reports cache health
+Users SHALL be able to query cache status and validation results for debugging and monitoring.
+
+#### Scenario: Check cache status
+- **WHEN** user runs `quaid cache status`
+- **THEN** system lists all cached models with status (complete/incomplete/corrupted), manifest validity, and last modified time
+
+#### Scenario: Check specific model cache
+- **WHEN** user runs `quaid cache status phi-3.5-mini`
+- **THEN** system displays cache directory path, manifest status, file count, total size, and validation results
+
+#### Scenario: Verbose cache inspection
+- **WHEN** user runs `quaid cache status --verbose`
+- **THEN** system displays individual file paths, sizes, and SHA-256 hashes from manifest
+
+### Requirement: Cache validation is non-blocking
+Cache validation failures SHALL not prevent model usage if alternative paths exist, but SHALL be logged and reported.
+
+#### Scenario: Validation failure doesn't block load
+- **WHEN** cache validation fails for a model
+- **THEN** system logs the failure and either uses a fallback cache or errors with clear recovery instructions
+
+#### Scenario: Lazy manifest generation succeeds silently
+- **WHEN** manifest is auto-generated for a previously-cached model
+- **THEN** system logs at trace level but doesn't surface as a warning or error
+
+### Requirement: Manifest format is stable and versioned
+Manifest files SHALL use a consistent format that survives model lifecycle upgrades.
+
+#### Scenario: Manifest includes version
+- **WHEN** manifest.json is created
+- **THEN** it includes a `manifest_version` field for future format changes
+
+#### Scenario: Manifest includes all required metadata
+- **WHEN** manifest.json is read
+- **THEN** it contains: requested_alias, repo_id, revision, file list with paths and SHA-256 hashes, timestamp

--- a/openspec/changes/improve-model-caching/specs/download-observability/spec.md
+++ b/openspec/changes/improve-model-caching/specs/download-observability/spec.md
@@ -1,76 +1,73 @@
 ## ADDED Requirements
 
 ### Requirement: Download progress is visible and granular
-Users SHALL see detailed progress information for model downloads including per-file status and overall progress.
+Users SHALL see useful progress information for model downloads, including
+per-file status and overall completion context when available.
 
-#### Scenario: Multi-file download shows progress
-- **WHEN** downloading a multi-file model (e.g., 10 files)
-- **THEN** system reports: "Downloading phi-3.5-mini [3/10] model-00001-of-00002.safetensors (5.0 GB / 6.1 GB)"
+#### Scenario: Multi-file download shows file progress
+- **WHEN** downloading a multi-file model
+- **THEN** system reports the alias, source repo, revision, file count, current file, and file index
 
-#### Scenario: Progress includes download speed
-- **WHEN** a file is being downloaded
-- **THEN** progress line includes estimated time remaining: "5.0 GB / 6.1 GB (2.1 MB/s, ~15m remaining)"
+#### Scenario: Progress includes byte counts and speed
+- **WHEN** the server provides a content length while a file is being downloaded
+- **THEN** progress output includes downloaded bytes, total bytes, current speed, and estimated time remaining
+
+#### Scenario: Unknown-size progress still advances
+- **WHEN** the server does not provide a content length
+- **THEN** progress output still reports downloaded bytes for the current file
 
 #### Scenario: Completion shows verification
 - **WHEN** download completes for a file
-- **THEN** status updates to show hash verification: "✓ model-00001-of-00002.safetensors (SHA-256: c5214cd...)"
+- **THEN** status reports that the file passed integrity verification
 
 #### Scenario: Summary on completion
 - **WHEN** entire model download succeeds
-- **THEN** system prints: "Downloaded phi-3.5-mini (10 files, 6.1 GB total) in 18m 42s"
+- **THEN** system prints a summary with alias, file count, total bytes when known, elapsed time, and cache path
 
-### Requirement: Download failures are logged clearly
-Users SHALL receive informative error logs that help diagnose download problems without requiring debug mode.
+### Requirement: Download failures are explicit and actionable
+Users SHALL receive informative errors that help diagnose download problems
+without enabling a separate logging framework.
 
 #### Scenario: Network error includes URL and details
 - **WHEN** GET request fails
-- **THEN** log includes: "GET https://huggingface.co/.../model-00001.safetensors failed: Connection timeout after 300s"
+- **THEN** error output includes the URL, model alias, file name when known, and underlying network error
 
-#### Scenario: Partial download doesn't hide incomplete state
-- **WHEN** download stops mid-file
-- **THEN** log includes: "Interrupted after 4.2 GB of 5.0 GB for model-00001.safetensors. Retrying will start fresh."
+#### Scenario: Partial download includes byte count
+- **WHEN** download stops mid-file after some bytes were received
+- **THEN** error output includes the received byte count and states that retry will start from a clean temporary file/directory
 
-#### Scenario: Cache validation failure is logged
-- **WHEN** manifest validation fails
-- **THEN** log includes: "Cache validation failed for phi-3.5-mini: file tokenizer.json missing (expected in manifest)"
+#### Scenario: Cache validation failure is reported
+- **WHEN** manifest or file validation fails
+- **THEN** error output includes the cache path, failing file or manifest field, and recommended recovery command
 
 #### Scenario: Cleanup failure is reported
-- **WHEN** temp directory cleanup fails
-- **THEN** log includes: "Warning: Failed to remove stale cache at {path}: Permission denied"
+- **WHEN** temporary artifact cleanup fails
+- **THEN** output includes the path and OS error
+- **AND** system does not claim cleanup success for that path
 
-### Requirement: Trace-level logging captures implementation details
-Developers SHALL be able to enable trace logging to understand download internals for debugging.
+### Requirement: Download observability uses existing interfaces
+Progress and errors SHALL use existing dependency-free channels.
 
-#### Scenario: Trace logging for hash computation
-- **WHEN** RUST_LOG=trace is set
-- **THEN** logs include: "Computing SHA-256 for {path}... (chunk 1/128, 65KB)"
+#### Scenario: Progress uses ProgressReporter
+- **WHEN** downloading a model in any CLI path
+- **THEN** implementation reports progress through `ProgressReporter::planned()`, `cache_hit()`, `file_started()`, `file_progress()`, and `file_finished()`
 
-#### Scenario: Trace logging for manifest operations
-- **WHEN** RUST_LOG=trace is set
-- **THEN** logs include: "Writing manifest.json with 10 files, timestamp {ts}"
-
-#### Scenario: Trace logging for cache scavenging
-- **WHEN** RUST_LOG=trace is set
-- **THEN** logs include: "Scavenging stale download dirs: found {N} candidates, {M} older than 6h, removing {K}"
-
-### Requirement: Download observability integrates with existing progress reporter
-Progress and errors SHALL use the existing `ProgressReporter` interface without requiring new dependencies.
-
-#### Scenario: Progress updates don't require new interfaces
-- **WHEN** downloading a model in any mode
-- **THEN** implementation uses existing `ProgressReporter::file_started()`, `file_progress()`, `file_finished()` methods
-
-#### Scenario: Errors flow through standard channels
+#### Scenario: Errors flow through standard results
 - **WHEN** a download error occurs
-- **THEN** error is returned as `ModelLifecycleError` and logged via tracing (existing infrastructure)
+- **THEN** error is returned through the existing `Result`/error type path and is rendered by the CLI
+
+#### Scenario: No logging dependency is required
+- **WHEN** this change is implemented
+- **THEN** it does not require adding `tracing`, `log`, `env_logger`, or a `RUST_LOG` configuration path
 
 ### Requirement: Cache status command provides observability
-Users SHALL be able to inspect cache health and debug issues without technical knowledge.
+Users SHALL be able to inspect cache health and debug model cache issues without
+knowing the on-disk layout.
 
 #### Scenario: Cache status shows validation results
-- **WHEN** user runs `quaid cache status`
-- **THEN** output includes for each cache: "Status | Files | Size | Manifest | Last Modified"
+- **WHEN** user runs `quaid model status`
+- **THEN** output includes status, files, size, manifest state, and last modified time for each recognized cache entry
 
 #### Scenario: Cache status identifies problems
 - **WHEN** a cache has issues
-- **THEN** status output highlights: ❌ incomplete, ⚠️  no manifest, ⚠️  hash mismatch
+- **THEN** status output labels it as incomplete, corrupted, stale temporary, active temporary, or complete

--- a/openspec/changes/improve-model-caching/specs/download-observability/spec.md
+++ b/openspec/changes/improve-model-caching/specs/download-observability/spec.md
@@ -1,0 +1,76 @@
+## ADDED Requirements
+
+### Requirement: Download progress is visible and granular
+Users SHALL see detailed progress information for model downloads including per-file status and overall progress.
+
+#### Scenario: Multi-file download shows progress
+- **WHEN** downloading a multi-file model (e.g., 10 files)
+- **THEN** system reports: "Downloading phi-3.5-mini [3/10] model-00001-of-00002.safetensors (5.0 GB / 6.1 GB)"
+
+#### Scenario: Progress includes download speed
+- **WHEN** a file is being downloaded
+- **THEN** progress line includes estimated time remaining: "5.0 GB / 6.1 GB (2.1 MB/s, ~15m remaining)"
+
+#### Scenario: Completion shows verification
+- **WHEN** download completes for a file
+- **THEN** status updates to show hash verification: "✓ model-00001-of-00002.safetensors (SHA-256: c5214cd...)"
+
+#### Scenario: Summary on completion
+- **WHEN** entire model download succeeds
+- **THEN** system prints: "Downloaded phi-3.5-mini (10 files, 6.1 GB total) in 18m 42s"
+
+### Requirement: Download failures are logged clearly
+Users SHALL receive informative error logs that help diagnose download problems without requiring debug mode.
+
+#### Scenario: Network error includes URL and details
+- **WHEN** GET request fails
+- **THEN** log includes: "GET https://huggingface.co/.../model-00001.safetensors failed: Connection timeout after 300s"
+
+#### Scenario: Partial download doesn't hide incomplete state
+- **WHEN** download stops mid-file
+- **THEN** log includes: "Interrupted after 4.2 GB of 5.0 GB for model-00001.safetensors. Retrying will start fresh."
+
+#### Scenario: Cache validation failure is logged
+- **WHEN** manifest validation fails
+- **THEN** log includes: "Cache validation failed for phi-3.5-mini: file tokenizer.json missing (expected in manifest)"
+
+#### Scenario: Cleanup failure is reported
+- **WHEN** temp directory cleanup fails
+- **THEN** log includes: "Warning: Failed to remove stale cache at {path}: Permission denied"
+
+### Requirement: Trace-level logging captures implementation details
+Developers SHALL be able to enable trace logging to understand download internals for debugging.
+
+#### Scenario: Trace logging for hash computation
+- **WHEN** RUST_LOG=trace is set
+- **THEN** logs include: "Computing SHA-256 for {path}... (chunk 1/128, 65KB)"
+
+#### Scenario: Trace logging for manifest operations
+- **WHEN** RUST_LOG=trace is set
+- **THEN** logs include: "Writing manifest.json with 10 files, timestamp {ts}"
+
+#### Scenario: Trace logging for cache scavenging
+- **WHEN** RUST_LOG=trace is set
+- **THEN** logs include: "Scavenging stale download dirs: found {N} candidates, {M} older than 6h, removing {K}"
+
+### Requirement: Download observability integrates with existing progress reporter
+Progress and errors SHALL use the existing `ProgressReporter` interface without requiring new dependencies.
+
+#### Scenario: Progress updates don't require new interfaces
+- **WHEN** downloading a model in any mode
+- **THEN** implementation uses existing `ProgressReporter::file_started()`, `file_progress()`, `file_finished()` methods
+
+#### Scenario: Errors flow through standard channels
+- **WHEN** a download error occurs
+- **THEN** error is returned as `ModelLifecycleError` and logged via tracing (existing infrastructure)
+
+### Requirement: Cache status command provides observability
+Users SHALL be able to inspect cache health and debug issues without technical knowledge.
+
+#### Scenario: Cache status shows validation results
+- **WHEN** user runs `quaid cache status`
+- **THEN** output includes for each cache: "Status | Files | Size | Manifest | Last Modified"
+
+#### Scenario: Cache status identifies problems
+- **WHEN** a cache has issues
+- **THEN** status output highlights: ❌ incomplete, ⚠️  no manifest, ⚠️  hash mismatch

--- a/openspec/changes/improve-model-caching/specs/download-resilience/spec.md
+++ b/openspec/changes/improve-model-caching/specs/download-resilience/spec.md
@@ -1,69 +1,86 @@
 ## ADDED Requirements
 
-### Requirement: Temporary directories are cleaned on download failure
-The system SHALL guarantee that temporary download directories are removed when a download operation fails, preventing orphaned incomplete caches.
+### Requirement: Temporary download artifacts are cleaned on failure
+The system SHALL remove temporary download directories/files created by Quaid
+when a download operation fails, unless the operating system refuses removal, in
+which case the failure SHALL be reported and the artifact SHALL remain eligible
+for later cleanup.
 
-#### Scenario: Network error during multi-file download
-- **WHEN** a download fails due to network error while downloading file 3 of 10
-- **THEN** system removes the temporary directory completely, regardless of error type or location
+#### Scenario: Network error during multi-file extraction download
+- **WHEN** an extraction model download fails due to a network error while downloading file 3 of 10
+- **THEN** system removes the temporary extraction download directory
+- **AND** reports any cleanup failure
+
+#### Scenario: Network error during embedding download
+- **WHEN** an embedding model file download fails after its temporary file is created
+- **THEN** system removes the temporary `{file}.download-*` file
+- **AND** keeps any previously completed valid files
 
 #### Scenario: Hash verification fails
 - **WHEN** file hash verification fails during download
-- **THEN** system removes the incomplete file and the temporary directory, leaving no residue
+- **THEN** system removes the temporary file or directory containing the failed file
+- **AND** does not promote the failed artifact to the final cache path
 
 #### Scenario: Disk full during download
 - **WHEN** disk runs out of space during file write
-- **THEN** system removes the temporary directory and reports error clearly
+- **THEN** system removes the temporary artifact it created
+- **AND** reports the disk/write error clearly
 
 #### Scenario: Rename failure
-- **WHEN** moving temporary directory to final cache location fails (permissions, already exists, etc.)
-- **THEN** system removes the temporary directory if rename fails, but preserves cache if cache already completed
+- **WHEN** moving a temporary artifact to the final cache location fails
+- **THEN** system removes the temporary artifact if the final cache did not validate
+- **AND** if another process already produced a valid final cache, system discards the local temporary artifact and treats the result as a cache hit
 
-#### Scenario: Timeout on final file
-- **WHEN** download times out on the last file of a multi-file model
-- **THEN** system removes the temporary directory including partially-downloaded final file
+#### Scenario: Early return after temp creation
+- **WHEN** code returns an error through `?` after creating a temporary download path but before the normal install block completes
+- **THEN** the cleanup guard removes the temporary path before the error reaches the caller
 
 ### Requirement: Download state is recoverable
-Users SHALL be able to safely retry failed downloads without manual cleanup or corruption.
+Users SHALL be able to safely retry failed downloads without manual filesystem
+cleanup or cache corruption.
 
 #### Scenario: Retry after network failure
 - **WHEN** user runs `quaid model pull phi-3.5-mini` after a previous download failed
-- **THEN** system starts fresh download from beginning, with old temp directory already cleaned
+- **THEN** system starts from a clean temporary path
+- **AND** stale partial artifacts from the failed attempt do not affect the retry
 
 #### Scenario: Retry detects existing complete cache
-- **WHEN** user runs `quaid model pull` and a complete valid cache already exists
-- **THEN** system skips download and returns cache immediately (cache hit)
+- **WHEN** user runs `quaid model pull <alias>` and a complete valid cache already exists
+- **THEN** system skips download and returns the verified cache immediately
 
-#### Scenario: Concurrent downloads don't corrupt cache
+#### Scenario: Concurrent downloads do not corrupt cache
 - **WHEN** two Quaid instances attempt to download the same model simultaneously
-- **THEN** at most one succeeds; the other waits or fails gracefully without corrupting shared cache
+- **THEN** at most one final cache is accepted
+- **AND** the losing temporary artifact is removed or reported as a cleanup failure
 
-### Requirement: No orphaned temporary directories accumulate
-The system SHALL prevent temporary download directories from accumulating indefinitely on disk.
+### Requirement: Stale temporary artifacts do not accumulate indefinitely
+The system SHALL identify and remove stale temporary download artifacts while
+avoiding active downloads.
 
 #### Scenario: Automatic stale cleanup before download
 - **WHEN** a model download is initiated
-- **THEN** system scavenges and removes temporary directories older than 6 hours before starting download
+- **THEN** system scavenges temporary artifacts older than the stale TTL before starting the new download
 
-#### Scenario: Cleanup handles already-in-use temp directories
-- **WHEN** attempting to remove a stale temp directory that another process is still writing to
-- **THEN** system skips that directory (doesn't delete in-progress downloads) and continues cleanup
+#### Scenario: Active temp artifact is skipped
+- **WHEN** cleanup sees a temporary artifact with a recent `.downloading` heartbeat or recent modified time
+- **THEN** system skips that artifact and continues cleanup
 
-#### Scenario: Manual cleanup via cache clean command
-- **WHEN** user runs `quaid cache clean --all`
-- **THEN** all temporary directories are identified and can be removed (see cache-cleanup spec)
+#### Scenario: Manual cleanup removes stale artifacts
+- **WHEN** user runs `quaid model clean --all --force`
+- **THEN** stale temporary artifacts are removed according to the cache-cleanup spec
 
-### Requirement: Download failures are explicit and actionable
-Users SHALL receive clear error messages that explain what went wrong and how to recover.
+### Requirement: Download failures include recovery instructions
+Users SHALL receive clear error messages that explain what went wrong and how to
+recover.
 
 #### Scenario: Network timeout
 - **WHEN** download times out
-- **THEN** error message states: "Download timeout after 300 seconds for {file}. Check your network or retry with `quaid model pull {alias}`"
+- **THEN** error message states the alias, file, timeout, and recommends retrying `quaid model pull <alias>`
 
 #### Scenario: Hash mismatch
-- **WHEN** file hash doesn't match expected value
-- **THEN** error message states: "Integrity check failed for {file}: expected SHA-256 {expected}, got {actual}. File may be corrupted. Run `quaid cache clean {alias}` and retry."
+- **WHEN** file hash does not match expected value
+- **THEN** error message states expected and actual digest values and recommends `quaid model clean <alias> --force` before retry
 
 #### Scenario: Permission denied
-- **WHEN** system can't write to cache directory
-- **THEN** error message states: "Permission denied writing to cache at {path}. Check directory permissions or set QUAID_MODEL_CACHE_DIR environment variable."
+- **WHEN** system cannot write to cache directory
+- **THEN** error message states the path and recommends checking permissions or setting `QUAID_MODEL_CACHE_DIR`

--- a/openspec/changes/improve-model-caching/specs/download-resilience/spec.md
+++ b/openspec/changes/improve-model-caching/specs/download-resilience/spec.md
@@ -1,0 +1,69 @@
+## ADDED Requirements
+
+### Requirement: Temporary directories are cleaned on download failure
+The system SHALL guarantee that temporary download directories are removed when a download operation fails, preventing orphaned incomplete caches.
+
+#### Scenario: Network error during multi-file download
+- **WHEN** a download fails due to network error while downloading file 3 of 10
+- **THEN** system removes the temporary directory completely, regardless of error type or location
+
+#### Scenario: Hash verification fails
+- **WHEN** file hash verification fails during download
+- **THEN** system removes the incomplete file and the temporary directory, leaving no residue
+
+#### Scenario: Disk full during download
+- **WHEN** disk runs out of space during file write
+- **THEN** system removes the temporary directory and reports error clearly
+
+#### Scenario: Rename failure
+- **WHEN** moving temporary directory to final cache location fails (permissions, already exists, etc.)
+- **THEN** system removes the temporary directory if rename fails, but preserves cache if cache already completed
+
+#### Scenario: Timeout on final file
+- **WHEN** download times out on the last file of a multi-file model
+- **THEN** system removes the temporary directory including partially-downloaded final file
+
+### Requirement: Download state is recoverable
+Users SHALL be able to safely retry failed downloads without manual cleanup or corruption.
+
+#### Scenario: Retry after network failure
+- **WHEN** user runs `quaid model pull phi-3.5-mini` after a previous download failed
+- **THEN** system starts fresh download from beginning, with old temp directory already cleaned
+
+#### Scenario: Retry detects existing complete cache
+- **WHEN** user runs `quaid model pull` and a complete valid cache already exists
+- **THEN** system skips download and returns cache immediately (cache hit)
+
+#### Scenario: Concurrent downloads don't corrupt cache
+- **WHEN** two Quaid instances attempt to download the same model simultaneously
+- **THEN** at most one succeeds; the other waits or fails gracefully without corrupting shared cache
+
+### Requirement: No orphaned temporary directories accumulate
+The system SHALL prevent temporary download directories from accumulating indefinitely on disk.
+
+#### Scenario: Automatic stale cleanup before download
+- **WHEN** a model download is initiated
+- **THEN** system scavenges and removes temporary directories older than 6 hours before starting download
+
+#### Scenario: Cleanup handles already-in-use temp directories
+- **WHEN** attempting to remove a stale temp directory that another process is still writing to
+- **THEN** system skips that directory (doesn't delete in-progress downloads) and continues cleanup
+
+#### Scenario: Manual cleanup via cache clean command
+- **WHEN** user runs `quaid cache clean --all`
+- **THEN** all temporary directories are identified and can be removed (see cache-cleanup spec)
+
+### Requirement: Download failures are explicit and actionable
+Users SHALL receive clear error messages that explain what went wrong and how to recover.
+
+#### Scenario: Network timeout
+- **WHEN** download times out
+- **THEN** error message states: "Download timeout after 300 seconds for {file}. Check your network or retry with `quaid model pull {alias}`"
+
+#### Scenario: Hash mismatch
+- **WHEN** file hash doesn't match expected value
+- **THEN** error message states: "Integrity check failed for {file}: expected SHA-256 {expected}, got {actual}. File may be corrupted. Run `quaid cache clean {alias}` and retry."
+
+#### Scenario: Permission denied
+- **WHEN** system can't write to cache directory
+- **THEN** error message states: "Permission denied writing to cache at {path}. Check directory permissions or set QUAID_MODEL_CACHE_DIR environment variable."

--- a/openspec/changes/improve-model-caching/specs/model-lifecycle/spec.md
+++ b/openspec/changes/improve-model-caching/specs/model-lifecycle/spec.md
@@ -1,0 +1,69 @@
+## MODIFIED Requirements
+
+### Requirement: Download errors don't leave orphaned temporary directories
+The system SHALL guarantee cleanup of temporary directories on all download failure paths.
+
+**Previous behavior**: Temp directories could persist if downloads failed, especially on rename failures or concurrent operations.
+
+**Updated behavior**: Every download operation has guaranteed cleanup via try-finally semantics. Temp directories are removed regardless of failure type.
+
+#### Scenario: Guaranteed cleanup on any error
+- **WHEN** a download fails for any reason (network, permissions, timeout, hash mismatch, disk full, etc.)
+- **THEN** the temporary directory is removed and no residue remains
+
+#### Scenario: Cleanup succeeds even if files are locked
+- **WHEN** cleanup attempts to remove temporary files that are still in use
+- **THEN** cleanup defers removal via OS-specific deferred delete (Windows) or marks for cleanup (Unix), rather than failing
+
+#### Scenario: Rename failure doesn't leave ambiguous state
+- **WHEN** temporary directory rename to final cache location fails
+- **THEN** system verifies whether cache succeeded (if cache_dir exists and validates, keep it; if not, remove temp_dir)
+
+### Requirement: Model caches can be validated without re-download
+The system SHALL automatically generate manifest files for existing complete caches.
+
+**Previous behavior**: If manifest.json was missing, model was assumed incomplete and required re-download.
+
+**Updated behavior**: System validates files and auto-generates manifest if all files are present with correct hashes.
+
+#### Scenario: Lazy manifest generation
+- **WHEN** model cache exists but manifest.json is missing
+- **THEN** system validates all files exist with correct SHA-256/git-blob hashes and creates manifest.json
+
+#### Scenario: Validation failure prevents silent cache acceptance
+- **WHEN** cache exists but file hashes don't match expected values
+- **THEN** manifest generation fails and cache is marked as corrupted; re-download is required
+
+### Requirement: Stale temporary directories are actively cleaned
+The system SHALL remove old incomplete temporary download directories to prevent disk accumulation.
+
+**Previous behavior**: Stale directories were only cleaned during the next download attempt via scavenge_stale_download_dirs().
+
+**Updated behavior**: Users can manually trigger cleanup via `quaid cache clean`, and pre-download scavenging remains for automatic cleanup.
+
+#### Scenario: Manual cache cleanup
+- **WHEN** user runs `quaid cache clean --all`
+- **THEN** system removes all temporary download directories older than 6 hours
+
+#### Scenario: Pre-download scavenging still occurs
+- **WHEN** model download is initiated
+- **THEN** system scavenges and removes stale temp directories before starting download
+
+### Requirement: Download state transitions are explicitly observable
+The system SHALL provide clear logging of download lifecycle events at appropriate log levels.
+
+**Previous behavior**: Download progress was reported via ProgressReporter but errors were not consistently logged.
+
+**Updated behavior**: All significant events (start, file completion, error, cleanup, success) are logged with context.
+
+#### Scenario: Download start is logged
+- **WHEN** model download begins
+- **THEN** system logs: "Starting model download: phi-3.5-mini from microsoft/Phi-3.5-mini-instruct (revision: main)"
+
+#### Scenario: Download error includes context
+- **WHEN** download fails
+- **THEN** system logs: "Download failed after 45 minutes: {file} - {error}. Cleaning up temporary cache."
+
+#### Scenario: Successful completion is logged
+- **WHEN** download completes and cache is moved to final location
+- **THEN** system logs: "Model successfully cached: phi-3.5-mini at {cache_path} (10 files, 6.1 GB)"

--- a/openspec/changes/improve-model-caching/specs/model-lifecycle/spec.md
+++ b/openspec/changes/improve-model-caching/specs/model-lifecycle/spec.md
@@ -1,69 +1,99 @@
 ## MODIFIED Requirements
 
-### Requirement: Download errors don't leave orphaned temporary directories
-The system SHALL guarantee cleanup of temporary directories on all download failure paths.
+### Requirement: Download errors do not leave orphaned temporary artifacts
+The system SHALL clean up temporary download artifacts created by Quaid on all
+download failure paths controlled by Quaid.
 
-**Previous behavior**: Temp directories could persist if downloads failed, especially on rename failures or concurrent operations.
+**Previous behavior**: Temporary directories/files could persist if downloads
+failed on some paths, especially around early returns, hash failures, or
+per-file embedding downloads.
 
-**Updated behavior**: Every download operation has guaranteed cleanup via try-finally semantics. Temp directories are removed regardless of failure type.
+**Updated behavior**: Extraction and embedding downloads use scope-bound cleanup
+guards so temporary paths are removed on ordinary Rust error propagation. If the
+operating system refuses cleanup, the failure is reported and the path remains
+eligible for `quaid model clean`.
 
-#### Scenario: Guaranteed cleanup on any error
-- **WHEN** a download fails for any reason (network, permissions, timeout, hash mismatch, disk full, etc.)
-- **THEN** the temporary directory is removed and no residue remains
+#### Scenario: Guard cleanup on any controlled error
+- **WHEN** a download fails for any reason after a temporary path is created
+- **THEN** the cleanup guard attempts to remove the temporary path before the error reaches the caller
 
-#### Scenario: Cleanup succeeds even if files are locked
-- **WHEN** cleanup attempts to remove temporary files that are still in use
-- **THEN** cleanup defers removal via OS-specific deferred delete (Windows) or marks for cleanup (Unix), rather than failing
+#### Scenario: Cleanup failure is explicit
+- **WHEN** cleanup cannot remove temporary files because the OS reports permission denied or in use
+- **THEN** system reports the cleanup failure and does not claim the path was removed
 
-#### Scenario: Rename failure doesn't leave ambiguous state
-- **WHEN** temporary directory rename to final cache location fails
-- **THEN** system verifies whether cache succeeded (if cache_dir exists and validates, keep it; if not, remove temp_dir)
+#### Scenario: Rename race leaves valid cache
+- **WHEN** temporary rename to the final cache location fails because another process produced a valid final cache first
+- **THEN** system verifies the final cache, removes the local temporary artifact, and returns a cache hit
 
-### Requirement: Model caches can be validated without re-download
-The system SHALL automatically generate manifest files for existing complete caches.
+### Requirement: Model caches can be validated without unnecessary re-download
+The system SHALL automatically accept, repair, or reject existing caches based on
+trusted validation evidence.
 
-**Previous behavior**: If manifest.json was missing, model was assumed incomplete and required re-download.
+**Previous behavior**: Missing extraction manifests caused otherwise complete
+caches to be treated as invalid and re-downloaded. Embedding caches had no
+manifest/status surface.
 
-**Updated behavior**: System validates files and auto-generates manifest if all files are present with correct hashes.
+**Updated behavior**: The system can generate or upgrade manifests when expected
+files and digests are known, accepts legacy manifests, and fails closed when a
+cache cannot be trusted.
 
-#### Scenario: Lazy manifest generation
-- **WHEN** model cache exists but manifest.json is missing
-- **THEN** system validates all files exist with correct SHA-256/git-blob hashes and creates manifest.json
+#### Scenario: Lazy manifest generation for source-verifiable cache
+- **WHEN** model cache exists but `manifest.json` is missing and all expected files match trusted source pins
+- **THEN** system creates a versioned manifest without re-downloading the model
+
+#### Scenario: Legacy manifest accepted
+- **WHEN** model cache has a versionless manifest and all referenced files verify
+- **THEN** system accepts the cache and may upgrade the manifest to version 1
+
+#### Scenario: Untrusted manifest generation is refused
+- **WHEN** a custom/unpinned cache lacks a manifest and trusted expected digests are unavailable
+- **THEN** system refuses to generate a manifest from arbitrary on-disk files and reports clear recovery instructions
 
 #### Scenario: Validation failure prevents silent cache acceptance
-- **WHEN** cache exists but file hashes don't match expected values
-- **THEN** manifest generation fails and cache is marked as corrupted; re-download is required
+- **WHEN** cache files do not match expected hashes
+- **THEN** system marks the cache corrupted and refuses to load it
 
-### Requirement: Stale temporary directories are actively cleaned
-The system SHALL remove old incomplete temporary download directories to prevent disk accumulation.
+### Requirement: Stale temporary artifacts are actively cleaned
+The system SHALL remove old incomplete temporary download artifacts to prevent
+disk accumulation.
 
-**Previous behavior**: Stale directories were only cleaned during the next download attempt via scavenge_stale_download_dirs().
+**Previous behavior**: Extraction stale directories were only scavenged before
+the next extraction model download, and embedding temp files had no shared
+cleanup path.
 
-**Updated behavior**: Users can manually trigger cleanup via `quaid cache clean`, and pre-download scavenging remains for automatic cleanup.
+**Updated behavior**: Pre-download scavenging remains, and users can manually
+trigger cache cleanup through `quaid model clean`.
 
-#### Scenario: Manual cache cleanup
-- **WHEN** user runs `quaid cache clean --all`
-- **THEN** system removes all temporary download directories older than 6 hours
+#### Scenario: Manual model cache cleanup
+- **WHEN** user runs `quaid model clean --all --force`
+- **THEN** system removes stale temporary artifacts and incomplete/corrupted caches
+- **AND** keeps complete verified caches
 
 #### Scenario: Pre-download scavenging still occurs
 - **WHEN** model download is initiated
-- **THEN** system scavenges and removes stale temp directories before starting download
+- **THEN** system scavenges stale temporary artifacts before starting download
 
-### Requirement: Download state transitions are explicitly observable
-The system SHALL provide clear logging of download lifecycle events at appropriate log levels.
+#### Scenario: TTL is configurable
+- **WHEN** `QUAID_STALE_MODEL_CACHE_TTL_SECS` is set
+- **THEN** system uses that value to determine stale temporary artifact age
 
-**Previous behavior**: Download progress was reported via ProgressReporter but errors were not consistently logged.
+### Requirement: Download state transitions are observable
+The system SHALL provide clear user-facing output for download lifecycle events.
 
-**Updated behavior**: All significant events (start, file completion, error, cleanup, success) are logged with context.
+**Previous behavior**: Download progress was reported, but errors and cleanup
+outcomes were not consistently actionable.
 
-#### Scenario: Download start is logged
+**Updated behavior**: Significant events are surfaced through the existing
+progress reporter and command errors without adding a logging dependency.
+
+#### Scenario: Download start is reported
 - **WHEN** model download begins
-- **THEN** system logs: "Starting model download: phi-3.5-mini from microsoft/Phi-3.5-mini-instruct (revision: main)"
+- **THEN** system reports the alias, source repo, revision, and planned file count
 
 #### Scenario: Download error includes context
 - **WHEN** download fails
-- **THEN** system logs: "Download failed after 45 minutes: {file} - {error}. Cleaning up temporary cache."
+- **THEN** system reports the file, path or URL when relevant, cause, cleanup outcome, and recovery command
 
-#### Scenario: Successful completion is logged
-- **WHEN** download completes and cache is moved to final location
-- **THEN** system logs: "Model successfully cached: phi-3.5-mini at {cache_path} (10 files, 6.1 GB)"
+#### Scenario: Successful completion is reported
+- **WHEN** download completes and cache is verified
+- **THEN** system reports the cache path, file count, total size when known, and elapsed time

--- a/openspec/changes/improve-model-caching/tasks.md
+++ b/openspec/changes/improve-model-caching/tasks.md
@@ -1,0 +1,175 @@
+## 1. Download Resilience - Error Handling
+
+- [ ] 1.1 Add guaranteed cleanup wrapper for download operations
+  - Implement try-finally pattern in `download_model_to_cache()` that removes temp_dir on all error paths
+  - Ensure cleanup happens before returning error to caller
+  
+- [ ] 1.2 Improve error messages with actionable recovery instructions
+  - Update `ModelLifecycleError` variants to include next steps (e.g., "Run `quaid cache clean`")
+  - Ensure all error paths provide context: file name, expected vs. actual, paths affected
+
+- [ ] 1.3 Add protection against concurrent download cleanup races
+  - Implement check for `.downloading` lock files before cleanup
+  - Prevent removing in-progress downloads from other Quaid instances
+  - Document single-writer constraint
+
+## 2. Download Observability - Logging
+
+- [ ] 2.1 Add trace-level logging throughout download lifecycle
+  - Log at download start: alias, repo_id, revision, file count, total size
+  - Log per-file: URL, size, start time, hash type
+  - Log per-file completion: actual hash, time elapsed, speed
+  - Log cleanup operations: which files removed, why
+
+- [ ] 2.2 Integrate error logging with existing ProgressReporter
+  - Add methods or logging hooks for error reporting without changing interface
+  - Ensure errors are logged at WARN level minimum (visible without RUST_LOG)
+  - Ensure success completion is logged at INFO level
+
+- [ ] 2.3 Add cache validation logging
+  - Log manifest validation results (found/not found, valid/invalid)
+  - Log file existence and hash verification for each file
+  - Log when manifest is auto-generated vs. already present
+
+## 3. Cache Validation - Manifest Generation
+
+- [ ] 3.1 Implement lazy manifest generation for existing caches
+  - Create function `ensure_cache_manifest(cache_dir, alias)` 
+  - Scan cache_dir for all expected files based on alias
+  - Compute SHA-256 for each file
+  - Create manifest.json if all files present with correct hashes
+  - Return error if files missing or hashes mismatch
+
+- [ ] 3.2 Add manifest version field for forward compatibility
+  - Update `CacheManifest` struct to include `manifest_version: u32`
+  - Set to 1 for initial version
+  - Add migration logic if version changes in future
+
+- [ ] 3.3 Call manifest validation before model load
+  - Update `load_model_from_local_cache()` to call `ensure_cache_manifest()`
+  - Ensure this happens automatically without user intervention
+  - Log trace-level message when manifest is auto-generated
+
+## 4. Cache Cleanup Command - CLI
+
+- [ ] 4.1 Create new `src/commands/cache.rs` command module
+  - Add subcommands: `clean`, `status`
+  - Implement `--list`, `--all`, `--force` flags for clean
+  - Implement `--verbose` flag for status
+  - Wire into CLI dispatcher in `main.rs`
+
+- [ ] 4.2 Implement `quaid cache clean --list` subcommand
+  - Scan ~/.quaid/models/ for temp directories (`.{cache_key}-download-*` pattern)
+  - Identify incomplete caches (missing manifest or failed validation)
+  - Display path, size, age, status for each
+  - Calculate total disk space would be freed
+
+- [ ] 4.3 Implement `quaid cache clean --all` with user confirmation
+  - Prompt user with summary: "This will remove N directories, freeing X GB"
+  - Support `--force` flag to skip confirmation
+  - Remove directories one by one, tracking failures
+  - Report results: successful removals, failures, total freed
+
+- [ ] 4.4 Implement `quaid cache clean <alias>` for specific models
+  - Remove only caches related to specified alias
+  - Support both temp directories and complete caches with `--force`
+  - Validate alias exists before offering to remove
+
+- [ ] 4.5 Implement `quaid cache status` subcommand
+  - List all cached models with columns: Alias | Status | Files | Size | Manifest | Modified
+  - Show status: ✓ complete, ⚠️  incomplete, ❌ corrupted
+  - Support `--verbose` to show file-by-file breakdown with SHA-256 hashes
+
+## 5. Stale Directory Scavenging - Refactoring
+
+- [ ] 5.1 Refactor scavenge_stale_download_dirs() for reusability
+  - Extract core logic into reusable function that returns list of stale directories
+  - Keep existing pre-download scavenging calling the refactored version
+  - Make available to CLI command module for on-demand cleanup
+
+- [ ] 5.2 Make TTL configurable via environment variable
+  - Add `QUAID_STALE_CACHE_TTL_SECS` environment variable
+  - Default to 6 hours (21600 seconds) if not set
+  - Allow override for testing and custom deployments
+
+## 6. Integration Tests
+
+- [ ] 6.1 Add integration test for incomplete download recovery
+  - Simulate download interruption (mock HTTP stream cutoff)
+  - Verify temp dir cleanup happens
+  - Verify subsequent download starts fresh without errors
+  - Test: incomplete cache → cache clean → fresh download succeeds
+
+- [ ] 6.2 Add integration test for manifest generation
+  - Create mock cache directory with all files but no manifest
+  - Call ensure_cache_manifest()
+  - Verify manifest is created with correct structure
+  - Verify file hashes in manifest match actual files
+
+- [ ] 6.3 Add integration test for cache cleanup command
+  - Create temp directories and incomplete caches
+  - Run `quaid cache clean --list` and verify output
+  - Run `quaid cache clean --all --force` and verify cleanup
+  - Verify final status is empty
+
+- [ ] 6.4 Add integration test for concurrent safety
+  - Simulate two Quaid instances attempting to download same model
+  - Verify only one succeeds and final cache is uncorrupted
+  - Verify no duplicate files in cache directory
+
+## 7. Documentation
+
+- [ ] 7.1 Update operator guide with model caching troubleshooting section
+  - Explain common failure scenarios and symptoms
+  - Document recovery procedures (cache clean, re-download)
+  - Explain QUAID_MODEL_CACHE_DIR and cache TTL configuration
+  - Add examples: inspecting cache status, manual cleanup
+
+- [ ] 7.2 Update CLI help text for new cache commands
+  - `quaid cache --help` explains all subcommands with examples
+  - `quaid cache clean --help` documents flags and safety behavior
+  - `quaid cache status --help` explains output format and verbose mode
+
+- [ ] 7.3 Add migration notes for users with stale caches
+  - Explain that old incomplete caches will be automatically cleaned
+  - Document how to manually recover existing complete caches via cache clean/status
+  - Provide script to identify large stale caches before update
+
+## 8. Testing and Validation
+
+- [ ] 8.1 Run full test suite and verify no regressions
+  - Existing model lifecycle tests pass
+  - New tests for resilience, validation, cleanup pass
+  - Integration tests pass in single and multi-instance scenarios
+
+- [ ] 8.2 Manual testing with real models
+  - Test with phi-3.5-mini: full download, interruption recovery, cache hit
+  - Test with gemma-3-1b: verify manifest generation for existing cache
+  - Test with network throttling/timeout scenarios
+
+- [ ] 8.3 Verify error messages and logging are clear
+  - Simulate various failure modes and verify error output
+  - Verify logs at TRACE level capture sufficient detail for debugging
+  - Verify users can recover without contacting support
+
+- [ ] 8.4 Performance verification
+  - Verify cache validation doesn't add significant latency (<100ms for typical cache)
+  - Verify cleanup command completes in <30 seconds for typical cache directory
+  - Verify logging doesn't noticeably slow down downloads
+
+## 9. Code Review and Refinement
+
+- [ ] 9.1 Peer review of error handling changes
+  - Ensure all error paths are covered by cleanup
+  - Verify no new resource leaks introduced
+  - Check that error messages are user-friendly
+
+- [ ] 9.2 Peer review of logging implementation
+  - Verify logging levels are appropriate (TRACE for detail, INFO for success, WARN for non-fatal errors)
+  - Check that sensitive information (paths, hashes) is not over-logged
+  - Ensure performance impact is acceptable
+
+- [ ] 9.3 Security review of cache cleanup command
+  - Verify permissions are respected (don't remove caches user doesn't own)
+  - Verify no path traversal vulnerabilities in cache directory scanning
+  - Check that `--force` flag doesn't bypass important safety checks

--- a/openspec/changes/improve-model-caching/tasks.md
+++ b/openspec/changes/improve-model-caching/tasks.md
@@ -1,175 +1,166 @@
-## 1. Download Resilience - Error Handling
+## 1. Download Resilience - Cleanup Guards
 
-- [ ] 1.1 Add guaranteed cleanup wrapper for download operations
-  - Implement try-finally pattern in `download_model_to_cache()` that removes temp_dir on all error paths
-  - Ensure cleanup happens before returning error to caller
-  
-- [ ] 1.2 Improve error messages with actionable recovery instructions
-  - Update `ModelLifecycleError` variants to include next steps (e.g., "Run `quaid cache clean`")
-  - Ensure all error paths provide context: file name, expected vs. actual, paths affected
+- [ ] 1.1 Add an extraction temp-directory cleanup guard
+  - Guard owns the `.{cache_key}-download-{timestamp}-{uuid}` path
+  - Guard removes the temp directory on `Drop` unless disarmed
+  - Disarm only after successful rename or after another process has produced a verified final cache
+  - Cover metadata/selection `?` early returns as well as file download errors
 
-- [ ] 1.3 Add protection against concurrent download cleanup races
-  - Implement check for `.downloading` lock files before cleanup
-  - Prevent removing in-progress downloads from other Quaid instances
-  - Document single-writer constraint
+- [ ] 1.2 Add an embedding temp-file cleanup guard
+  - Guard owns each `{file}.download-{uuid}` path in `src/core/inference.rs`
+  - Guard removes the temp file on network, write, hash, or rename failures
+  - Disarm only after the temp file is successfully renamed or a valid destination already exists
 
-## 2. Download Observability - Logging
+- [ ] 1.3 Add stale-download heartbeat handling
+  - Write `.downloading` marker metadata for extraction temp directories
+  - Refresh heartbeat during long downloads before TTL can expire
+  - Skip cleanup for temp artifacts with recent heartbeat/mtime
+  - Report cleanup failures instead of treating them as success
 
-- [ ] 2.1 Add trace-level logging throughout download lifecycle
-  - Log at download start: alias, repo_id, revision, file count, total size
-  - Log per-file: URL, size, start time, hash type
-  - Log per-file completion: actual hash, time elapsed, speed
-  - Log cleanup operations: which files removed, why
+- [ ] 1.4 Improve actionable error messages
+  - Include alias, file name, URL when relevant, affected path, expected vs actual hash, and bytes received when known
+  - Recommend `quaid model clean <alias> --force` plus `quaid model pull <alias>` where appropriate
+  - Keep errors as `Result` values; do not add panics or test-only seams
 
-- [ ] 2.2 Integrate error logging with existing ProgressReporter
-  - Add methods or logging hooks for error reporting without changing interface
-  - Ensure errors are logged at WARN level minimum (visible without RUST_LOG)
-  - Ensure success completion is logged at INFO level
+## 2. Cache Inventory and Validation
 
-- [ ] 2.3 Add cache validation logging
-  - Log manifest validation results (found/not found, valid/invalid)
-  - Log file existence and hash verification for each file
-  - Log when manifest is auto-generated vs. already present
+- [ ] 2.1 Add shared cache inventory helpers
+  - Resolve cache root from `QUAID_MODEL_CACHE_DIR` or `~/.quaid/models`
+  - Detect extraction SLM final caches and temp directories
+  - Detect embedding model final caches and `*.download-*` temp files
+  - Return structured status: family, alias/cache key, path, size, age, manifest state, validation state, cleanup eligibility
 
-## 3. Cache Validation - Manifest Generation
+- [ ] 2.2 Add manifest v1 while preserving legacy manifests
+  - Add `manifest_version`, `created_at_unix`, `size_bytes`, and `modified_unix`
+  - Read existing versionless manifests as legacy v0
+  - Treat missing v1 fields as legacy, not corruption, when existing hashes validate
+  - Upgrade legacy manifests only after successful full verification
 
-- [ ] 3.1 Implement lazy manifest generation for existing caches
-  - Create function `ensure_cache_manifest(cache_dir, alias)` 
-  - Scan cache_dir for all expected files based on alias
-  - Compute SHA-256 for each file
-  - Create manifest.json if all files present with correct hashes
-  - Return error if files missing or hashes mismatch
+- [ ] 2.3 Implement safe lazy manifest generation
+  - Generate manifests for curated extraction aliases from source pins
+  - Generate manifests for known embedding aliases from pinned `ModelConfig` hashes
+  - Generate manifests for custom models only after trusted metadata/checksums from a fresh pull
+  - Fail closed for custom/unpinned existing caches without a manifest when trusted expectations are unavailable
 
-- [ ] 3.2 Add manifest version field for forward compatibility
-  - Update `CacheManifest` struct to include `manifest_version: u32`
-  - Set to 1 for initial version
-  - Add migration logic if version changes in future
+- [ ] 2.4 Split fast validation from full verification
+  - Fast validation: manifest parse, path safety, file existence, size, and modified time
+  - Full verification: SHA-256/git-blob digest recomputation
+  - Run full verification after downloads, during manifest generation/upgrade, on fast-validation mismatch, and for `quaid model status --verify`
+  - Do not re-hash multi-GB models on every normal cache hit
 
-- [ ] 3.3 Call manifest validation before model load
-  - Update `load_model_from_local_cache()` to call `ensure_cache_manifest()`
-  - Ensure this happens automatically without user intervention
-  - Log trace-level message when manifest is auto-generated
+## 3. CLI - `quaid model status` and `quaid model clean`
 
-## 4. Cache Cleanup Command - CLI
+- [ ] 3.1 Extend `src/commands/model.rs`
+  - Keep existing `quaid model pull <alias>` behavior
+  - Add `status [alias] [--verbose] [--verify]`
+  - Add `clean --list [alias]`
+  - Add `clean --all [--force]`
+  - Add `clean <alias> --force`
 
-- [ ] 4.1 Create new `src/commands/cache.rs` command module
-  - Add subcommands: `clean`, `status`
-  - Implement `--list`, `--all`, `--force` flags for clean
-  - Implement `--verbose` flag for status
-  - Wire into CLI dispatcher in `main.rs`
+- [ ] 3.2 Implement `quaid model status`
+  - With no alias, list recognized caches with columns: Family | Alias/Key | Status | Files | Size | Manifest | Modified
+  - With an alias, show matching cache details and validation result
+  - With `--verbose`, show file-level paths, sizes, and manifest hashes
+  - With `--verify`, perform full hash verification and report duration
+  - Exit non-zero only for operational errors, not merely because a cache is missing/corrupted
 
-- [ ] 4.2 Implement `quaid cache clean --list` subcommand
-  - Scan ~/.quaid/models/ for temp directories (`.{cache_key}-download-*` pattern)
-  - Identify incomplete caches (missing manifest or failed validation)
-  - Display path, size, age, status for each
-  - Calculate total disk space would be freed
+- [ ] 3.3 Implement `quaid model clean --list`
+  - Preview stale temp directories, stale temp files, incomplete caches, and corrupted caches
+  - Clearly distinguish "would remove" from "kept"
+  - Show path, family, reason, age, and size
+  - Calculate total disk space eligible for cleanup
 
-- [ ] 4.3 Implement `quaid cache clean --all` with user confirmation
-  - Prompt user with summary: "This will remove N directories, freeing X GB"
-  - Support `--force` flag to skip confirmation
-  - Remove directories one by one, tracking failures
-  - Report results: successful removals, failures, total freed
+- [ ] 3.4 Implement `quaid model clean --all`
+  - Prompt with a summary unless `--force` is supplied
+  - Remove only stale/incomplete/corrupted artifacts, not complete verified caches
+  - Continue after partial failures and report failed paths with reasons
+  - Return non-zero when any requested removal fails
 
-- [ ] 4.4 Implement `quaid cache clean <alias>` for specific models
-  - Remove only caches related to specified alias
-  - Support both temp directories and complete caches with `--force`
-  - Validate alias exists before offering to remove
+- [ ] 3.5 Implement alias-specific cleanup
+  - `quaid model clean <alias> --force` may remove the complete verified cache for that alias
+  - Without `--force`, show the action that would be taken and require confirmation
+  - Validate alias/cache matching before removing anything
 
-- [ ] 4.5 Implement `quaid cache status` subcommand
-  - List all cached models with columns: Alias | Status | Files | Size | Manifest | Modified
-  - Show status: ✓ complete, ⚠️  incomplete, ❌ corrupted
-  - Support `--verbose` to show file-by-file breakdown with SHA-256 hashes
+## 4. Download Observability
 
-## 5. Stale Directory Scavenging - Refactoring
+- [ ] 4.1 Improve `ConsoleProgressReporter`
+  - Show alias, repo, revision, file count, and total bytes when known
+  - Implement throttled `file_progress()` output with downloaded bytes, total bytes, speed, and ETA when known
+  - Show per-file verification completion and final summary
 
-- [ ] 5.1 Refactor scavenge_stale_download_dirs() for reusability
-  - Extract core logic into reusable function that returns list of stale directories
-  - Keep existing pre-download scavenging calling the refactored version
-  - Make available to CLI command module for on-demand cleanup
+- [ ] 4.2 Keep observability dependency-free
+  - Do not introduce `tracing`, `log`, env_logger, or `RUST_LOG` requirements in this change
+  - Route user-visible diagnostics through progress output, command output, and returned errors
 
-- [ ] 5.2 Make TTL configurable via environment variable
-  - Add `QUAID_STALE_CACHE_TTL_SECS` environment variable
-  - Default to 6 hours (21600 seconds) if not set
-  - Allow override for testing and custom deployments
+- [ ] 4.3 Improve cleanup reporting
+  - Report successful temp cleanup at verbose/status level
+  - Report cleanup failures in normal error output when they affect recovery
+  - Include recovery command suggestions
 
-## 6. Integration Tests
+## 5. Tests
 
-- [ ] 6.1 Add integration test for incomplete download recovery
-  - Simulate download interruption (mock HTTP stream cutoff)
-  - Verify temp dir cleanup happens
-  - Verify subsequent download starts fresh without errors
-  - Test: incomplete cache → cache clean → fresh download succeeds
+- [ ] 5.1 Add extraction temp-directory cleanup tests
+  - Metadata/file-selection error after temp dir creation leaves no temp dir
+  - Network interruption leaves no temp dir
+  - Hash mismatch leaves no temp dir
+  - Rename race with existing verified cache returns cache hit and removes local temp
 
-- [ ] 6.2 Add integration test for manifest generation
-  - Create mock cache directory with all files but no manifest
-  - Call ensure_cache_manifest()
-  - Verify manifest is created with correct structure
-  - Verify file hashes in manifest match actual files
+- [ ] 5.2 Add embedding temp-file cleanup tests
+  - GET failure after temp file creation removes temp file
+  - Stream/write failure removes temp file
+  - Hash mismatch removes temp file
+  - Rename race with existing valid destination succeeds without corrupting cache
 
-- [ ] 6.3 Add integration test for cache cleanup command
-  - Create temp directories and incomplete caches
-  - Run `quaid cache clean --list` and verify output
-  - Run `quaid cache clean --all --force` and verify cleanup
-  - Verify final status is empty
+- [ ] 5.3 Add manifest compatibility tests
+  - Existing versionless manifest remains valid
+  - Legacy manifest upgrades to v1 after full verification
+  - Missing manifest for complete curated extraction cache is generated
+  - Missing manifest for custom/unpinned cache fails closed when trusted expectations are unavailable
 
-- [ ] 6.4 Add integration test for concurrent safety
-  - Simulate two Quaid instances attempting to download same model
-  - Verify only one succeeds and final cache is uncorrupted
-  - Verify no duplicate files in cache directory
+- [ ] 5.4 Add CLI status/clean integration tests
+  - `quaid model status` lists complete, missing, incomplete, and corrupted states
+  - `quaid model status --verify` performs full hash validation
+  - `quaid model clean --list` is dry-run only
+  - `quaid model clean --all --force` removes eligible stale artifacts and keeps complete verified caches
+  - `quaid model clean <alias> --force` removes that alias cache
 
-## 7. Documentation
+- [ ] 5.5 Add stale heartbeat/concurrency tests
+  - Recent `.downloading` marker prevents cleanup
+  - Expired heartbeat is eligible for cleanup
+  - Two simulated downloads for the same alias leave one valid final cache and no extra temp paths
 
-- [ ] 7.1 Update operator guide with model caching troubleshooting section
-  - Explain common failure scenarios and symptoms
-  - Document recovery procedures (cache clean, re-download)
-  - Explain QUAID_MODEL_CACHE_DIR and cache TTL configuration
-  - Add examples: inspecting cache status, manual cleanup
+## 6. Documentation
 
-- [ ] 7.2 Update CLI help text for new cache commands
-  - `quaid cache --help` explains all subcommands with examples
-  - `quaid cache clean --help` documents flags and safety behavior
-  - `quaid cache status --help` explains output format and verbose mode
+- [ ] 6.1 Update operator guide with model cache troubleshooting
+  - Explain extraction SLM vs embedding model cache layouts
+  - Document `QUAID_MODEL_CACHE_DIR`
+  - Document `QUAID_STALE_MODEL_CACHE_TTL_SECS`
+  - Show recovery examples using `quaid model status`, `quaid model clean`, and `quaid model pull`
 
-- [ ] 7.3 Add migration notes for users with stale caches
-  - Explain that old incomplete caches will be automatically cleaned
-  - Document how to manually recover existing complete caches via cache clean/status
-  - Provide script to identify large stale caches before update
+- [ ] 6.2 Update CLI help text
+  - `quaid model --help` lists `pull`, `status`, and `clean`
+  - `quaid model status --help` explains `--verbose` and `--verify`
+  - `quaid model clean --help` explains dry-run, confirmation, and `--force`
 
-## 8. Testing and Validation
+- [ ] 6.3 Add migration notes
+  - Legacy versionless manifests are accepted
+  - Complete source-verifiable caches can be repaired without re-download
+  - Custom/unpinned caches without trusted metadata may require re-pull
 
-- [ ] 8.1 Run full test suite and verify no regressions
-  - Existing model lifecycle tests pass
-  - New tests for resilience, validation, cleanup pass
-  - Integration tests pass in single and multi-instance scenarios
+## 7. Validation
 
-- [ ] 8.2 Manual testing with real models
-  - Test with phi-3.5-mini: full download, interruption recovery, cache hit
-  - Test with gemma-3-1b: verify manifest generation for existing cache
-  - Test with network throttling/timeout scenarios
+- [ ] 7.1 Run OpenSpec validation
+  - `openspec validate improve-model-caching --strict`
 
-- [ ] 8.3 Verify error messages and logging are clear
-  - Simulate various failure modes and verify error output
-  - Verify logs at TRACE level capture sufficient detail for debugging
-  - Verify users can recover without contacting support
+- [ ] 7.2 Run targeted test suites
+  - `cargo test --features online-model,test-harness --test model_lifecycle`
+  - Add and run new integration tests for model status/clean behavior
 
-- [ ] 8.4 Performance verification
-  - Verify cache validation doesn't add significant latency (<100ms for typical cache)
-  - Verify cleanup command completes in <30 seconds for typical cache directory
-  - Verify logging doesn't noticeably slow down downloads
+- [ ] 7.3 Run lint/format gates
+  - `cargo fmt --check`
+  - `cargo clippy --all-targets --all-features --locked -- -D warnings`
 
-## 9. Code Review and Refinement
-
-- [ ] 9.1 Peer review of error handling changes
-  - Ensure all error paths are covered by cleanup
-  - Verify no new resource leaks introduced
-  - Check that error messages are user-friendly
-
-- [ ] 9.2 Peer review of logging implementation
-  - Verify logging levels are appropriate (TRACE for detail, INFO for success, WARN for non-fatal errors)
-  - Check that sensitive information (paths, hashes) is not over-logged
-  - Ensure performance impact is acceptable
-
-- [ ] 9.3 Security review of cache cleanup command
-  - Verify permissions are respected (don't remove caches user doesn't own)
-  - Verify no path traversal vulnerabilities in cache directory scanning
-  - Check that `--force` flag doesn't bypass important safety checks
+- [ ] 7.4 Performance check
+  - Normal fast cache status should avoid full hashing and stay responsive for multi-GB caches
+  - `status --verify` may take longer, but should report elapsed time and remain bounded by disk throughput
+  - Cleanup should avoid recursively scanning unrelated directories outside the model cache root

--- a/openspec/changes/improve-model-caching/tasks.md
+++ b/openspec/changes/improve-model-caching/tasks.md
@@ -1,48 +1,48 @@
 ## 1. Download Resilience - Cleanup Guards
 
-- [ ] 1.1 Add an extraction temp-directory cleanup guard
+- [x] 1.1 Add an extraction temp-directory cleanup guard
   - Guard owns the `.{cache_key}-download-{timestamp}-{uuid}` path
   - Guard removes the temp directory on `Drop` unless disarmed
   - Disarm only after successful rename or after another process has produced a verified final cache
   - Cover metadata/selection `?` early returns as well as file download errors
 
-- [ ] 1.2 Add an embedding temp-file cleanup guard
+- [x] 1.2 Add an embedding temp-file cleanup guard
   - Guard owns each `{file}.download-{uuid}` path in `src/core/inference.rs`
   - Guard removes the temp file on network, write, hash, or rename failures
   - Disarm only after the temp file is successfully renamed or a valid destination already exists
 
-- [ ] 1.3 Add stale-download heartbeat handling
+- [x] 1.3 Add stale-download heartbeat handling
   - Write `.downloading` marker metadata for extraction temp directories
   - Refresh heartbeat during long downloads before TTL can expire
   - Skip cleanup for temp artifacts with recent heartbeat/mtime
   - Report cleanup failures instead of treating them as success
 
-- [ ] 1.4 Improve actionable error messages
+- [x] 1.4 Improve actionable error messages
   - Include alias, file name, URL when relevant, affected path, expected vs actual hash, and bytes received when known
   - Recommend `quaid model clean <alias> --force` plus `quaid model pull <alias>` where appropriate
   - Keep errors as `Result` values; do not add panics or test-only seams
 
 ## 2. Cache Inventory and Validation
 
-- [ ] 2.1 Add shared cache inventory helpers
+- [x] 2.1 Add shared cache inventory helpers
   - Resolve cache root from `QUAID_MODEL_CACHE_DIR` or `~/.quaid/models`
   - Detect extraction SLM final caches and temp directories
   - Detect embedding model final caches and `*.download-*` temp files
   - Return structured status: family, alias/cache key, path, size, age, manifest state, validation state, cleanup eligibility
 
-- [ ] 2.2 Add manifest v1 while preserving legacy manifests
+- [x] 2.2 Add manifest v1 while preserving legacy manifests
   - Add `manifest_version`, `created_at_unix`, `size_bytes`, and `modified_unix`
   - Read existing versionless manifests as legacy v0
   - Treat missing v1 fields as legacy, not corruption, when existing hashes validate
   - Upgrade legacy manifests only after successful full verification
 
-- [ ] 2.3 Implement safe lazy manifest generation
+- [x] 2.3 Implement safe lazy manifest generation
   - Generate manifests for curated extraction aliases from source pins
   - Generate manifests for known embedding aliases from pinned `ModelConfig` hashes
   - Generate manifests for custom models only after trusted metadata/checksums from a fresh pull
   - Fail closed for custom/unpinned existing caches without a manifest when trusted expectations are unavailable
 
-- [ ] 2.4 Split fast validation from full verification
+- [x] 2.4 Split fast validation from full verification
   - Fast validation: manifest parse, path safety, file existence, size, and modified time
   - Full verification: SHA-256/git-blob digest recomputation
   - Run full verification after downloads, during manifest generation/upgrade, on fast-validation mismatch, and for `quaid model status --verify`
@@ -50,113 +50,113 @@
 
 ## 3. CLI - `quaid model status` and `quaid model clean`
 
-- [ ] 3.1 Extend `src/commands/model.rs`
+- [x] 3.1 Extend `src/commands/model.rs`
   - Keep existing `quaid model pull <alias>` behavior
   - Add `status [alias] [--verbose] [--verify]`
   - Add `clean --list [alias]`
   - Add `clean --all [--force]`
   - Add `clean <alias> --force`
 
-- [ ] 3.2 Implement `quaid model status`
+- [x] 3.2 Implement `quaid model status`
   - With no alias, list recognized caches with columns: Family | Alias/Key | Status | Files | Size | Manifest | Modified
   - With an alias, show matching cache details and validation result
   - With `--verbose`, show file-level paths, sizes, and manifest hashes
   - With `--verify`, perform full hash verification and report duration
   - Exit non-zero only for operational errors, not merely because a cache is missing/corrupted
 
-- [ ] 3.3 Implement `quaid model clean --list`
+- [x] 3.3 Implement `quaid model clean --list`
   - Preview stale temp directories, stale temp files, incomplete caches, and corrupted caches
   - Clearly distinguish "would remove" from "kept"
   - Show path, family, reason, age, and size
   - Calculate total disk space eligible for cleanup
 
-- [ ] 3.4 Implement `quaid model clean --all`
+- [x] 3.4 Implement `quaid model clean --all`
   - Prompt with a summary unless `--force` is supplied
   - Remove only stale/incomplete/corrupted artifacts, not complete verified caches
   - Continue after partial failures and report failed paths with reasons
   - Return non-zero when any requested removal fails
 
-- [ ] 3.5 Implement alias-specific cleanup
+- [x] 3.5 Implement alias-specific cleanup
   - `quaid model clean <alias> --force` may remove the complete verified cache for that alias
   - Without `--force`, show the action that would be taken and require confirmation
   - Validate alias/cache matching before removing anything
 
 ## 4. Download Observability
 
-- [ ] 4.1 Improve `ConsoleProgressReporter`
+- [x] 4.1 Improve `ConsoleProgressReporter`
   - Show alias, repo, revision, file count, and total bytes when known
   - Implement throttled `file_progress()` output with downloaded bytes, total bytes, speed, and ETA when known
   - Show per-file verification completion and final summary
 
-- [ ] 4.2 Keep observability dependency-free
+- [x] 4.2 Keep observability dependency-free
   - Do not introduce `tracing`, `log`, env_logger, or `RUST_LOG` requirements in this change
   - Route user-visible diagnostics through progress output, command output, and returned errors
 
-- [ ] 4.3 Improve cleanup reporting
+- [x] 4.3 Improve cleanup reporting
   - Report successful temp cleanup at verbose/status level
   - Report cleanup failures in normal error output when they affect recovery
   - Include recovery command suggestions
 
 ## 5. Tests
 
-- [ ] 5.1 Add extraction temp-directory cleanup tests
+- [x] 5.1 Add extraction temp-directory cleanup tests
   - Metadata/file-selection error after temp dir creation leaves no temp dir
   - Network interruption leaves no temp dir
   - Hash mismatch leaves no temp dir
   - Rename race with existing verified cache returns cache hit and removes local temp
 
-- [ ] 5.2 Add embedding temp-file cleanup tests
+- [x] 5.2 Add embedding temp-file cleanup tests
   - GET failure after temp file creation removes temp file
   - Stream/write failure removes temp file
   - Hash mismatch removes temp file
   - Rename race with existing valid destination succeeds without corrupting cache
 
-- [ ] 5.3 Add manifest compatibility tests
+- [x] 5.3 Add manifest compatibility tests
   - Existing versionless manifest remains valid
   - Legacy manifest upgrades to v1 after full verification
   - Missing manifest for complete curated extraction cache is generated
   - Missing manifest for custom/unpinned cache fails closed when trusted expectations are unavailable
 
-- [ ] 5.4 Add CLI status/clean integration tests
+- [x] 5.4 Add CLI status/clean integration tests
   - `quaid model status` lists complete, missing, incomplete, and corrupted states
   - `quaid model status --verify` performs full hash validation
   - `quaid model clean --list` is dry-run only
   - `quaid model clean --all --force` removes eligible stale artifacts and keeps complete verified caches
   - `quaid model clean <alias> --force` removes that alias cache
 
-- [ ] 5.5 Add stale heartbeat/concurrency tests
+- [x] 5.5 Add stale heartbeat/concurrency tests
   - Recent `.downloading` marker prevents cleanup
   - Expired heartbeat is eligible for cleanup
   - Two simulated downloads for the same alias leave one valid final cache and no extra temp paths
 
 ## 6. Documentation
 
-- [ ] 6.1 Update operator guide with model cache troubleshooting
+- [x] 6.1 Update operator guide with model cache troubleshooting
   - Explain extraction SLM vs embedding model cache layouts
   - Document `QUAID_MODEL_CACHE_DIR`
   - Document `QUAID_STALE_MODEL_CACHE_TTL_SECS`
   - Show recovery examples using `quaid model status`, `quaid model clean`, and `quaid model pull`
 
-- [ ] 6.2 Update CLI help text
+- [x] 6.2 Update CLI help text
   - `quaid model --help` lists `pull`, `status`, and `clean`
   - `quaid model status --help` explains `--verbose` and `--verify`
   - `quaid model clean --help` explains dry-run, confirmation, and `--force`
 
-- [ ] 6.3 Add migration notes
+- [x] 6.3 Add migration notes
   - Legacy versionless manifests are accepted
   - Complete source-verifiable caches can be repaired without re-download
   - Custom/unpinned caches without trusted metadata may require re-pull
 
 ## 7. Validation
 
-- [ ] 7.1 Run OpenSpec validation
+- [x] 7.1 Run OpenSpec validation
   - `openspec validate improve-model-caching --strict`
 
-- [ ] 7.2 Run targeted test suites
-  - `cargo test --features online-model,test-harness --test model_lifecycle`
+- [x] 7.2 Run targeted test suites
+  - `cargo test --no-default-features --features bundled,online-model,test-harness --test model_lifecycle`
   - Add and run new integration tests for model status/clean behavior
 
-- [ ] 7.3 Run lint/format gates
+- [x] 7.3 Run lint/format gates
   - `cargo fmt --check`
   - `cargo clippy --all-targets --all-features --locked -- -D warnings`
 

--- a/openspec/changes/sensible-memory-defaults/.openspec.yaml
+++ b/openspec/changes/sensible-memory-defaults/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-16

--- a/openspec/changes/sensible-memory-defaults/design.md
+++ b/openspec/changes/sensible-memory-defaults/design.md
@@ -1,0 +1,65 @@
+## Context
+
+Fresh databases initialize with a default collection row, but write flows can still fail on first run when the write-target root is not configured to a writable path. This especially impacts conversation capture flows (`memory_add_turn`) where users expect immediate success in playground, MCP, and CLI-assisted onboarding.
+
+The proposal sets a product requirement for sensible defaults: a first-run writable collection root at `~/.quaid/vault` without requiring manual collection bootstrap commands.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Ensure new databases have a usable, writable write-target root by default.
+- Make first conversation-write operations succeed on clean installs without manual collection setup.
+- Keep safety posture explicit: writes still route to a known local collection root owned by the current user.
+- Preserve backward compatibility for already-configured databases.
+
+**Non-Goals:**
+- No migration that force-overwrites existing user-configured collection roots.
+- No change to multi-collection routing semantics or ambiguity resolution rules.
+- No changes to extraction policy, model download policy, or unrelated runtime bootstrap behavior.
+
+## Decisions
+
+1. Default root path for first-run write-target
+- Decision: define the default collection root as `~/.quaid/vault` for new installs and unconfigured default-write-target states.
+- Rationale: this is predictable, user-owned, and aligned with Quaid's home-directory convention.
+- Alternatives considered:
+  - `~/.quaid/default-vault`: clearer as a vault concept but less intuitive than `memory` for first-run users.
+  - Keeping detached/empty root until explicit attach: safer by strictness but causes first-run failures and poor UX.
+
+2. Initialization-time bootstrap over client-side workarounds
+- Decision: establish the writable default in core initialization/first-run logic, not in individual clients (playground, wrappers).
+- Rationale: one source of truth ensures consistent behavior across CLI, MCP, playground, and future clients.
+- Alternatives considered:
+  - Playground-only bootstrap: fixes one entry point but leaves MCP/CLI users exposed.
+  - Lazy repair only inside `memory_add_turn`: narrower fix, but less transparent and repeats root-setup logic in request paths.
+
+3. Compatibility behavior for existing databases
+- Decision: only apply defaults when the write-target is missing or unconfigured; preserve valid existing roots.
+- Rationale: prevents surprise relocation of storage and avoids breaking existing setups.
+- Alternatives considered:
+  - Hard migration for all DBs: too risky and intrusive.
+  - No migration path at all: leaves old broken/unconfigured states unresolved.
+
+## Risks / Trade-offs
+
+- [Risk] Creating `~/.quaid/vault` in constrained environments may fail due to permissions.
+  → Mitigation: return a clear configuration error and remediation guidance; keep existing explicit collection commands available.
+
+- [Risk] Legacy DBs with unusual collection states may not fit a single bootstrap rule.
+  → Mitigation: gate bootstrap on strict predicates (no writable root configured) and add integration tests for existing-state preservation.
+
+- [Risk] Spec and docs drift if behavior changes but onboarding docs do not.
+  → Mitigation: include docs updates and first-run acceptance tests in the task list.
+
+## Migration Plan
+
+- Apply behavior for newly initialized databases immediately.
+- For existing databases, run a safe conditional bootstrap at open/startup only when write-target configuration is unusable.
+- Do not modify databases that already have a writable configured write-target.
+- Rollback strategy: disable conditional bootstrap path and revert to previous explicit setup requirements if regressions are found.
+
+## Open Questions
+
+- Should the conditional bootstrap run only at `quaid init`, or also at DB open when a legacy DB has an empty write-target root?
+- Should bootstrap also normalize collection state (`detached` to `active`) for the default row when assigning `~/.quaid/vault`?
+- What level of warning/telemetry should be emitted when automatic first-run bootstrap occurs?

--- a/openspec/changes/sensible-memory-defaults/proposal.md
+++ b/openspec/changes/sensible-memory-defaults/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Fresh installs currently require users to manually bootstrap a writable collection root before conversation tools can write turns. This causes first-run failures in common flows (including playground and MCP `memory_add_turn`) and creates avoidable setup friction.
+
+## What Changes
+
+- Define sensible first-run collection defaults during database initialization so conversation and write flows work without manual collection setup.
+- Set the default write-target collection root to `~/.quaid/vault` (resolved to the current user's home directory) when no writable root is configured.
+- Ensure first-run defaults preserve existing safety expectations (explicit writable target, local user-owned path, no hidden remote behavior).
+- Document and test the first-run behavior so CLI, MCP, and playground flows consistently succeed on a clean install.
+
+## Capabilities
+
+### New Capabilities
+- None.
+
+### Modified Capabilities
+- `collections`: Change first-run default collection behavior so a writable write-target root is automatically available at `~/.quaid/vault`.
+- `conversation-turn-capture`: Require `memory_add_turn` and related conversation-write tools to succeed on a fresh initialized database without prior manual collection bootstrap.
+
+## Impact
+
+- Affected areas: DB initialization/default collection setup, collection metadata defaults, conversation turn writer preconditions, and first-run docs.
+- Affected surfaces: CLI (`quaid init`), MCP conversation tools, playground first-run UX.
+- Compatibility: Existing configured databases should keep their current collection roots; defaults apply to new DBs or unconfigured default write-target states.

--- a/openspec/changes/sensible-memory-defaults/specs/collections/spec.md
+++ b/openspec/changes/sensible-memory-defaults/specs/collections/spec.md
@@ -1,0 +1,35 @@
+## MODIFIED Requirements
+
+### Requirement: Collection as first-class entity
+
+The system SHALL store every page within a named collection. Each collection SHALL have a unique name, a root path on the local filesystem (`collections.root_path TEXT NOT NULL` — storage always retains the last-known absolute path even when the collection is `detached`, so that `sync --remap-root` can be attempted without first re-attaching and operators can see where the collection was last bound), an ignore-pattern list, and a boolean flag indicating whether it is the default target for agent-initiated writes. The MCP surface (`memory_collections`) presents `root_path` as `null` when `state != 'active'` because a detached/restoring root is not safe to walk or open, even though the underlying column is non-null — the API shapes the view, storage retains history.
+
+For first-run usability, `quaid init` SHALL provision the default collection with a writable write-target root at `~/.quaid/vault` (resolved to an absolute path for the current user and created if missing). Existing databases that already have a writable configured write-target root SHALL remain unchanged.
+
+#### Scenario: Fresh init creates default collection
+
+- **WHEN** a user runs `quaid init` in a directory with no existing `memory.db`
+- **THEN** the system creates `memory.db`, creates a `collections` row named `default` with `root_path = ~/.quaid/vault` (creating the directory if missing), and sets `is_write_target = 1`
+
+#### Scenario: Adding a new collection — atomic `.quaidignore` parse gates creation
+
+- **WHEN** a user runs `quaid collection add work ~/Documents/work-vault` and any `.quaidignore` at the vault root parses cleanly (or is absent)
+- **THEN** the system inserts a `collections` row with name `work`, absolute-resolved root path, `ignore_patterns` populated with the validated `.quaidignore` user patterns ONLY (per the file-authoritative contract — built-in defaults are NOT merged into the stored mirror; they are applied in code at reconciler-query time) or NULL if the file is absent, and `is_write_target = 0`
+- **AND** the initial walk ingests all non-ignored `.md` files under the root
+
+#### Scenario: `collection add` refuses when `.quaidignore` fails atomic parse
+
+- **WHEN** a user runs `quaid collection add work ~/Documents/work-vault` and the vault's `.quaidignore` contains any invalid glob
+- **THEN** `collection add` SHALL refuse — return a non-zero exit with the parse error details (line number + raw line + error message for each invalid line), and NOT create the `collections` row, NOT run the initial walk, NOT mutate any DB state
+- **AND** the command message instructs the user to fix `.quaidignore` and re-run `add`
+- **AND** there is NO last-known-good pattern set to fall back to (this is a brand-new collection) — the atomic-parse failure therefore prevents ANY ingest until the file is fixed. This ensures a privacy-sensitive `.quaidignore` is never silently bypassed on initial ingest.
+
+#### Scenario: Name collision rejected
+
+- **WHEN** a user runs `quaid collection add work ~/other-path` and a collection named `work` already exists
+- **THEN** the command errors with a message referencing the existing collection; no database changes are made
+
+#### Scenario: Setting write target is exclusive
+
+- **WHEN** a user runs `quaid collection add memory ~/memory --write-target` and another collection is currently `is_write_target = 1`
+- **THEN** the system clears the previous write target and sets it on the new collection in a single transaction; exactly one collection has `is_write_target = 1` at all times

--- a/openspec/changes/sensible-memory-defaults/specs/conversation-turn-capture/spec.md
+++ b/openspec/changes/sensible-memory-defaults/specs/conversation-turn-capture/spec.md
@@ -1,0 +1,31 @@
+## MODIFIED Requirements
+
+### Requirement: `memory_add_turn` MCP tool appends turns to a per-session vault file
+The system SHALL expose an MCP tool `memory_add_turn` that accepts `{session_id: string, role: "user"|"assistant"|"system"|"tool", content: string, timestamp?: ISO-8601, metadata?: object}` and SHALL append the turn to a vault-resident markdown file at `<vault>/conversations/<YYYY-MM-DD>/<session-id>.md`, where `<YYYY-MM-DD>` is derived from the turn's timestamp (server `now` when the timestamp is omitted). The append SHALL be durable: the file SHALL exist on disk with the new turn block before the call returns. Concurrent appends for the same session SHALL serialize across processes so ordinals remain unique and ordered. The tool SHALL return synchronously with `{turn_id, conversation_path, extraction_scheduled_at}`. The implementation SHALL NOT invoke any SLM on the request path.
+
+On a fresh initialized database with default settings, callers SHALL NOT need to manually create or attach a collection before first use. `memory_add_turn` SHALL succeed by writing under the default writable write-target rooted at `~/.quaid/vault`.
+
+#### Scenario: First turn for a session creates the conversation file
+- **WHEN** `memory_add_turn` is called with `session_id="s1"`, `role="user"`, `content="hi"`, `timestamp="2026-05-03T09:14:22Z"` and no file exists yet
+- **THEN** the file `<vault>/conversations/2026-05-03/s1.md` is created with conversation frontmatter and a single turn block, and the response includes `turn_id="s1:1"` and `conversation_path="conversations/2026-05-03/s1.md"`
+
+#### Scenario: Fresh initialized DB works without manual collection bootstrap
+- **WHEN** a user has a freshly initialized database with no manual `collection add` and calls `memory_add_turn` for a new session
+- **THEN** the call succeeds and writes to `~/.quaid/vault/conversations/<YYYY-MM-DD>/<session-id>.md` via the default writable write-target
+- **AND** no `ConfigError` is returned for missing writable collection root
+
+#### Scenario: Subsequent turn appends to the same file with the next ordinal
+- **WHEN** `memory_add_turn` is called twice in succession for the same `session_id` on the same calendar day
+- **THEN** the second call appends a second turn block to the same file with `turn_id="<session>:2"` and the file contains both turn blocks in order
+
+#### Scenario: Append is durable before the call returns
+- **WHEN** `memory_add_turn` returns successfully
+- **THEN** the appended turn content is observable on disk by an independent file read
+
+#### Scenario: Same-session concurrent appends serialize across processes
+- **WHEN** two processes append turns concurrently for the same `session_id`
+- **THEN** exactly one append holds the session lock at a time, and the resulting file contains both turns with distinct ordinals in append order
+
+#### Scenario: Caller-supplied metadata is preserved verbatim in the turn block
+- **WHEN** `memory_add_turn` is called with `metadata={"tool_name": "bash", "importance": "high"}`
+- **THEN** the rendered turn block in the conversation file preserves the metadata fields and they survive a parse-then-render round-trip

--- a/openspec/changes/sensible-memory-defaults/tasks.md
+++ b/openspec/changes/sensible-memory-defaults/tasks.md
@@ -1,29 +1,29 @@
 ## 1. Initialization Defaults
 
-- [ ] 1.1 Update DB initialization logic so fresh `quaid init` sets default collection root to `~/.quaid/vault` and keeps it as write-target.
-- [ ] 1.2 Ensure initialization creates the resolved default root directory when missing and surfaces clear errors on permission failures.
-- [ ] 1.3 Add guard logic so existing databases with already-valid writable write-target roots are not modified.
+- [x] 1.1 Update DB initialization logic so fresh `quaid init` sets default collection root to `~/.quaid/vault` and keeps it as write-target.
+- [x] 1.2 Ensure initialization creates the resolved default root directory when missing and surfaces clear errors on permission failures.
+- [x] 1.3 Add guard logic so existing databases with already-valid writable write-target roots are not modified.
 
 ## 2. Conversation Write Path Compatibility
 
-- [ ] 2.1 Align conversation turn write preconditions with the new first-run default behavior so fresh initialized DBs no longer fail with missing writable root.
-- [ ] 2.2 Add/adjust fallback handling for legacy unconfigured default states according to the approved migration rule.
-- [ ] 2.3 Verify no changes to multi-collection ambiguity routing or write-target exclusivity semantics.
+- [x] 2.1 Align conversation turn write preconditions with the new first-run default behavior so fresh initialized DBs no longer fail with missing writable root.
+- [x] 2.2 Add/adjust fallback handling for legacy unconfigured default states according to the approved migration rule.
+- [x] 2.3 Verify no changes to multi-collection ambiguity routing or write-target exclusivity semantics.
 
 ## 3. Tests
 
-- [ ] 3.1 Add integration tests for fresh init defaults validating `root_path`, `is_write_target`, and directory creation.
-- [ ] 3.2 Add conversation tool tests proving `memory_add_turn` succeeds on a fresh initialized DB without manual collection bootstrap.
-- [ ] 3.3 Add regression tests ensuring existing configured DBs are preserved and not rewritten.
+- [x] 3.1 Add integration tests for fresh init defaults validating `root_path`, `is_write_target`, and directory creation.
+- [x] 3.2 Add conversation tool tests proving `memory_add_turn` succeeds on a fresh initialized DB without manual collection bootstrap.
+- [x] 3.3 Add regression tests ensuring existing configured DBs are preserved and not rewritten.
 
 ## 4. Documentation
 
-- [ ] 4.1 Update getting-started and operator docs to describe default root behavior at `~/.quaid/vault`.
-- [ ] 4.2 Document compatibility behavior for existing DBs and manual override paths for custom collection roots.
-- [ ] 4.3 Add release-note/changelog entry for first-run sensible collection defaults.
+- [x] 4.1 Update getting-started and operator docs to describe default root behavior at `~/.quaid/vault`.
+- [x] 4.2 Document compatibility behavior for existing DBs and manual override paths for custom collection roots.
+- [x] 4.3 Add release-note/changelog entry for first-run sensible collection defaults.
 
 ## 5. Validation and Rollout Readiness
 
-- [ ] 5.1 Run full relevant test suites and confirm no regressions in collection and conversation flows.
-- [ ] 5.2 Validate CLI, MCP, and playground first-run smoke tests against a clean environment.
-- [ ] 5.3 Prepare rollback notes for disabling conditional bootstrap if unexpected regressions appear.
+- [x] 5.1 Run full relevant test suites and confirm no regressions in collection and conversation flows.
+- [x] 5.2 Validate CLI, MCP, and playground first-run smoke tests against a clean environment.
+- [x] 5.3 Prepare rollback notes for disabling conditional bootstrap if unexpected regressions appear.

--- a/openspec/changes/sensible-memory-defaults/tasks.md
+++ b/openspec/changes/sensible-memory-defaults/tasks.md
@@ -1,0 +1,29 @@
+## 1. Initialization Defaults
+
+- [ ] 1.1 Update DB initialization logic so fresh `quaid init` sets default collection root to `~/.quaid/vault` and keeps it as write-target.
+- [ ] 1.2 Ensure initialization creates the resolved default root directory when missing and surfaces clear errors on permission failures.
+- [ ] 1.3 Add guard logic so existing databases with already-valid writable write-target roots are not modified.
+
+## 2. Conversation Write Path Compatibility
+
+- [ ] 2.1 Align conversation turn write preconditions with the new first-run default behavior so fresh initialized DBs no longer fail with missing writable root.
+- [ ] 2.2 Add/adjust fallback handling for legacy unconfigured default states according to the approved migration rule.
+- [ ] 2.3 Verify no changes to multi-collection ambiguity routing or write-target exclusivity semantics.
+
+## 3. Tests
+
+- [ ] 3.1 Add integration tests for fresh init defaults validating `root_path`, `is_write_target`, and directory creation.
+- [ ] 3.2 Add conversation tool tests proving `memory_add_turn` succeeds on a fresh initialized DB without manual collection bootstrap.
+- [ ] 3.3 Add regression tests ensuring existing configured DBs are preserved and not rewritten.
+
+## 4. Documentation
+
+- [ ] 4.1 Update getting-started and operator docs to describe default root behavior at `~/.quaid/vault`.
+- [ ] 4.2 Document compatibility behavior for existing DBs and manual override paths for custom collection roots.
+- [ ] 4.3 Add release-note/changelog entry for first-run sensible collection defaults.
+
+## 5. Validation and Rollout Readiness
+
+- [ ] 5.1 Run full relevant test suites and confirm no regressions in collection and conversation flows.
+- [ ] 5.2 Validate CLI, MCP, and playground first-run smoke tests against a clean environment.
+- [ ] 5.3 Prepare rollback notes for disabling conditional bootstrap if unexpected regressions appear.

--- a/playground/.gitignore
+++ b/playground/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+dist/
+coverage/
+test-results/
+playwright-report/
+.quaid-profiles/
+*.local
+*.log

--- a/playground/README.md
+++ b/playground/README.md
@@ -1,0 +1,52 @@
+# Quaid Playground
+
+React/Vite playground for testing Quaid memory, conversations, extraction,
+models, files, and graph views.
+
+## WSL Startup
+
+Run from WSL because Quaid itself is Linux-only in this setup.
+
+```bash
+cd /mnt/d/repos/quaid
+cargo build
+
+cd /mnt/d/repos/quaid/playground
+pnpm install
+
+QUAID_BIN=/mnt/d/repos/quaid/target/debug/quaid \
+QUAID_DB="$HOME/.quaid/memory.db" \
+pnpm dev --host 127.0.0.1
+```
+
+Managed mode auto-starts:
+
+```bash
+quaid --db "$QUAID_DB" --model small serve --http --port 3112 --trust-loopback
+```
+
+If the DB is missing, the playground creates the parent directory and runs:
+
+```bash
+quaid --model small init "$QUAID_DB"
+```
+
+Runtime logs appear in two places:
+
+- the Vite terminal as `[quaid-runtime] ...`
+- the left status panel under **Runtime log**
+
+## Useful Environment Variables
+
+- `QUAID_BIN`: path to the Linux Quaid binary.
+- `QUAID_DB`: DB path, defaults to `~/.quaid/memory.db`.
+- `QUAID_MODEL`: embedding model alias, defaults to `small`.
+- `QUAID_MCP_URL`: external MCP URL; when set, the playground does not manage `quaid serve`.
+- `QUAID_PLAYGROUND_AUTO_INIT`: auto-init missing DBs, defaults to `true`.
+- `QUAID_PLAYGROUND_AUTO_ENABLE_EXTRACTION`: auto-run `quaid extraction enable`, defaults to `false` because it may download an SLM model.
+
+To auto-enable fact extraction at startup:
+
+```bash
+QUAID_PLAYGROUND_AUTO_ENABLE_EXTRACTION=1 pnpm dev --host 127.0.0.1
+```

--- a/playground/docs/future-mcp.md
+++ b/playground/docs/future-mcp.md
@@ -1,0 +1,48 @@
+# Future MCP Endpoints
+
+The playground intentionally avoids Rust changes. These endpoints would make the
+UI cleaner later, but are not required for the initial playground.
+
+## SLM Chat / Inference
+
+Expose the internal SLM runner through MCP for basic local assistant behavior.
+
+Suggested tool names:
+
+- `slm_infer`
+- `memory_assistant_chat`
+
+Suggested inputs:
+
+- `model_alias`
+- `messages` or `prompt`
+- `max_tokens`
+- later: `temperature`, `top_p`, streaming, and chat template selection
+
+The playground can then retrieve context with `memory_query`, pass that context
+to the local SLM, store assistant turns with `memory_add_turn`, and run fact
+extraction over the conversation.
+
+## File and Raw Import APIs
+
+Dedicated MCP tools would avoid read-only SQLite/file inspection from the
+playground backend:
+
+- list collections and root paths
+- list synced files
+- read active raw import bytes
+- read live collection files with root containment handled by Quaid
+
+## Model Management APIs
+
+Dedicated MCP tools would replace the CLI bridge for:
+
+- model download/status
+- extraction enable/disable/status
+- embedding profile creation and re-embedding
+
+## Graph APIs
+
+A whole-knowledge-base graph endpoint would avoid the playground building a
+graph from read-only SQLite rows. The current focused graph flow can use
+`memory_graph`.

--- a/playground/index.html
+++ b/playground/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Quaid Playground</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/playground/package.json
+++ b/playground/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "quaid-playground",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "serve": "QUAID_PLAYGROUND_AUTO_ENABLE_EXTRACTION=1 QUAID_BIN=../target/release/quaid QUAID_DB=\"$HOME/.quaid/memory.db\" vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "e2e": "playwright test"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.90.12",
+    "better-sqlite3": "^12.5.0",
+    "lucide-react": "^0.561.0",
+    "react": "^19.2.1",
+    "react-dom": "^19.2.1",
+    "react-force-graph-2d": "^1.29.0",
+    "react-markdown": "^10.1.0",
+    "react-router-dom": "^7.10.1",
+    "remark-gfm": "^4.0.1"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.57.0",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.0",
+    "@types/better-sqlite3": "^7.6.13",
+    "@types/node": "^24.10.1",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^5.1.1",
+    "jsdom": "^27.2.0",
+    "typescript": "^5.9.3",
+    "vite": "^7.2.6",
+    "vitest": "^4.0.15"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "better-sqlite3",
+      "esbuild"
+    ]
+  },
+  "packageManager": "pnpm@10.28.2+sha512.41872f037ad22f7348e3b1debbaf7e867cfd448f2726d9cf74c08f19507c31d2c8e7a11525b983febc2df640b5438dee6023ebb1f84ed43cc2d654d2bc326264"
+}

--- a/playground/playwright.config.ts
+++ b/playground/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  timeout: 60_000,
+  expect: {
+    timeout: 10_000
+  },
+  use: {
+    baseURL: "http://127.0.0.1:5174",
+    trace: "on-first-retry"
+  },
+  webServer: {
+    command: "corepack pnpm dev --host 127.0.0.1",
+    url: "http://127.0.0.1:5174",
+    reuseExistingServer: true,
+    timeout: 120_000
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] }
+    }
+  ]
+});

--- a/playground/pnpm-lock.yaml
+++ b/playground/pnpm-lock.yaml
@@ -1,0 +1,3508 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@tanstack/react-query':
+        specifier: ^5.90.12
+        version: 5.100.10(react@19.2.6)
+      better-sqlite3:
+        specifier: ^12.5.0
+        version: 12.10.0
+      lucide-react:
+        specifier: ^0.561.0
+        version: 0.561.0(react@19.2.6)
+      react:
+        specifier: ^19.2.1
+        version: 19.2.6
+      react-dom:
+        specifier: ^19.2.1
+        version: 19.2.6(react@19.2.6)
+      react-force-graph-2d:
+        specifier: ^1.29.0
+        version: 1.29.1(react@19.2.6)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.2.14)(react@19.2.6)
+      react-router-dom:
+        specifier: ^7.10.1
+        version: 7.15.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.57.0
+        version: 1.60.0
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
+      '@types/node':
+        specifier: ^24.10.1
+        version: 24.12.4
+      '@types/react':
+        specifier: ^19.2.7
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^5.1.1
+        version: 5.2.0(vite@7.3.3(@types/node@24.12.4))
+      jsdom:
+        specifier: ^27.2.0
+        version: 27.4.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^7.2.6
+        version: 7.3.3(@types/node@24.12.4)
+      vitest:
+        specifier: ^4.0.15
+        version: 4.1.6(@types/node@24.12.4)(jsdom@27.4.0)(vite@7.3.3(@types/node@24.12.4))
+
+packages:
+
+  '@acemir/cssom@0.9.31':
+    resolution: {integrity: sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==}
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
+  '@asamuzakjp/css-color@4.1.2':
+    resolution: {integrity: sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==}
+
+  '@asamuzakjp/dom-selector@6.8.1':
+    resolution: {integrity: sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.3':
+    resolution: {integrity: sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.0':
+    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.2':
+    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.3':
+    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1':
+    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1':
+    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.1':
+    resolution: {integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.1':
+    resolution: {integrity: sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.4':
+    resolution: {integrity: sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@rolldown/pluginutils@1.0.0-rc.3':
+    resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
+
+  '@rollup/rollup-android-arm-eabi@4.60.4':
+    resolution: {integrity: sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.4':
+    resolution: {integrity: sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.4':
+    resolution: {integrity: sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.4':
+    resolution: {integrity: sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.4':
+    resolution: {integrity: sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.4':
+    resolution: {integrity: sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
+    resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
+    resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.4':
+    resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.4':
+    resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.4':
+    resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.4':
+    resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
+    resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.4':
+    resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
+    resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.4':
+    resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.4':
+    resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.4':
+    resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.4':
+    resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.4':
+    resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.4':
+    resolution: {integrity: sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.4':
+    resolution: {integrity: sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.4':
+    resolution: {integrity: sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.4':
+    resolution: {integrity: sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.4':
+    resolution: {integrity: sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tanstack/query-core@5.100.10':
+    resolution: {integrity: sha512-8UR0yJR+GiQ40m3lPhUr0xbfAupe6GSQiksSBSa9SM2NjezFyxXCIA69/lz8cSoNKZLrw1/PktIyQBJcVeMi3w==}
+
+  '@tanstack/react-query@5.100.10':
+    resolution: {integrity: sha512-FLaZf2RCrA/Zgp4aiu5tG3TyasTRO7aZ99skxQpr3Hg/zXOhu6yq5FZCYQ/tRaJtM9ylnoK8tFK7PolXQadv6Q==}
+    peerDependencies:
+      react: ^18 || ^19
+
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@tweenjs/tween.js@25.0.0':
+    resolution: {integrity: sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/better-sqlite3@7.6.13':
+    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
+  '@types/node@24.12.4':
+    resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@ungap/structured-clone@1.3.1':
+    resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
+
+  '@vitejs/plugin-react@5.2.0':
+    resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  '@vitest/expect@4.1.6':
+    resolution: {integrity: sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==}
+
+  '@vitest/mocker@4.1.6':
+    resolution: {integrity: sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.6':
+    resolution: {integrity: sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==}
+
+  '@vitest/runner@4.1.6':
+    resolution: {integrity: sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==}
+
+  '@vitest/snapshot@4.1.6':
+    resolution: {integrity: sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==}
+
+  '@vitest/spy@4.1.6':
+    resolution: {integrity: sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==}
+
+  '@vitest/utils@4.1.6':
+    resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
+
+  accessor-fn@1.5.3:
+    resolution: {integrity: sha512-rkAofCwe/FvYFUlMB0v0gWmhqtfAtV1IUkdPbfhTUyYniu5LrC0A0UJkTH0Jv3S8SvwkmfuAlY+mQIJATdocMA==}
+    engines: {node: '>=12'}
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  baseline-browser-mapping@2.10.29:
+    resolution: {integrity: sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  better-sqlite3@12.10.0:
+    resolution: {integrity: sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
+
+  bezier-js@6.1.4:
+    resolution: {integrity: sha512-PA0FW9ZpcHbojUCMu28z9Vg/fNkwTj5YhusSAjHHDfHDGLxJ6YUKrAN2vk1fP2MMOxVw4Oko16FMlRGVBGqLKg==}
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  caniuse-lite@1.0.30001792:
+    resolution: {integrity: sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==}
+
+  canvas-color-tracker@1.3.2:
+    resolution: {integrity: sha512-ryQkDX26yJ3CXzb3hxUVNlg1NKE4REc5crLBq661Nxzr8TNd236SaEf2ffYLXyI5tSABSeguHLqcVq4vf9L3Zg==}
+    engines: {node: '>=12'}
+
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
+  cssstyle@5.3.7:
+    resolution: {integrity: sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==}
+    engines: {node: '>=20'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-binarytree@1.0.2:
+    resolution: {integrity: sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw==}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-force-3d@3.0.6:
+    resolution: {integrity: sha512-4tsKHUPLOVkyfEffZo1v6sFHvGFwAIIjt/W8IThbp08DYAsXZck+2pSHEG5W1+gQgEvFLdZkYvmJAbRM2EzMnA==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-octree@1.1.0:
+    resolution: {integrity: sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A==}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
+  data-urls@6.0.1:
+    resolution: {integrity: sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==}
+    engines: {node: '>=20'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  electron-to-chromium@1.5.356:
+    resolution: {integrity: sha512-9NgFd7m5t5MCJ5rUSjJITUXAH9mEGlrlofnMf4YEr+pz6JlP7cWmTAH+JFmbPnaSW8koVTkuW7pacORWAnA5Yw==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
+  float-tooltip@1.7.5:
+    resolution: {integrity: sha512-/kXzuDnnBqyyWyhDMH7+PfP8J/oXiAavGzcRxASOMRHFuReDtofizLLJsf7nnDLAfEaMW4pVWaXrAjtnglpEkg==}
+    engines: {node: '>=12'}
+
+  force-graph@1.51.4:
+    resolution: {integrity: sha512-TdJ2KbkoiDQ7NIRx8IPGD0mAXXpLhamS7c+b7W98b0MHG7lphnda1VOQX/98UDTsttIAdH4TcP0l0MauSnLK8w==}
+    engines: {node: '>=12'}
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
+  index-array-by@1.4.2:
+    resolution: {integrity: sha512-SP23P27OUKzXWEC/TOyWlwLviofQkCSCKONnc62eItjp69yCZZPqDQtr3Pw5gJDnPeUMqExmKydNZaJO0FU9pw==}
+    engines: {node: '>=12'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
+
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  jerrypick@1.1.2:
+    resolution: {integrity: sha512-YKnxXEekXKzhpf7CLYA0A+oDP8V0OhICNCr5lv96FvSsDEmrb0GKM776JgQvHTMjr7DTTPEVv/1Ciaw0uEWzBA==}
+    engines: {node: '>=12'}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsdom@27.4.0:
+    resolution: {integrity: sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  kapsule@1.16.3:
+    resolution: {integrity: sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg==}
+    engines: {node: '>=12'}
+
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
+  lru-cache@11.3.6:
+    resolution: {integrity: sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==}
+    engines: {node: 20 || >=22}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-react@0.561.0:
+    resolution: {integrity: sha512-Y59gMY38tl4/i0qewcqohPdEbieBy7SovpBL9IFebhc2mDd8x4PZSOsiFRkpPcOq6bj1r/mjH/Rk73gSlIJP2A==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
+
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
+  node-abi@3.92.0:
+    resolution: {integrity: sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==}
+    engines: {node: '>=10'}
+
+  node-releases@2.0.44:
+    resolution: {integrity: sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  preact@10.29.1:
+    resolution: {integrity: sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==}
+
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
+
+  react-dom@19.2.6:
+    resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
+    peerDependencies:
+      react: ^19.2.6
+
+  react-force-graph-2d@1.29.1:
+    resolution: {integrity: sha512-1Rl/1Z3xy2iTHKj6a0jRXGyiI86xUti81K+jBQZ+Oe46csaMikp47L5AjrzA9hY9fNGD63X8ffrqnvaORukCuQ==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '*'
+
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-kapsule@2.5.7:
+    resolution: {integrity: sha512-kifAF4ZPD77qZKc4CKLmozq6GY1sBzPEJTIJb0wWFK6HsePJatK3jXplZn2eeAt3x67CDozgi7/rO8fNQ/AL7A==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16.13.1'
+
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
+
+  react-refresh@0.18.0:
+    resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
+    engines: {node: '>=0.10.0'}
+
+  react-router-dom@7.15.1:
+    resolution: {integrity: sha512-AzF62gjY6U9rkMq4RfP/r2EVtQ7DMfNMjyOp/flLTCrtRylLiK4wT4pSq6O8rOXZ2eXdZYJPEYe+ifomiv+Igg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+
+  react-router@7.15.1:
+    resolution: {integrity: sha512-R8rl9HhgikFYoPJymnUtPXWbnDb3oget6lQnfIoupbt61aT9aOhRkDsY2XRhZRyX1Z/8a5sL74fXmFNm3NRK5A==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
+  react@19.2.6:
+    resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
+    engines: {node: '>=0.10.0'}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  rollup@4.60.4:
+    resolution: {integrity: sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  semver@7.8.0:
+    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinycolor2@1.6.0:
+    resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
+
+  tinyexec@1.1.2:
+    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@7.0.30:
+    resolution: {integrity: sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==}
+
+  tldts@7.0.30:
+    resolution: {integrity: sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==}
+    hasBin: true
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
+
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  vite@7.3.3:
+    resolution: {integrity: sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.6:
+    resolution: {integrity: sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.6
+      '@vitest/browser-preview': 4.1.6
+      '@vitest/browser-webdriverio': 4.1.6
+      '@vitest/coverage-istanbul': 4.1.6
+      '@vitest/coverage-v8': 4.1.6
+      '@vitest/ui': 4.1.6
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@15.1.0:
+    resolution: {integrity: sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==}
+    engines: {node: '>=20'}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+
+snapshots:
+
+  '@acemir/cssom@0.9.31': {}
+
+  '@adobe/css-tools@4.4.4': {}
+
+  '@asamuzakjp/css-color@4.1.2':
+    dependencies:
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.3.6
+
+  '@asamuzakjp/dom-selector@6.8.1':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.3.6
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.3': {}
+
+  '@babel/core@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helpers': 7.29.2
+      '@babel/parser': 7.29.3
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.28.6':
+    dependencies:
+      '@babel/compat-data': 7.29.3
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.28.6': {}
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.29.2':
+    dependencies:
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+
+  '@babel/parser@7.29.3':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/runtime@7.29.2': {}
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.3
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.4(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@exodus/bytes@1.15.0': {}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
+
+  '@rolldown/pluginutils@1.0.0-rc.3': {}
+
+  '@rollup/rollup-android-arm-eabi@4.60.4':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.4':
+    optional: true
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@tanstack/query-core@5.100.10': {}
+
+  '@tanstack/react-query@5.100.10(react@19.2.6)':
+    dependencies:
+      '@tanstack/query-core': 5.100.10
+      react: 19.2.6
+
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@tweenjs/tween.js@25.0.0': {}
+
+  '@types/aria-query@5.0.4': {}
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/better-sqlite3@7.6.13':
+    dependencies:
+      '@types/node': 24.12.4
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.9
+
+  '@types/estree@1.0.8': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/ms@2.1.0': {}
+
+  '@types/node@24.12.4':
+    dependencies:
+      undici-types: 7.16.0
+
+  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+
+  '@types/react@19.2.14':
+    dependencies:
+      csstype: 3.2.3
+
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
+
+  '@ungap/structured-clone@1.3.1': {}
+
+  '@vitejs/plugin-react@5.2.0(vite@7.3.3(@types/node@24.12.4))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-rc.3
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.18.0
+      vite: 7.3.3(@types/node@24.12.4)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/expect@4.1.6':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.6
+      '@vitest/utils': 4.1.6
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.6(vite@7.3.3(@types/node@24.12.4))':
+    dependencies:
+      '@vitest/spy': 4.1.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.3(@types/node@24.12.4)
+
+  '@vitest/pretty-format@4.1.6':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.6':
+    dependencies:
+      '@vitest/utils': 4.1.6
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.6':
+    dependencies:
+      '@vitest/pretty-format': 4.1.6
+      '@vitest/utils': 4.1.6
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.6': {}
+
+  '@vitest/utils@4.1.6':
+    dependencies:
+      '@vitest/pretty-format': 4.1.6
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  accessor-fn@1.5.3: {}
+
+  agent-base@7.1.4: {}
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@5.2.0: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
+
+  assertion-error@2.0.1: {}
+
+  bail@2.0.2: {}
+
+  base64-js@1.5.1: {}
+
+  baseline-browser-mapping@2.10.29: {}
+
+  better-sqlite3@12.10.0:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
+  bezier-js@6.1.4: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.29
+      caniuse-lite: 1.0.30001792
+      electron-to-chromium: 1.5.356
+      node-releases: 2.0.44
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  caniuse-lite@1.0.30001792: {}
+
+  canvas-color-tracker@1.3.2:
+    dependencies:
+      tinycolor2: 1.6.0
+
+  ccount@2.0.1: {}
+
+  chai@6.2.2: {}
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
+
+  chownr@1.1.4: {}
+
+  comma-separated-tokens@2.0.3: {}
+
+  convert-source-map@2.0.0: {}
+
+  cookie@1.1.1: {}
+
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  css.escape@1.5.1: {}
+
+  cssstyle@5.3.7:
+    dependencies:
+      '@asamuzakjp/css-color': 4.1.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.4(css-tree@3.2.1)
+      css-tree: 3.2.1
+      lru-cache: 11.3.6
+
+  csstype@3.2.3: {}
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-binarytree@1.0.2: {}
+
+  d3-color@3.1.0: {}
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-ease@3.0.1: {}
+
+  d3-force-3d@3.0.6:
+    dependencies:
+      d3-binarytree: 1.0.2
+      d3-dispatch: 3.0.1
+      d3-octree: 1.1.0
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-octree@1.1.0: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  data-urls@6.0.1:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 15.1.0
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  decimal.js@10.6.0: {}
+
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
+  deep-extend@0.6.0: {}
+
+  dequal@2.0.3: {}
+
+  detect-libc@2.1.2: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
+
+  electron-to-chromium@1.5.356: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+
+  entities@8.0.0: {}
+
+  es-module-lexer@2.1.0: {}
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
+  escalade@3.2.0: {}
+
+  escape-string-regexp@5.0.0: {}
+
+  estree-util-is-identifier-name@3.0.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expand-template@2.0.3: {}
+
+  expect-type@1.3.0: {}
+
+  extend@3.0.2: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  file-uri-to-path@1.0.0: {}
+
+  float-tooltip@1.7.5:
+    dependencies:
+      d3-selection: 3.0.0
+      kapsule: 1.16.3
+      preact: 10.29.1
+
+  force-graph@1.51.4:
+    dependencies:
+      '@tweenjs/tween.js': 25.0.0
+      accessor-fn: 1.5.3
+      bezier-js: 6.1.4
+      canvas-color-tracker: 1.3.2
+      d3-array: 3.2.4
+      d3-drag: 3.0.0
+      d3-force-3d: 3.0.6
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+      float-tooltip: 1.7.5
+      index-array-by: 1.4.2
+      kapsule: 1.16.3
+      lodash-es: 4.18.1
+
+  fs-constants@1.0.0: {}
+
+  fsevents@2.3.2:
+    optional: true
+
+  fsevents@2.3.3:
+    optional: true
+
+  gensync@1.0.0-beta.2: {}
+
+  github-from-package@0.0.0: {}
+
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  html-url-attributes@3.0.1: {}
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  ieee754@1.2.1: {}
+
+  indent-string@4.0.0: {}
+
+  index-array-by@1.4.2: {}
+
+  inherits@2.0.4: {}
+
+  ini@1.3.8: {}
+
+  inline-style-parser@0.2.7: {}
+
+  internmap@2.0.3: {}
+
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
+
+  is-decimal@2.0.1: {}
+
+  is-hexadecimal@2.0.1: {}
+
+  is-plain-obj@4.1.0: {}
+
+  is-potential-custom-element-name@1.0.1: {}
+
+  jerrypick@1.1.2: {}
+
+  js-tokens@4.0.0: {}
+
+  jsdom@27.4.0:
+    dependencies:
+      '@acemir/cssom': 0.9.31
+      '@asamuzakjp/dom-selector': 6.8.1
+      '@exodus/bytes': 1.15.0
+      cssstyle: 5.3.7
+      data-urls: 6.0.1
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 15.1.0
+      ws: 8.20.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  jsesc@3.1.0: {}
+
+  json5@2.2.3: {}
+
+  kapsule@1.16.3:
+    dependencies:
+      lodash-es: 4.18.1
+
+  lodash-es@4.18.1: {}
+
+  longest-streak@3.1.0: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
+  lru-cache@11.3.6: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  lucide-react@0.561.0(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+
+  lz-string@1.5.0: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  markdown-table@3.0.4: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.1
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
+  mdn-data@2.27.1: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mimic-response@3.1.0: {}
+
+  min-indent@1.0.1: {}
+
+  minimist@1.2.8: {}
+
+  mkdirp-classic@0.5.3: {}
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.12: {}
+
+  napi-build-utils@2.0.0: {}
+
+  node-abi@3.92.0:
+    dependencies:
+      semver: 7.8.0
+
+  node-releases@2.0.44: {}
+
+  object-assign@4.1.1: {}
+
+  obug@2.1.1: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  postcss@8.5.14:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  preact@10.29.1: {}
+
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.92.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
+
+  property-information@7.1.0: {}
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
+  punycode@2.3.1: {}
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
+
+  react-dom@19.2.6(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      scheduler: 0.27.0
+
+  react-force-graph-2d@1.29.1(react@19.2.6):
+    dependencies:
+      force-graph: 1.51.4
+      prop-types: 15.8.1
+      react: 19.2.6
+      react-kapsule: 2.5.7(react@19.2.6)
+
+  react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
+
+  react-kapsule@2.5.7(react@19.2.6):
+    dependencies:
+      jerrypick: 1.1.2
+      react: 19.2.6
+
+  react-markdown@10.1.0(@types/react@19.2.14)(react@19.2.6):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/react': 19.2.14
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      react: 19.2.6
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  react-refresh@0.18.0: {}
+
+  react-router-dom@7.15.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      react-router: 7.15.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+
+  react-router@7.15.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      cookie: 1.1.1
+      react: 19.2.6
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 19.2.6(react@19.2.6)
+
+  react@19.2.6: {}
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
+
+  require-from-string@2.0.2: {}
+
+  rollup@4.60.4:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.4
+      '@rollup/rollup-android-arm64': 4.60.4
+      '@rollup/rollup-darwin-arm64': 4.60.4
+      '@rollup/rollup-darwin-x64': 4.60.4
+      '@rollup/rollup-freebsd-arm64': 4.60.4
+      '@rollup/rollup-freebsd-x64': 4.60.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.4
+      '@rollup/rollup-linux-arm64-gnu': 4.60.4
+      '@rollup/rollup-linux-arm64-musl': 4.60.4
+      '@rollup/rollup-linux-loong64-gnu': 4.60.4
+      '@rollup/rollup-linux-loong64-musl': 4.60.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.4
+      '@rollup/rollup-linux-ppc64-musl': 4.60.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.4
+      '@rollup/rollup-linux-riscv64-musl': 4.60.4
+      '@rollup/rollup-linux-s390x-gnu': 4.60.4
+      '@rollup/rollup-linux-x64-gnu': 4.60.4
+      '@rollup/rollup-linux-x64-musl': 4.60.4
+      '@rollup/rollup-openbsd-x64': 4.60.4
+      '@rollup/rollup-openharmony-arm64': 4.60.4
+      '@rollup/rollup-win32-arm64-msvc': 4.60.4
+      '@rollup/rollup-win32-ia32-msvc': 4.60.4
+      '@rollup/rollup-win32-x64-gnu': 4.60.4
+      '@rollup/rollup-win32-x64-msvc': 4.60.4
+      fsevents: 2.3.3
+
+  safe-buffer@5.2.1: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
+  scheduler@0.27.0: {}
+
+  semver@6.3.1: {}
+
+  semver@7.8.0: {}
+
+  set-cookie-parser@2.7.2: {}
+
+  siginfo@2.0.0: {}
+
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
+  source-map-js@1.2.1: {}
+
+  space-separated-tokens@2.0.2: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
+  strip-json-comments@2.0.1: {}
+
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
+
+  symbol-tree@3.2.4: {}
+
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  tinybench@2.9.0: {}
+
+  tinycolor2@1.6.0: {}
+
+  tinyexec@1.1.2: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
+
+  tldts-core@7.0.30: {}
+
+  tldts@7.0.30:
+    dependencies:
+      tldts-core: 7.0.30
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.30
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
+
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  typescript@5.9.3: {}
+
+  undici-types@7.16.0: {}
+
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  util-deprecate@1.0.2: {}
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
+
+  vite@7.3.3(@types/node@24.12.4):
+    dependencies:
+      esbuild: 0.27.7
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.14
+      rollup: 4.60.4
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 24.12.4
+      fsevents: 2.3.3
+
+  vitest@4.1.6(@types/node@24.12.4)(jsdom@27.4.0)(vite@7.3.3(@types/node@24.12.4)):
+    dependencies:
+      '@vitest/expect': 4.1.6
+      '@vitest/mocker': 4.1.6(vite@7.3.3(@types/node@24.12.4))
+      '@vitest/pretty-format': 4.1.6
+      '@vitest/runner': 4.1.6
+      '@vitest/snapshot': 4.1.6
+      '@vitest/spy': 4.1.6
+      '@vitest/utils': 4.1.6
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 7.3.3(@types/node@24.12.4)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.12.4
+      jsdom: 27.4.0
+    transitivePeerDependencies:
+      - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@15.1.0:
+    dependencies:
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  wrappy@1.0.2: {}
+
+  ws@8.20.1: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
+
+  yallist@3.1.1: {}
+
+  zwitch@2.0.4: {}

--- a/playground/server/cli.ts
+++ b/playground/server/cli.ts
@@ -1,0 +1,266 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { getConfig } from "./config";
+import { ApiError } from "./http";
+import type { CliCommandSpec, CliRunRequest, CliRunResult } from "./types";
+
+const execFileAsync = promisify(execFile);
+
+export const CLI_COMMANDS: CliCommandSpec[] = [
+  {
+    id: "model.pull",
+    label: "Download SLM model",
+    description: "Runs quaid model pull for a fact-extraction SLM alias.",
+    risky: true,
+    params: [{ name: "alias", label: "Model alias", required: true, defaultValue: "phi-3.5-mini" }]
+  },
+  {
+    id: "extraction.status",
+    label: "Extraction status",
+    description: "Shows fact extraction runtime and queue status.",
+    risky: false,
+    params: []
+  },
+  {
+    id: "extraction.enable",
+    label: "Enable extraction",
+    description: "Enables conversation fact extraction for the active DB.",
+    risky: true,
+    params: []
+  },
+  {
+    id: "extraction.disable",
+    label: "Disable extraction",
+    description: "Disables conversation fact extraction for the active DB.",
+    risky: true,
+    params: []
+  },
+  {
+    id: "config.set",
+    label: "Set config value",
+    description: "Sets one Quaid config key in the active DB.",
+    risky: true,
+    params: [
+      { name: "key", label: "Key", required: true, defaultValue: "extraction.model_alias" },
+      { name: "value", label: "Value", required: true, defaultValue: "phi-3.5-mini" }
+    ]
+  },
+  {
+    id: "config.get",
+    label: "Get config value",
+    description: "Reads one Quaid config key from the active DB.",
+    risky: false,
+    params: [{ name: "key", label: "Key", required: true, defaultValue: "extraction.model_alias" }]
+  },
+  {
+    id: "extract.session",
+    label: "Extract session",
+    description: "Enqueues fact extraction for one conversation session.",
+    risky: true,
+    params: [
+      { name: "sessionId", label: "Session ID", required: true },
+      { name: "force", label: "Force", type: "boolean", defaultValue: false }
+    ]
+  },
+  {
+    id: "extract.all",
+    label: "Extract all",
+    description: "Enqueues fact extraction across all conversation sessions.",
+    risky: true,
+    params: [{ name: "force", label: "Force", type: "boolean", defaultValue: false }]
+  },
+  {
+    id: "embed.all",
+    label: "Embed all",
+    description: "Refreshes all embeddings in the active DB.",
+    risky: true,
+    params: []
+  },
+  {
+    id: "embed.stale",
+    label: "Embed stale",
+    description: "Refreshes stale embeddings in the active DB.",
+    risky: true,
+    params: []
+  },
+  {
+    id: "status.json",
+    label: "Runtime status",
+    description: "Runs quaid status --json.",
+    risky: false,
+    params: []
+  },
+  {
+    id: "stats.json",
+    label: "Memory stats",
+    description: "Runs quaid --json stats.",
+    risky: false,
+    params: []
+  },
+  {
+    id: "mcp.call",
+    label: "Raw MCP tool call",
+    description: "Calls an existing Quaid MCP tool through quaid call.",
+    risky: true,
+    params: [
+      { name: "tool", label: "Tool", required: true, defaultValue: "memory_stats" },
+      { name: "params", label: "JSON params", type: "json", defaultValue: "{}" }
+    ]
+  }
+];
+
+const specsById = new Map(CLI_COMMANDS.map((command) => [command.id, command]));
+
+function stringParam(params: Record<string, unknown>, name: string, fallback = ""): string {
+  const value = params[name];
+  if (value == null || value === "") {
+    return fallback;
+  }
+  return String(value);
+}
+
+function boolParam(params: Record<string, unknown>, name: string, fallback = false): boolean {
+  const value = params[name];
+  if (value == null || value === "") {
+    return fallback;
+  }
+  if (typeof value === "boolean") {
+    return value;
+  }
+  return ["1", "true", "yes", "on"].includes(String(value).toLowerCase());
+}
+
+function jsonParam(params: Record<string, unknown>, name: string): string {
+  const value = params[name];
+  if (typeof value === "string") {
+    JSON.parse(value);
+    return value;
+  }
+  return JSON.stringify(value ?? {});
+}
+
+export function buildCliArgs(request: CliRunRequest): string[] {
+  const config = getConfig();
+  const params = request.params ?? {};
+  const base = ["--db", config.dbPath, "--model", config.embeddingModel];
+
+  switch (request.id) {
+    case "model.pull":
+      return ["model", "pull", stringParam(params, "alias", "phi-3.5-mini")];
+    case "extraction.status":
+      return [...base, "extraction", "status"];
+    case "extraction.enable":
+      return [...base, "extraction", "enable"];
+    case "extraction.disable":
+      return [...base, "extraction", "disable"];
+    case "config.set":
+      return [...base, "config", "set", stringParam(params, "key"), stringParam(params, "value")];
+    case "config.get":
+      return [...base, "config", "get", stringParam(params, "key")];
+    case "extract.session": {
+      const args = [...base, "extract", stringParam(params, "sessionId")];
+      if (boolParam(params, "force")) {
+        args.push("--force");
+      }
+      return args;
+    }
+    case "extract.all": {
+      const args = [...base, "extract", "--all"];
+      if (boolParam(params, "force")) {
+        args.push("--force");
+      }
+      return args;
+    }
+    case "embed.all":
+      return [...base, "embed", "--all"];
+    case "embed.stale":
+      return [...base, "embed", "--stale"];
+    case "status.json":
+      return [...base, "status", "--json"];
+    case "stats.json":
+      return [...base, "--json", "stats"];
+    case "mcp.call":
+      return [
+        ...base,
+        "call",
+        stringParam(params, "tool", "memory_stats"),
+        jsonParam(params, "params")
+      ];
+    default:
+      throw new ApiError(400, `Unknown CLI command id: ${request.id}`);
+  }
+}
+
+function parseStdout(stdout: string): unknown | undefined {
+  const trimmed = stdout.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return undefined;
+  }
+}
+
+export async function runCliCommand(request: CliRunRequest): Promise<CliRunResult> {
+  const spec = specsById.get(request.id);
+  if (!spec) {
+    throw new ApiError(400, `Unknown CLI command id: ${request.id}`);
+  }
+  if (spec.risky && request.confirmed !== true) {
+    throw new ApiError(409, `Command requires confirmation: ${request.id}`);
+  }
+
+  const args = buildCliArgs(request);
+  const config = getConfig();
+
+  try {
+    const result = await execFileAsync(config.quaidBin, args, {
+      cwd: config.rootDir,
+      windowsHide: true,
+      timeout: 10 * 60 * 1000,
+      maxBuffer: 20 * 1024 * 1024
+    });
+    return {
+      id: request.id,
+      args,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      exitCode: 0,
+      parsed: parseStdout(result.stdout)
+    };
+  } catch (error) {
+    const err = error as Error & {
+      stdout?: string;
+      stderr?: string;
+      code?: number;
+    };
+    return {
+      id: request.id,
+      args,
+      stdout: err.stdout ?? "",
+      stderr: err.stderr ?? err.message,
+      exitCode: typeof err.code === "number" ? err.code : 1,
+      parsed: parseStdout(err.stdout ?? "")
+    };
+  }
+}
+
+export async function callToolViaCli(tool: string, params: unknown): Promise<unknown> {
+  const result = await runCliCommand({
+    id: "mcp.call",
+    params: {
+      tool,
+      params
+    },
+    confirmed: true
+  });
+  if (result.exitCode !== 0) {
+    throw new ApiError(502, `quaid call failed for ${tool}`, {
+      stdout: result.stdout,
+      stderr: result.stderr
+    });
+  }
+  return result.parsed ?? result.stdout;
+}

--- a/playground/server/config.ts
+++ b/playground/server/config.ts
@@ -1,0 +1,56 @@
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { PlaygroundConfig } from "./types";
+
+const serverDir = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(serverDir, "..");
+
+function defaultDbPath(): string {
+  return path.join(os.homedir(), ".quaid", "memory.db");
+}
+
+function envFlag(name: string, defaultValue: boolean): boolean {
+  const raw = process.env[name];
+  if (raw == null || raw === "") {
+    return defaultValue;
+  }
+  return ["1", "true", "yes", "on"].includes(raw.toLowerCase());
+}
+
+export function getConfig(): PlaygroundConfig {
+  const httpPort = Number(process.env.QUAID_HTTP_PORT ?? "3112");
+  const explicitMcpUrl = process.env.QUAID_MCP_URL?.trim();
+  const mcpUrl = explicitMcpUrl || `http://127.0.0.1:${httpPort}`;
+
+  return {
+    rootDir,
+    profilesDir: path.join(rootDir, ".quaid-profiles"),
+    quaidBin: process.env.QUAID_BIN?.trim() || "quaid",
+    dbPath: process.env.QUAID_DB?.trim() || defaultDbPath(),
+    embeddingModel: process.env.QUAID_MODEL?.trim() || "small",
+    httpPort,
+    mcpUrl,
+    runtimeMode: explicitMcpUrl ? "external" : "managed",
+    cliFallbackForMcp: envFlag("QUAID_PLAYGROUND_MCP_CLI_FALLBACK", true),
+    autoInitDb: envFlag("QUAID_PLAYGROUND_AUTO_INIT", true),
+    autoEnableExtraction: envFlag("QUAID_PLAYGROUND_AUTO_ENABLE_EXTRACTION", false)
+  };
+}
+
+export function publicConfig() {
+  const config = getConfig();
+  return {
+    rootDir: config.rootDir,
+    profilesDir: config.profilesDir,
+    quaidBin: config.quaidBin,
+    dbPath: config.dbPath,
+    embeddingModel: config.embeddingModel,
+    httpPort: config.httpPort,
+    mcpUrl: config.mcpUrl,
+    runtimeMode: config.runtimeMode,
+    cliFallbackForMcp: config.cliFallbackForMcp,
+    autoInitDb: config.autoInitDb,
+    autoEnableExtraction: config.autoEnableExtraction
+  };
+}

--- a/playground/server/db.ts
+++ b/playground/server/db.ts
@@ -1,0 +1,412 @@
+import fs from "node:fs";
+import Database from "better-sqlite3";
+import { getConfig } from "./config";
+import { ApiError } from "./http";
+import type { GraphData, TreeNode } from "./types";
+
+type SqliteDb = InstanceType<typeof Database>;
+
+function openReadonly(): SqliteDb {
+  const config = getConfig();
+  if (!fs.existsSync(config.dbPath)) {
+    throw new ApiError(404, `Quaid DB does not exist: ${config.dbPath}`);
+  }
+  const db = new Database(config.dbPath, {
+    readonly: true,
+    fileMustExist: true
+  });
+  db.pragma("query_only = ON");
+  return db;
+}
+
+function one<T>(db: SqliteDb, sql: string, params: unknown[] = []): T | undefined {
+  return db.prepare(sql).get(...params) as T | undefined;
+}
+
+function all<T>(db: SqliteDb, sql: string, params: unknown[] = []): T[] {
+  return db.prepare(sql).all(...params) as T[];
+}
+
+export function getDbStatus() {
+  const config = getConfig();
+  if (!fs.existsSync(config.dbPath)) {
+    return {
+      databaseExists: false,
+      dbPath: config.dbPath,
+      pageCount: 0,
+      collections: [],
+      config: {}
+    };
+  }
+
+  const db = openReadonly();
+  try {
+    const pageCount = one<{ count: number }>(db, "SELECT COUNT(*) AS count FROM pages")?.count ?? 0;
+    const linkCount = one<{ count: number }>(db, "SELECT COUNT(*) AS count FROM links")?.count ?? 0;
+    const embeddingJobs = one<{ count: number }>(
+      db,
+      "SELECT COUNT(*) AS count FROM embedding_jobs WHERE job_state IN ('pending', 'running')"
+    )?.count ?? 0;
+    const extractionQueue = one<{ count: number }>(
+      db,
+      "SELECT COUNT(*) AS count FROM extraction_queue WHERE status IN ('pending', 'running')"
+    )?.count ?? 0;
+    const activeEmbedding = one<{ name: string; dimensions: number }>(
+      db,
+      "SELECT name, dimensions FROM embedding_models WHERE active = 1 LIMIT 1"
+    );
+    const configRows = all<{ key: string; value: string }>(
+      db,
+      "SELECT key, value FROM config WHERE key IN ('embedding_model', 'embedding_dimensions', 'extraction.enabled', 'extraction.model_alias', 'graph_depth') ORDER BY key"
+    );
+    const collections = getCollectionsFromDb(db);
+
+    return {
+      databaseExists: true,
+      dbPath: config.dbPath,
+      pageCount,
+      linkCount,
+      embeddingJobs,
+      extractionQueue,
+      activeEmbedding,
+      collections,
+      config: Object.fromEntries(configRows.map((row) => [row.key, row.value]))
+    };
+  } finally {
+    db.close();
+  }
+}
+
+export function getCollections() {
+  const db = openReadonly();
+  try {
+    return getCollectionsFromDb(db);
+  } finally {
+    db.close();
+  }
+}
+
+function getCollectionsFromDb(db: SqliteDb) {
+  return all<{
+    id: number;
+    name: string;
+    root_path: string;
+    state: string;
+    writable: number;
+    is_write_target: number;
+    needs_full_sync: number;
+    last_sync_at: string | null;
+    page_count: number;
+  }>(
+    db,
+    `SELECT c.id,
+            c.name,
+            c.root_path,
+            c.state,
+            c.writable,
+            c.is_write_target,
+            c.needs_full_sync,
+            c.last_sync_at,
+            COUNT(p.id) AS page_count
+       FROM collections c
+       LEFT JOIN pages p ON p.collection_id = c.id
+      GROUP BY c.id
+      ORDER BY c.is_write_target DESC, c.name ASC`
+  );
+}
+
+export function getDbTree(): TreeNode[] {
+  const db = openReadonly();
+  try {
+    const pages = all<{
+      id: number;
+      collection_name: string;
+      slug: string;
+      type: string;
+      title: string;
+      updated_at: string;
+    }>(
+      db,
+      `SELECT p.id, c.name AS collection_name, p.slug, p.type, p.title, p.updated_at
+         FROM pages p
+         JOIN collections c ON c.id = p.collection_id
+        WHERE p.quarantined_at IS NULL
+        ORDER BY c.name, p.slug
+        LIMIT 2000`
+    );
+    const rawImports = all<{
+      id: number;
+      collection_name: string;
+      slug: string;
+      file_path: string;
+      created_at: string;
+      content_hash: string;
+    }>(
+      db,
+      `SELECT r.id, c.name AS collection_name, p.slug, r.file_path, r.created_at, r.content_hash
+         FROM raw_imports r
+         JOIN pages p ON p.id = r.page_id
+         JOIN collections c ON c.id = p.collection_id
+        WHERE r.is_active = 1
+        ORDER BY c.name, r.file_path
+        LIMIT 2000`
+    );
+
+    return [
+      makePathTree(
+        "pages",
+        "Pages",
+        pages.map((page) => ({
+          id: `page:${page.id}`,
+          path: `${page.collection_name}/${page.slug}`,
+          label: page.slug.split("/").at(-1) ?? page.slug,
+          type: "page" as const,
+          meta: page
+        }))
+      ),
+      makePathTree(
+        "raw",
+        "Raw imports",
+        rawImports.map((raw) => ({
+          id: `raw:${raw.id}`,
+          path: `${raw.collection_name}/${raw.file_path || raw.slug}`,
+          label: (raw.file_path || raw.slug).split(/[\\/]/).at(-1) ?? raw.slug,
+          type: "raw-import" as const,
+          meta: raw
+        }))
+      )
+    ];
+  } finally {
+    db.close();
+  }
+}
+
+function makePathTree(rootId: string, label: string, leaves: Array<Omit<TreeNode, "children">>): TreeNode {
+  const root: TreeNode = { id: rootId, label, type: "root", children: [] };
+  for (const leaf of leaves) {
+    const parts = (leaf.path ?? leaf.label).split(/[\\/]/).filter(Boolean);
+    let cursor = root;
+    parts.slice(0, -1).forEach((part, index) => {
+      cursor.children ??= [];
+      const existing = cursor.children.find((child) => child.type === "directory" && child.label === part);
+      if (existing) {
+        cursor = existing;
+        return;
+      }
+      const child: TreeNode = {
+        id: `${rootId}:${parts.slice(0, index + 1).join("/")}`,
+        label: part,
+        type: "directory",
+        children: []
+      };
+      cursor.children.push(child);
+      cursor = child;
+    });
+    cursor.children ??= [];
+    cursor.children.push({
+      ...leaf,
+      label: parts.at(-1) ?? leaf.label
+    });
+  }
+  return root;
+}
+
+export function getRawImport(id: number) {
+  const db = openReadonly();
+  try {
+    const row = one<{
+      id: number;
+      slug: string;
+      title: string;
+      file_path: string;
+      raw_bytes: Buffer;
+      content_hash: string;
+      created_at: string;
+    }>(
+      db,
+      `SELECT r.id, p.slug, p.title, r.file_path, r.raw_bytes, r.content_hash, r.created_at
+         FROM raw_imports r
+         JOIN pages p ON p.id = r.page_id
+        WHERE r.id = ?1`,
+      [id]
+    );
+    if (!row) {
+      throw new ApiError(404, `Raw import not found: ${id}`);
+    }
+    return {
+      id: row.id,
+      slug: row.slug,
+      title: row.title,
+      filePath: row.file_path,
+      contentHash: row.content_hash,
+      createdAt: row.created_at,
+      content: row.raw_bytes.toString("utf8")
+    };
+  } finally {
+    db.close();
+  }
+}
+
+export function getPageBySlug(slug: string) {
+  const db = openReadonly();
+  try {
+    const normalized = slug.includes("::") ? slug.split("::").slice(1).join("::") : slug;
+    const row = one<{
+      id: number;
+      collection_name: string;
+      slug: string;
+      uuid: string | null;
+      type: string;
+      title: string;
+      summary: string;
+      compiled_truth: string;
+      timeline: string;
+      frontmatter: string;
+      wing: string;
+      room: string;
+      version: number;
+      created_at: string;
+      updated_at: string;
+    }>(
+      db,
+      `SELECT p.*, c.name AS collection_name
+         FROM pages p
+         JOIN collections c ON c.id = p.collection_id
+        WHERE p.slug = ?1 OR (c.name || '::' || p.slug) = ?2
+        ORDER BY p.updated_at DESC
+        LIMIT 1`,
+      [normalized, slug]
+    );
+    if (!row) {
+      throw new ApiError(404, `Page not found: ${slug}`);
+    }
+    const markdown = [
+      "---",
+      `title: ${row.title}`,
+      `type: ${row.type}`,
+      `slug: ${row.collection_name}::${row.slug}`,
+      "---",
+      "",
+      row.summary ? `# Summary\n\n${row.summary}` : "",
+      row.compiled_truth ? `# Compiled Truth\n\n${row.compiled_truth}` : "",
+      row.timeline ? `# Timeline\n\n${row.timeline}` : ""
+    ]
+      .filter(Boolean)
+      .join("\n\n");
+    return {
+      ...row,
+      canonicalSlug: `${row.collection_name}::${row.slug}`,
+      markdown
+    };
+  } finally {
+    db.close();
+  }
+}
+
+export function getGraph(scope: "whole" | "focused", slug?: string, depth = 2): GraphData {
+  const db = openReadonly();
+  try {
+    if (scope === "focused" && slug) {
+      return getFocusedGraph(db, slug, depth);
+    }
+    return getWholeGraph(db);
+  } finally {
+    db.close();
+  }
+}
+
+function getWholeGraph(db: SqliteDb): GraphData {
+  const nodes = all<{ id: number; slug: string; title: string; type: string }>(
+    db,
+    "SELECT id, slug, title, type FROM pages WHERE quarantined_at IS NULL ORDER BY updated_at DESC LIMIT 800"
+  );
+  const nodeIds = new Set(nodes.map((node) => node.id));
+  const links = all<{ source: number; target: number; relationship: string }>(
+    db,
+    `SELECT from_page_id AS source, to_page_id AS target, relationship
+       FROM links
+      WHERE valid_until IS NULL
+      LIMIT 2000`
+  ).filter((edge) => nodeIds.has(edge.source) && nodeIds.has(edge.target));
+  return {
+    nodes: nodes.map((node) => ({
+      id: String(node.id),
+      label: node.slug,
+      title: node.title,
+      type: node.type
+    })),
+    links: links.map((edge) => ({
+      source: String(edge.source),
+      target: String(edge.target),
+      label: edge.relationship
+    }))
+  };
+}
+
+function getFocusedGraph(db: SqliteDb, slug: string, depth: number): GraphData {
+  const root = one<{ id: number }>(
+    db,
+    `SELECT p.id
+       FROM pages p
+       JOIN collections c ON c.id = p.collection_id
+      WHERE p.slug = ?1 OR (c.name || '::' || p.slug) = ?2
+      LIMIT 1`,
+    [slug.includes("::") ? slug.split("::").slice(1).join("::") : slug, slug]
+  );
+  if (!root) {
+    throw new ApiError(404, `Page not found: ${slug}`);
+  }
+  const seen = new Set<number>([root.id]);
+  let frontier = [root.id];
+  const maxDepth = Math.max(0, Math.min(depth, 4));
+  for (let i = 0; i < maxDepth; i += 1) {
+    const next = new Set<number>();
+    for (const id of frontier) {
+      const rows = all<{ id: number }>(
+        db,
+        `SELECT to_page_id AS id FROM links WHERE from_page_id = ?1 AND valid_until IS NULL
+         UNION
+         SELECT from_page_id AS id FROM links WHERE to_page_id = ?1 AND valid_until IS NULL`,
+        [id]
+      );
+      rows.forEach((row) => {
+        if (!seen.has(row.id)) {
+          next.add(row.id);
+          seen.add(row.id);
+        }
+      });
+    }
+    frontier = [...next];
+    if (frontier.length === 0 || seen.size > 400) {
+      break;
+    }
+  }
+  const placeholders = [...seen].map(() => "?").join(",");
+  const nodes = all<{ id: number; slug: string; title: string; type: string }>(
+    db,
+    `SELECT id, slug, title, type FROM pages WHERE id IN (${placeholders})`,
+    [...seen]
+  );
+  const links = all<{ source: number; target: number; relationship: string }>(
+    db,
+    `SELECT from_page_id AS source, to_page_id AS target, relationship
+       FROM links
+      WHERE valid_until IS NULL
+        AND from_page_id IN (${placeholders})
+        AND to_page_id IN (${placeholders})`,
+    [...seen, ...seen]
+  );
+  return {
+    nodes: nodes.map((node) => ({
+      id: String(node.id),
+      label: node.slug,
+      title: node.title,
+      type: node.type
+    })),
+    links: links.map((edge) => ({
+      source: String(edge.source),
+      target: String(edge.target),
+      label: edge.relationship
+    }))
+  };
+}

--- a/playground/server/files.ts
+++ b/playground/server/files.ts
@@ -1,0 +1,116 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { getCollections } from "./db";
+import { ApiError } from "./http";
+import { isPathInside } from "./pathSafety";
+import type { TreeNode } from "./types";
+
+const MAX_FILE_BYTES = 2 * 1024 * 1024;
+
+export async function listLiveFiles(rootPath: string, relativePath = "", depth = 3): Promise<TreeNode> {
+  const root = await allowedRoot(rootPath);
+  const target = path.resolve(root, relativePath);
+  if (!isPathInside(root, target)) {
+    throw new ApiError(403, "Requested path is outside the selected collection root");
+  }
+  return readDirNode(root, target, depth);
+}
+
+export async function readLiveFile(filePath: string) {
+  const roots = await allowedRoots();
+  const target = path.resolve(filePath);
+  const root = roots.find((candidate) => isPathInside(candidate, target));
+  if (!root) {
+    throw new ApiError(403, "File is outside all active collection roots");
+  }
+  const stats = await fs.stat(target);
+  if (!stats.isFile()) {
+    throw new ApiError(400, "Path is not a file");
+  }
+  if (stats.size > MAX_FILE_BYTES) {
+    throw new ApiError(413, "File is too large for the playground viewer");
+  }
+  return {
+    path: target,
+    size: stats.size,
+    modifiedAt: stats.mtime.toISOString(),
+    content: await fs.readFile(target, "utf8")
+  };
+}
+
+async function allowedRoot(rootPath: string): Promise<string> {
+  const roots = await allowedRoots();
+  const resolved = path.resolve(rootPath);
+  const match = roots.find((root) => path.resolve(root) === resolved);
+  if (!match) {
+    throw new ApiError(403, "Unknown collection root");
+  }
+  return match;
+}
+
+async function allowedRoots(): Promise<string[]> {
+  return getCollections()
+    .map((collection) => String(collection.root_path ?? "").trim())
+    .filter(Boolean)
+    .map((root) => path.resolve(root));
+}
+
+async function readDirNode(root: string, target: string, depth: number): Promise<TreeNode> {
+  const stats = await fs.stat(target);
+  if (stats.isFile()) {
+    return {
+      id: target,
+      label: path.basename(target),
+      path: target,
+      type: "file",
+      meta: {
+        size: stats.size,
+        modifiedAt: stats.mtime.toISOString(),
+        relativePath: path.relative(root, target)
+      }
+    };
+  }
+
+  const entries = await fs.readdir(target, { withFileTypes: true });
+  const children: TreeNode[] = [];
+  for (const entry of entries.sort((a, b) => Number(b.isDirectory()) - Number(a.isDirectory()) || a.name.localeCompare(b.name))) {
+    if (entry.name.startsWith(".git")) {
+      continue;
+    }
+    const childPath = path.join(target, entry.name);
+    if (entry.isDirectory()) {
+      children.push(
+        depth > 0
+          ? await readDirNode(root, childPath, depth - 1)
+          : {
+              id: childPath,
+              label: entry.name,
+              path: childPath,
+              type: "directory",
+              children: []
+            }
+      );
+    } else if (entry.isFile()) {
+      const childStats = await fs.stat(childPath);
+      children.push({
+        id: childPath,
+        label: entry.name,
+        path: childPath,
+        type: "file",
+        meta: {
+          size: childStats.size,
+          modifiedAt: childStats.mtime.toISOString(),
+          relativePath: path.relative(root, childPath)
+        }
+      });
+    }
+  }
+
+  return {
+    id: target,
+    label: path.basename(target) || target,
+    path: target,
+    type: target === root ? "root" : "directory",
+    children
+  };
+}

--- a/playground/server/http.ts
+++ b/playground/server/http.ts
@@ -1,0 +1,79 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { ApiErrorShape } from "./types";
+
+export type Middleware = (
+  req: IncomingMessage,
+  res: ServerResponse,
+  next: (error?: unknown) => void
+) => void;
+
+export class ApiError extends Error {
+  readonly status: number;
+  readonly details?: unknown;
+
+  constructor(status: number, message: string, details?: unknown) {
+    super(message);
+    this.status = status;
+    this.details = details;
+  }
+}
+
+export function sendJson(res: ServerResponse, status: number, value: unknown): void {
+  const body = JSON.stringify(value, null, 2);
+  res.statusCode = status;
+  res.setHeader("content-type", "application/json; charset=utf-8");
+  res.setHeader("cache-control", "no-store");
+  res.end(body);
+}
+
+export function sendText(res: ServerResponse, status: number, value: string, contentType = "text/plain; charset=utf-8"): void {
+  res.statusCode = status;
+  res.setHeader("content-type", contentType);
+  res.setHeader("cache-control", "no-store");
+  res.end(value);
+}
+
+export function sendError(res: ServerResponse, error: unknown): void {
+  const apiError = normalizeError(error);
+  const body: ApiErrorShape = {
+    error: apiError.message,
+    details: apiError.details
+  };
+  sendJson(res, apiError.status, body);
+}
+
+export function normalizeError(error: unknown): ApiError {
+  if (error instanceof ApiError) {
+    return error;
+  }
+  if (error instanceof Error) {
+    return new ApiError(500, error.message);
+  }
+  return new ApiError(500, String(error));
+}
+
+export async function readJsonBody<T = unknown>(req: IncomingMessage): Promise<T> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  const raw = Buffer.concat(chunks).toString("utf8").trim();
+  if (!raw) {
+    return {} as T;
+  }
+  try {
+    return JSON.parse(raw) as T;
+  } catch (error) {
+    throw new ApiError(400, "Request body must be valid JSON", error);
+  }
+}
+
+export function requireMethod(req: IncomingMessage, method: string): void {
+  if (req.method !== method) {
+    throw new ApiError(405, `Expected ${method}, got ${req.method ?? "UNKNOWN"}`);
+  }
+}
+
+export function parseUrl(req: IncomingMessage): URL {
+  return new URL(req.url ?? "/", "http://127.0.0.1");
+}

--- a/playground/server/index.ts
+++ b/playground/server/index.ts
@@ -1,0 +1,214 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { CLI_COMMANDS, runCliCommand } from "./cli";
+import { publicConfig } from "./config";
+import { getCollections, getDbStatus, getDbTree, getGraph, getPageBySlug, getRawImport } from "./db";
+import { listLiveFiles, readLiveFile } from "./files";
+import { ApiError, parseUrl, readJsonBody, requireMethod, sendError, sendJson, type Middleware } from "./http";
+import { callMcpTool, listMcpTools } from "./mcp";
+import { createProfile, embedProfile, listProfiles, queryProfile } from "./profiles";
+import { ensureManagedRuntimeStarted, restartRuntime, runtimeStatus, startRuntime, stopRuntime } from "./runtime";
+import type { CliRunRequest } from "./types";
+
+type Handler = (req: IncomingMessage, res: ServerResponse, url: URL) => Promise<void>;
+
+function route(pathname: string, method: string, expectedPath: string, expectedMethod: string): boolean {
+  return pathname === expectedPath && method === expectedMethod;
+}
+
+async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const url = parseUrl(req);
+  const method = req.method ?? "GET";
+
+  const routes: Handler[] = [
+    statusRoute,
+    runtimeRoute,
+    mcpRoute,
+    cliRoute,
+    dbRoute,
+    filesRoute,
+    profilesRoute
+  ];
+
+  for (const handler of routes) {
+    const handled = await maybeHandle(handler, req, res, url);
+    if (handled) {
+      return;
+    }
+  }
+
+  throw new ApiError(404, `Unknown API route: ${method} ${url.pathname}`);
+}
+
+async function maybeHandle(
+  handler: Handler,
+  req: IncomingMessage,
+  res: ServerResponse,
+  url: URL
+): Promise<boolean> {
+  const before = res.writableEnded;
+  await handler(req, res, url);
+  return !before && res.writableEnded;
+}
+
+async function statusRoute(req: IncomingMessage, res: ServerResponse, url: URL): Promise<void> {
+  if (!route(url.pathname, req.method ?? "GET", "/status", "GET")) {
+    return;
+  }
+  sendJson(res, 200, {
+    config: publicConfig(),
+    runtime: runtimeStatus(),
+    database: getDbStatus()
+  });
+}
+
+async function runtimeRoute(req: IncomingMessage, res: ServerResponse, url: URL): Promise<void> {
+  if (!url.pathname.startsWith("/runtime/")) {
+    return;
+  }
+  requireMethod(req, "POST");
+  switch (url.pathname) {
+    case "/runtime/start":
+      sendJson(res, 200, startRuntime());
+      return;
+    case "/runtime/stop":
+      sendJson(res, 200, stopRuntime());
+      return;
+    case "/runtime/restart":
+      sendJson(res, 200, restartRuntime());
+      return;
+    default:
+      throw new ApiError(404, `Unknown runtime route: ${url.pathname}`);
+  }
+}
+
+async function mcpRoute(req: IncomingMessage, res: ServerResponse, url: URL): Promise<void> {
+  if (route(url.pathname, req.method ?? "GET", "/mcp/tools", "GET")) {
+    sendJson(res, 200, await listMcpTools());
+    return;
+  }
+  if (route(url.pathname, req.method ?? "POST", "/mcp/call", "POST")) {
+    const body = await readJsonBody<{ name?: string; args?: unknown }>(req);
+    if (!body.name) {
+      throw new ApiError(400, "MCP tool name is required");
+    }
+    sendJson(res, 200, await callMcpTool(body.name, body.args ?? {}));
+  }
+}
+
+async function cliRoute(req: IncomingMessage, res: ServerResponse, url: URL): Promise<void> {
+  if (route(url.pathname, req.method ?? "GET", "/cli/catalog", "GET")) {
+    sendJson(res, 200, CLI_COMMANDS);
+    return;
+  }
+  if (route(url.pathname, req.method ?? "POST", "/cli/run", "POST")) {
+    const body = await readJsonBody<CliRunRequest>(req);
+    sendJson(res, 200, await runCliCommand(body));
+  }
+}
+
+async function dbRoute(req: IncomingMessage, res: ServerResponse, url: URL): Promise<void> {
+  if (!url.pathname.startsWith("/db/")) {
+    return;
+  }
+  requireMethod(req, "GET");
+  switch (url.pathname) {
+    case "/db/status":
+      sendJson(res, 200, getDbStatus());
+      return;
+    case "/db/collections":
+      sendJson(res, 200, getCollections());
+      return;
+    case "/db/tree":
+      sendJson(res, 200, getDbTree());
+      return;
+    case "/db/page": {
+      const slug = url.searchParams.get("slug");
+      if (!slug) {
+        throw new ApiError(400, "slug query parameter is required");
+      }
+      sendJson(res, 200, getPageBySlug(slug));
+      return;
+    }
+    case "/db/raw-file": {
+      const id = Number(url.searchParams.get("id"));
+      if (!Number.isFinite(id)) {
+        throw new ApiError(400, "numeric id query parameter is required");
+      }
+      sendJson(res, 200, getRawImport(id));
+      return;
+    }
+    case "/db/graph": {
+      const scope = url.searchParams.get("scope") === "focused" ? "focused" : "whole";
+      const slug = url.searchParams.get("slug") ?? undefined;
+      const depth = Number(url.searchParams.get("depth") ?? "2");
+      sendJson(res, 200, getGraph(scope, slug, depth));
+      return;
+    }
+    default:
+      throw new ApiError(404, `Unknown DB route: ${url.pathname}`);
+  }
+}
+
+async function filesRoute(req: IncomingMessage, res: ServerResponse, url: URL): Promise<void> {
+  if (!url.pathname.startsWith("/files/")) {
+    return;
+  }
+  requireMethod(req, "GET");
+  if (url.pathname === "/files/tree") {
+    const root = url.searchParams.get("root");
+    if (!root) {
+      throw new ApiError(400, "root query parameter is required");
+    }
+    const relativePath = url.searchParams.get("path") ?? "";
+    sendJson(res, 200, await listLiveFiles(root, relativePath));
+    return;
+  }
+  if (url.pathname === "/files/read") {
+    const filePath = url.searchParams.get("path");
+    if (!filePath) {
+      throw new ApiError(400, "path query parameter is required");
+    }
+    sendJson(res, 200, await readLiveFile(filePath));
+    return;
+  }
+  throw new ApiError(404, `Unknown file route: ${url.pathname}`);
+}
+
+async function profilesRoute(req: IncomingMessage, res: ServerResponse, url: URL): Promise<void> {
+  if (!url.pathname.startsWith("/profiles")) {
+    return;
+  }
+  if (route(url.pathname, req.method ?? "GET", "/profiles", "GET")) {
+    sendJson(res, 200, await listProfiles());
+    return;
+  }
+  if (route(url.pathname, req.method ?? "POST", "/profiles/create", "POST")) {
+    const body = await readJsonBody<{ name?: string; modelAlias?: string }>(req);
+    sendJson(res, 200, await createProfile(body.name ?? "", body.modelAlias ?? ""));
+    return;
+  }
+  if (route(url.pathname, req.method ?? "POST", "/profiles/embed", "POST")) {
+    const body = await readJsonBody<{ name?: string }>(req);
+    sendJson(res, 200, await embedProfile(body.name ?? ""));
+    return;
+  }
+  if (route(url.pathname, req.method ?? "POST", "/profiles/query", "POST")) {
+    const body = await readJsonBody<{ name?: string; query?: string; limit?: number }>(req);
+    sendJson(res, 200, await queryProfile(body.name ?? "", body.query ?? "", body.limit ?? 10));
+    return;
+  }
+  throw new ApiError(404, `Unknown profile route: ${url.pathname}`);
+}
+
+export function createPlaygroundApiMiddleware(): Middleware {
+  ensureManagedRuntimeStarted();
+  return (req, res, next) => {
+    handleRequest(req, res).catch((error) => {
+      if (!res.writableEnded) {
+        sendError(res, error);
+        return;
+      }
+      next(error);
+    });
+  };
+}

--- a/playground/server/mcp.ts
+++ b/playground/server/mcp.ts
@@ -1,0 +1,256 @@
+import { callToolViaCli } from "./cli";
+import { getConfig } from "./config";
+import { ApiError } from "./http";
+
+type PendingRequest = {
+  resolve: (value: unknown) => void;
+  reject: (error: unknown) => void;
+};
+
+type SseEvent = {
+  event?: string;
+  data: string;
+};
+
+class McpSseClient {
+  private endpoint: string | null = null;
+  private endpointPromise: Promise<string> | null = null;
+  private idCounter = 1;
+  private pending = new Map<number, PendingRequest>();
+  private connectedUrl = "";
+
+  async request(method: string, params?: unknown): Promise<unknown> {
+    const config = getConfig();
+    if (this.connectedUrl !== config.mcpUrl) {
+      this.reset();
+      this.connectedUrl = config.mcpUrl;
+    }
+    const endpoint = await this.ensureEndpoint(config.mcpUrl);
+    const id = this.idCounter++;
+    const responsePromise = new Promise<unknown>((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      setTimeout(() => {
+        if (this.pending.delete(id)) {
+          reject(new ApiError(504, `MCP request timed out: ${method}`));
+        }
+      }, 30_000);
+    });
+
+    const postUrl = new URL(endpoint, config.mcpUrl).toString();
+    const postResponse = await fetch(postUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id,
+        method,
+        params
+      })
+    });
+    if (!postResponse.ok) {
+      this.pending.delete(id);
+      throw new ApiError(postResponse.status, `MCP POST failed: ${postResponse.statusText}`);
+    }
+
+    return responsePromise;
+  }
+
+  private reset(): void {
+    this.endpoint = null;
+    this.endpointPromise = null;
+    for (const pending of this.pending.values()) {
+      pending.reject(new ApiError(503, "MCP client reset"));
+    }
+    this.pending.clear();
+  }
+
+  private ensureEndpoint(baseUrl: string): Promise<string> {
+    if (this.endpoint) {
+      return Promise.resolve(this.endpoint);
+    }
+    if (!this.endpointPromise) {
+      this.endpointPromise = this.connect(baseUrl);
+    }
+    return this.endpointPromise;
+  }
+
+  private async connect(baseUrl: string): Promise<string> {
+    const response = await fetch(new URL("/sse", baseUrl), {
+      headers: { accept: "text/event-stream" }
+    });
+    const body = response.body;
+    if (!response.ok || !body) {
+      throw new ApiError(response.status || 502, `Failed to open MCP SSE stream: ${response.statusText}`);
+    }
+
+    const endpointPromise = new Promise<string>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new ApiError(504, "MCP endpoint event timed out")), 10_000);
+      this.readSse(body, (event) => {
+        if (event.data.includes("/message")) {
+          clearTimeout(timeout);
+          this.endpoint = event.data.trim();
+          resolve(this.endpoint);
+          return;
+        }
+        this.handleMessage(event.data);
+      }).catch((error) => {
+        clearTimeout(timeout);
+        this.reset();
+        reject(error);
+      });
+    });
+
+    return endpointPromise;
+  }
+
+  private async readSse(
+    body: ReadableStream<Uint8Array>,
+    onEvent: (event: SseEvent) => void
+  ): Promise<void> {
+    const reader = body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) {
+        break;
+      }
+      buffer += decoder.decode(value, { stream: true }).replace(/\r\n/g, "\n");
+      let boundary = buffer.indexOf("\n\n");
+      while (boundary >= 0) {
+        const block = buffer.slice(0, boundary);
+        buffer = buffer.slice(boundary + 2);
+        const event = parseSseEvent(block);
+        if (event.data) {
+          onEvent(event);
+        }
+        boundary = buffer.indexOf("\n\n");
+      }
+    }
+  }
+
+  private handleMessage(data: string): void {
+    let message: { id?: number; result?: unknown; error?: unknown };
+    try {
+      message = JSON.parse(data) as { id?: number; result?: unknown; error?: unknown };
+    } catch {
+      return;
+    }
+    if (typeof message.id !== "number") {
+      return;
+    }
+    const pending = this.pending.get(message.id);
+    if (!pending) {
+      return;
+    }
+    this.pending.delete(message.id);
+    if (message.error) {
+      pending.reject(new ApiError(502, "MCP tool returned an error", message.error));
+    } else {
+      pending.resolve(message.result);
+    }
+  }
+}
+
+function parseSseEvent(block: string): SseEvent {
+  const event: SseEvent = { data: "" };
+  for (const line of block.split(/\r?\n/)) {
+    if (line.startsWith("event:")) {
+      event.event = line.slice("event:".length).trim();
+    } else if (line.startsWith("data:")) {
+      event.data += `${line.slice("data:".length).trim()}\n`;
+    }
+  }
+  event.data = event.data.trim();
+  return event;
+}
+
+const client = new McpSseClient();
+
+function extractCallResult(result: unknown): unknown {
+  if (!result || typeof result !== "object") {
+    return result;
+  }
+  const maybeContent = (result as { content?: unknown }).content;
+  if (!Array.isArray(maybeContent)) {
+    return result;
+  }
+  const text = maybeContent
+    .map((item) => {
+      if (item && typeof item === "object") {
+        const rawText = (item as { text?: unknown }).text;
+        if (typeof rawText === "string") {
+          return rawText;
+        }
+      }
+      return "";
+    })
+    .join("")
+    .trim();
+  if (!text) {
+    return result;
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+export async function listMcpTools(): Promise<unknown> {
+  try {
+    return await client.request("tools/list");
+  } catch (error) {
+    const config = getConfig();
+    if (!config.cliFallbackForMcp) {
+      throw error;
+    }
+    return {
+      fallback: "cli",
+      tools: [
+        "memory_get",
+        "memory_put",
+        "memory_list",
+        "memory_raw",
+        "memory_query",
+        "memory_search",
+        "memory_link",
+        "memory_link_close",
+        "memory_backlinks",
+        "memory_graph",
+        "memory_check",
+        "memory_timeline",
+        "memory_tags",
+        "memory_gap",
+        "memory_gaps",
+        "memory_add_turn",
+        "memory_close_session",
+        "memory_close_action",
+        "memory_correct",
+        "memory_correct_continue",
+        "memory_stats",
+        "memory_collections",
+        "memory_namespace_create",
+        "memory_namespace_destroy"
+      ],
+      reason: error instanceof Error ? error.message : String(error)
+    };
+  }
+}
+
+export async function callMcpTool(name: string, args: unknown): Promise<unknown> {
+  try {
+    const result = await client.request("tools/call", {
+      name,
+      arguments: args ?? {}
+    });
+    return extractCallResult(result);
+  } catch (error) {
+    const config = getConfig();
+    if (!config.cliFallbackForMcp) {
+      throw error;
+    }
+    return callToolViaCli(name, args ?? {});
+  }
+}

--- a/playground/server/pathSafety.ts
+++ b/playground/server/pathSafety.ts
@@ -1,0 +1,28 @@
+import path from "node:path";
+
+export function normalizeForCompare(value: string): string {
+  const resolved = path.resolve(value);
+  return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+}
+
+export function isPathInside(root: string, candidate: string): boolean {
+  const normalizedRoot = normalizeForCompare(root);
+  const normalizedCandidate = normalizeForCompare(candidate);
+  if (normalizedRoot === normalizedCandidate) {
+    return true;
+  }
+  const relative = path.relative(normalizedRoot, normalizedCandidate);
+  return Boolean(relative) && !relative.startsWith("..") && !path.isAbsolute(relative);
+}
+
+export function assertPathInside(root: string, candidate: string): string {
+  const resolved = path.resolve(candidate);
+  if (!isPathInside(root, resolved)) {
+    throw new Error(`Path is outside allowed root: ${candidate}`);
+  }
+  return resolved;
+}
+
+export function safeSegment(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 80) || "profile";
+}

--- a/playground/server/profiles.ts
+++ b/playground/server/profiles.ts
@@ -1,0 +1,164 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { getConfig } from "./config";
+import { ApiError } from "./http";
+import { safeSegment } from "./pathSafety";
+
+const execFileAsync = promisify(execFile);
+
+export interface EmbeddingProfile {
+  name: string;
+  modelAlias: string;
+  dbPath: string;
+  createdAt: string;
+}
+
+async function profilePath(name: string): Promise<string> {
+  const config = getConfig();
+  const dir = path.join(config.profilesDir, safeSegment(name));
+  await fs.mkdir(dir, { recursive: true });
+  return dir;
+}
+
+async function metadataPath(name: string): Promise<string> {
+  return path.join(await profilePath(name), "profile.json");
+}
+
+export async function listProfiles(): Promise<EmbeddingProfile[]> {
+  const config = getConfig();
+  try {
+    const entries = await fs.readdir(config.profilesDir, { withFileTypes: true });
+    const profiles: EmbeddingProfile[] = [];
+    for (const entry of entries) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+      const metadataFile = path.join(config.profilesDir, entry.name, "profile.json");
+      try {
+        const raw = await fs.readFile(metadataFile, "utf8");
+        profiles.push(JSON.parse(raw) as EmbeddingProfile);
+      } catch {
+        continue;
+      }
+    }
+    return profiles.sort((a, b) => a.name.localeCompare(b.name));
+  } catch {
+    return [];
+  }
+}
+
+export async function createProfile(name: string, modelAlias: string): Promise<EmbeddingProfile> {
+  if (!name.trim()) {
+    throw new ApiError(400, "Profile name is required");
+  }
+  if (!modelAlias.trim()) {
+    throw new ApiError(400, "Embedding model alias is required");
+  }
+
+  const config = getConfig();
+  const dir = await profilePath(name);
+  const dbPath = path.join(dir, "memory.db");
+  const metadata: EmbeddingProfile = {
+    name,
+    modelAlias,
+    dbPath,
+    createdAt: new Date().toISOString()
+  };
+
+  try {
+    await execFileAsync(config.quaidBin, ["--model", modelAlias, "init", dbPath], {
+      cwd: config.rootDir,
+      windowsHide: true,
+      timeout: 120_000,
+      maxBuffer: 10 * 1024 * 1024
+    });
+    await fs.writeFile(await metadataPath(name), JSON.stringify(metadata, null, 2), "utf8");
+    return metadata;
+  } catch (error) {
+    const err = error as Error & { stderr?: string; stdout?: string };
+    throw new ApiError(502, `Failed to create embedding profile: ${err.message}`, {
+      stdout: err.stdout,
+      stderr: err.stderr
+    });
+  }
+}
+
+export async function embedProfile(name: string) {
+  const profile = await loadProfile(name);
+  const config = getConfig();
+  try {
+    const result = await execFileAsync(
+      config.quaidBin,
+      ["--db", profile.dbPath, "--model", profile.modelAlias, "embed", "--all"],
+      {
+        cwd: config.rootDir,
+        windowsHide: true,
+        timeout: 10 * 60 * 1000,
+        maxBuffer: 20 * 1024 * 1024
+      }
+    );
+    return {
+      profile,
+      stdout: result.stdout,
+      stderr: result.stderr
+    };
+  } catch (error) {
+    const err = error as Error & { stderr?: string; stdout?: string };
+    throw new ApiError(502, `Failed to embed profile: ${err.message}`, {
+      stdout: err.stdout,
+      stderr: err.stderr
+    });
+  }
+}
+
+export async function queryProfile(name: string, query: string, limit = 10) {
+  const profile = await loadProfile(name);
+  const config = getConfig();
+  try {
+    const result = await execFileAsync(
+      config.quaidBin,
+      [
+        "--db",
+        profile.dbPath,
+        "--model",
+        profile.modelAlias,
+        "--json",
+        "query",
+        query,
+        "--limit",
+        String(limit)
+      ],
+      {
+        cwd: config.rootDir,
+        windowsHide: true,
+        timeout: 120_000,
+        maxBuffer: 20 * 1024 * 1024
+      }
+    );
+    const parsed = JSON.parse(result.stdout || "[]");
+    return {
+      profile,
+      results: parsed,
+      stdout: result.stdout,
+      stderr: result.stderr
+    };
+  } catch (error) {
+    const err = error as Error & { stderr?: string; stdout?: string };
+    throw new ApiError(502, `Failed to query profile: ${err.message}`, {
+      stdout: err.stdout,
+      stderr: err.stderr
+    });
+  }
+}
+
+async function loadProfile(name: string): Promise<EmbeddingProfile> {
+  const file = await metadataPath(name);
+  try {
+    const raw = await fs.readFile(file, "utf8");
+    return JSON.parse(raw) as EmbeddingProfile;
+  } catch {
+    throw new ApiError(404, `Embedding profile not found: ${name}`);
+  }
+}

--- a/playground/server/runtime.ts
+++ b/playground/server/runtime.ts
@@ -1,0 +1,154 @@
+import { execFileSync, spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { existsSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { getConfig } from "./config";
+import { ApiError } from "./http";
+
+let managedProcess: ChildProcessWithoutNullStreams | null = null;
+const logLines: string[] = [];
+let autoStartAttempted = false;
+
+function remember(line: string): void {
+  const lines = line
+    .split(/\r?\n/)
+    .map((part) => part.trimEnd())
+    .filter(Boolean);
+  for (const clean of lines) {
+    logLines.push(clean);
+    console.info(`[quaid-runtime] ${clean}`);
+  }
+  while (logLines.length > 200) {
+    logLines.shift();
+  }
+}
+
+export function runtimeStatus() {
+  const config = getConfig();
+  return {
+    mode: config.runtimeMode,
+    mcpUrl: config.mcpUrl,
+    managedRunning: Boolean(managedProcess && !managedProcess.killed),
+    pid: managedProcess?.pid ?? null,
+    logTail: logLines.slice(-40)
+  };
+}
+
+export function startRuntime() {
+  const config = getConfig();
+  if (config.runtimeMode === "external") {
+    throw new ApiError(409, "Runtime is external; start Quaid outside the playground.");
+  }
+  if (managedProcess && !managedProcess.killed) {
+    return runtimeStatus();
+  }
+
+  bootstrapManagedRuntime();
+
+  const args = [
+    "--db",
+    config.dbPath,
+    "--model",
+    config.embeddingModel,
+    "serve",
+    "--http",
+    "--port",
+    String(config.httpPort),
+    "--trust-loopback"
+  ];
+
+  managedProcess = spawn(config.quaidBin, args, {
+    cwd: config.rootDir,
+    windowsHide: true,
+    env: {
+      ...process.env,
+      QUAID_DB: config.dbPath,
+      QUAID_MODEL: config.embeddingModel
+    }
+  });
+
+  remember(`started: ${config.quaidBin} ${args.join(" ")}`);
+  managedProcess.stdout.on("data", (chunk) => remember(String(chunk)));
+  managedProcess.stderr.on("data", (chunk) => remember(String(chunk)));
+  managedProcess.on("error", (error) => {
+    remember(`quaid serve failed to start: ${error.message}`);
+    managedProcess = null;
+  });
+  managedProcess.on("exit", (code, signal) => {
+    remember(`quaid serve exited code=${code ?? "null"} signal=${signal ?? "null"}`);
+    managedProcess = null;
+  });
+
+  return runtimeStatus();
+}
+
+function bootstrapManagedRuntime(): void {
+  const config = getConfig();
+  const env = {
+    ...process.env,
+    QUAID_DB: config.dbPath,
+    QUAID_MODEL: config.embeddingModel
+  };
+
+  if (config.autoInitDb && !existsSync(config.dbPath)) {
+    const parent = dirname(config.dbPath);
+    mkdirSync(parent, { recursive: true });
+    remember(`initializing missing DB: ${config.dbPath}`);
+    runQuaidBootstrap(["--model", config.embeddingModel, "init", config.dbPath], env);
+  }
+
+  if (config.autoEnableExtraction) {
+    remember("auto-enabling fact extraction");
+    runQuaidBootstrap(
+      ["--db", config.dbPath, "--model", config.embeddingModel, "extraction", "enable"],
+      env
+    );
+  }
+}
+
+function runQuaidBootstrap(args: string[], env: NodeJS.ProcessEnv): void {
+  const config = getConfig();
+  try {
+    const output = execFileSync(config.quaidBin, args, {
+      cwd: config.rootDir,
+      env,
+      encoding: "utf8",
+      windowsHide: true,
+      timeout: 10 * 60 * 1000,
+      maxBuffer: 20 * 1024 * 1024
+    });
+    remember(output || `completed: ${config.quaidBin} ${args.join(" ")}`);
+  } catch (error) {
+    const err = error as Error & { stdout?: string; stderr?: string };
+    remember(err.stdout ?? "");
+    remember(err.stderr ?? "");
+    throw new ApiError(502, `Quaid bootstrap failed: ${err.message}`);
+  }
+}
+
+export function stopRuntime() {
+  if (managedProcess && !managedProcess.killed) {
+    managedProcess.kill();
+    remember("stop requested");
+  }
+  managedProcess = null;
+  return runtimeStatus();
+}
+
+export function restartRuntime() {
+  stopRuntime();
+  return startRuntime();
+}
+
+export function ensureManagedRuntimeStarted() {
+  const config = getConfig();
+  if (config.runtimeMode === "external" || autoStartAttempted) {
+    return runtimeStatus();
+  }
+  autoStartAttempted = true;
+  try {
+    return startRuntime();
+  } catch (error) {
+    remember(`quaid serve auto-start failed: ${error instanceof Error ? error.message : String(error)}`);
+    return runtimeStatus();
+  }
+}

--- a/playground/server/types.ts
+++ b/playground/server/types.ts
@@ -1,0 +1,82 @@
+export type JsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+export interface PlaygroundConfig {
+  rootDir: string;
+  profilesDir: string;
+  quaidBin: string;
+  dbPath: string;
+  embeddingModel: string;
+  httpPort: number;
+  mcpUrl: string;
+  runtimeMode: "managed" | "external";
+  cliFallbackForMcp: boolean;
+  autoInitDb: boolean;
+  autoEnableExtraction: boolean;
+}
+
+export interface ApiErrorShape {
+  error: string;
+  details?: unknown;
+}
+
+export interface CliCommandSpec {
+  id: string;
+  label: string;
+  description: string;
+  risky: boolean;
+  params: Array<{
+    name: string;
+    label: string;
+    required?: boolean;
+    defaultValue?: string | number | boolean;
+    type?: "string" | "number" | "boolean" | "json";
+  }>;
+}
+
+export interface CliRunRequest {
+  id: string;
+  params?: Record<string, unknown>;
+  confirmed?: boolean;
+}
+
+export interface CliRunResult {
+  id: string;
+  args: string[];
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  parsed?: unknown;
+}
+
+export interface TreeNode {
+  id: string;
+  label: string;
+  type: "root" | "directory" | "page" | "raw-import" | "file";
+  path?: string;
+  children?: TreeNode[];
+  meta?: Record<string, unknown>;
+}
+
+export interface GraphNode {
+  id: string;
+  label: string;
+  type?: string;
+  title?: string;
+}
+
+export interface GraphEdge {
+  source: string;
+  target: string;
+  label?: string;
+}
+
+export interface GraphData {
+  nodes: GraphNode[];
+  links: GraphEdge[];
+}

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -1,0 +1,79 @@
+import { NavLink, Navigate, Route, Routes } from "react-router-dom";
+import {
+  Blocks,
+  Bot,
+  Database,
+  FileText,
+  GitBranch,
+  MessageSquareText,
+  Search,
+  Settings2
+} from "lucide-react";
+import { lazy, Suspense } from "react";
+import { StatusPanel } from "./components/StatusPanel";
+import { ChatPage } from "./pages/ChatPage";
+import { ConversationPage } from "./pages/ConversationPage";
+import { FilesPage } from "./pages/FilesPage";
+import { ModelPage } from "./pages/ModelPage";
+import { OpsPage } from "./pages/OpsPage";
+
+const GraphPage = lazy(() => import("./pages/GraphPage").then((module) => ({ default: module.GraphPage })));
+
+const navItems = [
+  { to: "/chat", label: "Chat", icon: Search },
+  { to: "/conversation", label: "Conversations", icon: MessageSquareText },
+  { to: "/models", label: "Models", icon: Bot },
+  { to: "/files", label: "Files", icon: FileText },
+  { to: "/graph", label: "Graph", icon: GitBranch },
+  { to: "/ops", label: "Ops", icon: Settings2 }
+];
+
+export default function App() {
+  return (
+    <div className="app-shell">
+      <aside className="sidebar">
+        <div className="brand">
+          <Blocks aria-hidden="true" size={24} />
+          <div>
+            <strong>Quaid</strong>
+            <span>Playground</span>
+          </div>
+        </div>
+        <nav className="nav-list" aria-label="Playground sections">
+          {navItems.map((item) => {
+            const Icon = item.icon;
+            return (
+              <NavLink key={item.to} to={item.to} className={({ isActive }) => `nav-link ${isActive ? "active" : ""}`}>
+                <Icon aria-hidden="true" size={18} />
+                <span>{item.label}</span>
+              </NavLink>
+            );
+          })}
+        </nav>
+        <StatusPanel />
+      </aside>
+      <main className="main-pane">
+        <Routes>
+          <Route path="/" element={<Navigate to="/chat" replace />} />
+          <Route path="/chat" element={<ChatPage />} />
+          <Route path="/conversation" element={<ConversationPage />} />
+          <Route path="/models" element={<ModelPage />} />
+          <Route path="/files" element={<FilesPage />} />
+          <Route
+            path="/graph"
+            element={
+              <Suspense fallback={<div className="empty-state">Loading graph...</div>}>
+                <GraphPage />
+              </Suspense>
+            }
+          />
+          <Route path="/ops" element={<OpsPage />} />
+        </Routes>
+      </main>
+      <div className="mobile-status">
+        <Database aria-hidden="true" size={16} />
+        <span>Local Quaid playground</span>
+      </div>
+    </div>
+  );
+}

--- a/playground/src/components/FormField.tsx
+++ b/playground/src/components/FormField.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from "react";
+
+export function FormField({
+  label,
+  children,
+  hint
+}: {
+  label: string;
+  children: ReactNode;
+  hint?: string;
+}) {
+  return (
+    <label className="form-field">
+      <span>{label}</span>
+      {children}
+      {hint ? <small>{hint}</small> : null}
+    </label>
+  );
+}

--- a/playground/src/components/JsonPanel.tsx
+++ b/playground/src/components/JsonPanel.tsx
@@ -1,0 +1,10 @@
+import { prettyJson } from "../lib/api";
+
+export function JsonPanel({ value, title = "Output" }: { value: unknown; title?: string }) {
+  return (
+    <section className="json-panel">
+      <header>{title}</header>
+      <pre>{prettyJson(value)}</pre>
+    </section>
+  );
+}

--- a/playground/src/components/MarkdownView.tsx
+++ b/playground/src/components/MarkdownView.tsx
@@ -1,0 +1,10 @@
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+export function MarkdownView({ markdown }: { markdown: string }) {
+  return (
+    <div className="markdown-view">
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>{markdown || "_No markdown content._"}</ReactMarkdown>
+    </div>
+  );
+}

--- a/playground/src/components/ResultCard.tsx
+++ b/playground/src/components/ResultCard.tsx
@@ -1,0 +1,41 @@
+import { FileText } from "lucide-react";
+import type { EnrichedResult } from "../lib/types";
+
+export function ResultCard({ item }: { item: EnrichedResult }) {
+  const page = item.page;
+  const result = item.result;
+  const title = page?.title || result.title || result.slug;
+  const summary = page?.summary || result.summary || page?.compiled_truth || "No summary available.";
+
+  return (
+    <article className="result-card">
+      <header>
+        <FileText aria-hidden="true" size={18} />
+        <div>
+          <h3>{title}</h3>
+          <span>{page?.canonicalSlug || result.slug}</span>
+        </div>
+      </header>
+      <p>{summary}</p>
+      <dl className="metadata-grid">
+        <div>
+          <dt>Type</dt>
+          <dd>{page?.type || result.type || "-"}</dd>
+        </div>
+        <div>
+          <dt>Score</dt>
+          <dd>{typeof result.score === "number" ? result.score.toFixed(3) : "-"}</dd>
+        </div>
+        <div>
+          <dt>Wing</dt>
+          <dd>{page?.wing || result.wing || "-"}</dd>
+        </div>
+        <div>
+          <dt>Version</dt>
+          <dd>{page?.version ?? "-"}</dd>
+        </div>
+      </dl>
+      {item.error ? <p className="inline-error">{item.error}</p> : null}
+    </article>
+  );
+}

--- a/playground/src/components/StatusPanel.tsx
+++ b/playground/src/components/StatusPanel.tsx
@@ -1,0 +1,90 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Play, RefreshCcw, Square } from "lucide-react";
+import { apiGet, apiPost } from "../lib/api";
+import type { ApiStatus } from "../lib/types";
+
+export function StatusPanel() {
+  const queryClient = useQueryClient();
+  const { data, isLoading, error } = useQuery<ApiStatus>({
+    queryKey: ["status"],
+    queryFn: () => apiGet<ApiStatus>("/status"),
+    refetchInterval: 10_000
+  });
+
+  const runtimeMutation = useMutation({
+    mutationFn: (action: "start" | "stop" | "restart") => apiPost(`/runtime/${action}`),
+    onSettled: () => queryClient.invalidateQueries({ queryKey: ["status"] })
+  });
+
+  if (isLoading) {
+    return <section className="status-panel">Loading status...</section>;
+  }
+
+  if (error || !data) {
+    return <section className="status-panel error">Status unavailable</section>;
+  }
+
+  const runtime = data.runtime;
+  const database = data.database;
+
+  return (
+    <section className="status-panel" aria-label="Runtime status">
+      <div className="status-row">
+        <span>Runtime</span>
+        <strong>{runtime.mode}</strong>
+      </div>
+      <div className="status-row">
+        <span>MCP</span>
+        <strong>{runtime.managedRunning || runtime.mode === "external" ? "ready" : "stopped"}</strong>
+      </div>
+      <div className="status-row">
+        <span>DB</span>
+        <strong>{database.databaseExists ? `${database.pageCount} pages` : "missing"}</strong>
+      </div>
+      <div className="status-row">
+        <span>Embedding</span>
+        <strong>{database.activeEmbedding?.name ?? data.config.embeddingModel}</strong>
+      </div>
+      <div className="status-row">
+        <span>Extraction</span>
+        <strong>{database.config["extraction.enabled"] ?? "unknown"}</strong>
+      </div>
+      <div className="runtime-actions">
+        <button
+          className="icon-button"
+          type="button"
+          title="Start managed runtime"
+          disabled={runtime.mode === "external" || runtimeMutation.isPending}
+          onClick={() => runtimeMutation.mutate("start")}
+        >
+          <Play size={16} />
+        </button>
+        <button
+          className="icon-button"
+          type="button"
+          title="Restart managed runtime"
+          disabled={runtime.mode === "external" || runtimeMutation.isPending}
+          onClick={() => runtimeMutation.mutate("restart")}
+        >
+          <RefreshCcw size={16} />
+        </button>
+        <button
+          className="icon-button"
+          type="button"
+          title="Stop managed runtime"
+          disabled={runtime.mode === "external" || runtimeMutation.isPending}
+          onClick={() => runtimeMutation.mutate("stop")}
+        >
+          <Square size={16} />
+        </button>
+      </div>
+      <div className="path-readout" title={data.config.dbPath}>
+        {data.config.dbPath}
+      </div>
+      <details className="runtime-log">
+        <summary>Runtime log</summary>
+        <pre>{runtime.logTail.length ? runtime.logTail.join("\n") : "No Quaid runtime output yet."}</pre>
+      </details>
+    </section>
+  );
+}

--- a/playground/src/components/TreeView.tsx
+++ b/playground/src/components/TreeView.tsx
@@ -1,0 +1,58 @@
+import { ChevronRight } from "lucide-react";
+import { useState } from "react";
+import type { TreeNode } from "../lib/types";
+
+export function TreeView({
+  nodes,
+  onSelect
+}: {
+  nodes: TreeNode[];
+  onSelect: (node: TreeNode) => void;
+}) {
+  return (
+    <div className="tree-view">
+      {nodes.map((node) => (
+        <TreeItem key={node.id} node={node} onSelect={onSelect} level={0} />
+      ))}
+    </div>
+  );
+}
+
+function TreeItem({
+  node,
+  onSelect,
+  level
+}: {
+  node: TreeNode;
+  onSelect: (node: TreeNode) => void;
+  level: number;
+}) {
+  const [open, setOpen] = useState(level < 1);
+  const hasChildren = Boolean(node.children?.length);
+
+  return (
+    <div>
+      <button
+        className={`tree-row ${node.type}`}
+        type="button"
+        style={{ paddingLeft: `${8 + level * 16}px` }}
+        onClick={() => {
+          if (hasChildren) {
+            setOpen((value) => !value);
+          } else {
+            onSelect(node);
+          }
+        }}
+        onDoubleClick={() => onSelect(node)}
+      >
+        <ChevronRight className={open ? "open" : ""} size={14} aria-hidden="true" />
+        <span>{node.label}</span>
+      </button>
+      {open && hasChildren
+        ? node.children!.map((child) => (
+            <TreeItem key={child.id} node={child} onSelect={onSelect} level={level + 1} />
+          ))
+        : null}
+    </div>
+  );
+}

--- a/playground/src/lib/api.ts
+++ b/playground/src/lib/api.ts
@@ -1,0 +1,45 @@
+import type { CliRunResult } from "./types";
+
+async function parseResponse<T>(response: Response): Promise<T> {
+  const contentType = response.headers.get("content-type") ?? "";
+  const value = contentType.includes("application/json") ? await response.json() : await response.text();
+  if (!response.ok) {
+    const message = typeof value === "object" && value && "error" in value ? String(value.error) : response.statusText;
+    throw new Error(message);
+  }
+  return value as T;
+}
+
+export async function apiGet<T>(path: string): Promise<T> {
+  const response = await fetch(`/api${path}`, {
+    headers: { accept: "application/json" }
+  });
+  return parseResponse<T>(response);
+}
+
+export async function apiPost<T>(path: string, body: unknown = {}): Promise<T> {
+  const response = await fetch(`/api${path}`, {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      "content-type": "application/json"
+    },
+    body: JSON.stringify(body)
+  });
+  return parseResponse<T>(response);
+}
+
+export async function callMcp<T = unknown>(name: string, args: unknown = {}): Promise<T> {
+  return apiPost<T>("/mcp/call", { name, args });
+}
+
+export async function runCli(id: string, params: Record<string, unknown> = {}, confirmed = false): Promise<CliRunResult> {
+  return apiPost<CliRunResult>("/cli/run", { id, params, confirmed });
+}
+
+export function prettyJson(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  return JSON.stringify(value, null, 2);
+}

--- a/playground/src/lib/search.ts
+++ b/playground/src/lib/search.ts
@@ -1,0 +1,70 @@
+import { callMcp } from "./api";
+import type { EnrichedResult, MemoryPage, SearchResult } from "./types";
+
+export function normalizeSearchResults(value: unknown): SearchResult[] {
+  if (Array.isArray(value)) {
+    return value.filter(isSearchResult);
+  }
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    for (const key of ["results", "items", "pages"]) {
+      if (Array.isArray(record[key])) {
+        return record[key].filter(isSearchResult);
+      }
+    }
+  }
+  return [];
+}
+
+function isSearchResult(value: unknown): value is SearchResult {
+  return Boolean(value && typeof value === "object" && typeof (value as { slug?: unknown }).slug === "string");
+}
+
+export async function queryAndEnrich(query: string, limit: number, namespace?: string): Promise<EnrichedResult[]> {
+  const raw = await callMcp("memory_query", {
+    query,
+    limit,
+    depth: "auto",
+    namespace: namespace || undefined
+  });
+  const results = normalizeSearchResults(raw);
+  return Promise.all(
+    results.map(async (result) => {
+      try {
+        const page = await callMcp<MemoryPage>("memory_get", { slug: result.slug });
+        return { result, page };
+      } catch (error) {
+        return {
+          result,
+          error: error instanceof Error ? error.message : String(error)
+        };
+      }
+    })
+  );
+}
+
+export function composeRetrievalAnswer(question: string, items: EnrichedResult[]): string {
+  if (items.length === 0) {
+    return "No matching memories were retrieved. Try a broader query or check whether extraction has produced facts for this conversation.";
+  }
+
+  const snippets = items
+    .slice(0, 3)
+    .map((item) => {
+      const page = item.page;
+      const source = page?.title || item.result.title || item.result.slug;
+      const text = [page?.summary, page?.compiled_truth, item.result.summary]
+        .filter(Boolean)
+        .join(" ")
+        .replace(/\s+/g, " ")
+        .slice(0, 240);
+      return `${source}: ${text}`;
+    })
+    .filter((line) => !line.endsWith(": "));
+
+  if (snippets.length === 0) {
+    return `Retrieved ${items.length} result${items.length === 1 ? "" : "s"} for "${question}", but none exposed a summary or compiled fact body.`;
+  }
+
+  return `Retrieved evidence for "${question}" points to: ${snippets.join(" ")}`
+}

--- a/playground/src/lib/types.ts
+++ b/playground/src/lib/types.ts
@@ -1,0 +1,135 @@
+export interface ApiStatus {
+  config: {
+    rootDir: string;
+    profilesDir: string;
+    quaidBin: string;
+    dbPath: string;
+    embeddingModel: string;
+    httpPort: number;
+    mcpUrl: string;
+    runtimeMode: "managed" | "external";
+    cliFallbackForMcp: boolean;
+    autoInitDb: boolean;
+    autoEnableExtraction: boolean;
+  };
+  runtime: {
+    mode: "managed" | "external";
+    mcpUrl: string;
+    managedRunning: boolean;
+    pid: number | null;
+    logTail: string[];
+  };
+  database: DbStatus;
+}
+
+export interface DbStatus {
+  databaseExists: boolean;
+  dbPath: string;
+  pageCount: number;
+  linkCount?: number;
+  embeddingJobs?: number;
+  extractionQueue?: number;
+  activeEmbedding?: {
+    name: string;
+    dimensions: number;
+  };
+  collections: CollectionInfo[];
+  config: Record<string, string>;
+}
+
+export interface CollectionInfo {
+  id: number;
+  name: string;
+  root_path: string;
+  state: string;
+  writable: number;
+  is_write_target: number;
+  needs_full_sync: number;
+  last_sync_at: string | null;
+  page_count: number;
+}
+
+export interface SearchResult {
+  slug: string;
+  title?: string;
+  summary?: string;
+  score?: number;
+  wing?: string;
+  type?: string;
+  [key: string]: unknown;
+}
+
+export interface MemoryPage {
+  slug: string;
+  canonicalSlug?: string;
+  title: string;
+  type: string;
+  summary: string;
+  compiled_truth: string;
+  timeline: string;
+  wing: string;
+  room: string;
+  version: number;
+  updated_at: string;
+  markdown?: string;
+  [key: string]: unknown;
+}
+
+export interface EnrichedResult {
+  result: SearchResult;
+  page?: MemoryPage;
+  error?: string;
+}
+
+export interface TreeNode {
+  id: string;
+  label: string;
+  type: "root" | "directory" | "page" | "raw-import" | "file";
+  path?: string;
+  children?: TreeNode[];
+  meta?: Record<string, unknown>;
+}
+
+export interface CliCommandSpec {
+  id: string;
+  label: string;
+  description: string;
+  risky: boolean;
+  params: Array<{
+    name: string;
+    label: string;
+    required?: boolean;
+    defaultValue?: string | number | boolean;
+    type?: "string" | "number" | "boolean" | "json";
+  }>;
+}
+
+export interface CliRunResult {
+  id: string;
+  args: string[];
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  parsed?: unknown;
+}
+
+export interface GraphData {
+  nodes: Array<{
+    id: string;
+    label: string;
+    type?: string;
+    title?: string;
+  }>;
+  links: Array<{
+    source: string;
+    target: string;
+    label?: string;
+  }>;
+}
+
+export interface EmbeddingProfile {
+  name: string;
+  modelAlias: string;
+  dbPath: string;
+  createdAt: string;
+}

--- a/playground/src/main.tsx
+++ b/playground/src/main.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { BrowserRouter } from "react-router-dom";
+import App from "./App";
+import "./styles.css";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      retry: 1
+    }
+  }
+});
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </QueryClientProvider>
+  </React.StrictMode>
+);

--- a/playground/src/pages/ChatPage.tsx
+++ b/playground/src/pages/ChatPage.tsx
@@ -1,0 +1,98 @@
+import { useMutation } from "@tanstack/react-query";
+import { Send } from "lucide-react";
+import { useMemo, useState } from "react";
+import { FormField } from "../components/FormField";
+import { ResultCard } from "../components/ResultCard";
+import { composeRetrievalAnswer, queryAndEnrich } from "../lib/search";
+import type { EnrichedResult } from "../lib/types";
+
+export function ChatPage() {
+  const [question, setQuestion] = useState("");
+  const [namespace, setNamespace] = useState("");
+  const [limit, setLimit] = useState(8);
+  const [lastQuestion, setLastQuestion] = useState("");
+
+  const mutation = useMutation({
+    mutationFn: () => queryAndEnrich(question, limit, namespace),
+    onSuccess: () => setLastQuestion(question)
+  });
+
+  const results = mutation.data ?? [];
+  const answer = useMemo(() => composeRetrievalAnswer(lastQuestion, results), [lastQuestion, results]);
+
+  function submit() {
+    if (!question.trim()) {
+      return;
+    }
+    mutation.mutate();
+  }
+
+  return (
+    <section className="page-grid chat-page">
+      <div className="page-header">
+        <div>
+          <h1>Memory Search</h1>
+          <p>Ask against Quaid memory and inspect the retrieved evidence.</p>
+        </div>
+      </div>
+
+      <section className="chat-surface">
+        <div className="question-box">
+          <textarea
+            value={question}
+            onChange={(event) => setQuestion(event.target.value)}
+            placeholder="What is my preferred beverage?"
+            rows={4}
+            onKeyDown={(event) => {
+              if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+                submit();
+              }
+            }}
+          />
+          <div className="question-controls">
+            <FormField label="Namespace">
+              <input value={namespace} onChange={(event) => setNamespace(event.target.value)} placeholder="optional" />
+            </FormField>
+            <FormField label="Limit">
+              <input
+                type="number"
+                min={1}
+                max={30}
+                value={limit}
+                onChange={(event) => setLimit(Number(event.target.value))}
+              />
+            </FormField>
+            <button className="primary-button" type="button" onClick={submit} disabled={mutation.isPending}>
+              <Send size={16} />
+              <span>{mutation.isPending ? "Searching" : "Ask"}</span>
+            </button>
+          </div>
+        </div>
+
+        {mutation.error ? <div className="notice error">{mutation.error.message}</div> : null}
+
+        {mutation.data ? (
+          <div className="answer-band">
+            <h2>Retrieval Answer</h2>
+            <p>{answer}</p>
+          </div>
+        ) : null}
+      </section>
+
+      <ResultList results={results} />
+    </section>
+  );
+}
+
+function ResultList({ results }: { results: EnrichedResult[] }) {
+  if (results.length === 0) {
+    return <div className="empty-state">No results yet.</div>;
+  }
+  return (
+    <section className="result-grid" aria-label="Search results">
+      {results.map((item) => (
+        <ResultCard key={item.result.slug} item={item} />
+      ))}
+    </section>
+  );
+}

--- a/playground/src/pages/ConversationPage.tsx
+++ b/playground/src/pages/ConversationPage.tsx
@@ -1,0 +1,131 @@
+import { useMutation } from "@tanstack/react-query";
+import { CirclePlus, ScanSearch, Send, SquareCheckBig } from "lucide-react";
+import { useMemo, useState } from "react";
+import { FormField } from "../components/FormField";
+import { JsonPanel } from "../components/JsonPanel";
+import { ResultCard } from "../components/ResultCard";
+import { callMcp, runCli } from "../lib/api";
+import { composeRetrievalAnswer, queryAndEnrich } from "../lib/search";
+import type { EnrichedResult } from "../lib/types";
+
+function defaultSessionId() {
+  return `playground-${new Date().toISOString().replace(/[:.]/g, "-")}`;
+}
+
+export function ConversationPage() {
+  const [sessionId, setSessionId] = useState(defaultSessionId);
+  const [namespace, setNamespace] = useState("");
+  const [role, setRole] = useState("user");
+  const [content, setContent] = useState("I like to drink coffee more than tea.");
+  const [question, setQuestion] = useState("What is my preferred beverage?");
+  const [results, setResults] = useState<EnrichedResult[]>([]);
+  const [lastQuestion, setLastQuestion] = useState(question);
+
+  const addTurn = useMutation({
+    mutationFn: () =>
+      callMcp("memory_add_turn", {
+        session_id: sessionId,
+        role,
+        content,
+        namespace: namespace || undefined,
+        metadata: {
+          source: "quaid-playground"
+        }
+      })
+  });
+
+  const closeSession = useMutation({
+    mutationFn: () =>
+      callMcp("memory_close_session", {
+        session_id: sessionId,
+        namespace: namespace || undefined
+      })
+  });
+
+  const forceExtract = useMutation({
+    mutationFn: () => runCli("extract.session", { sessionId, force: true }, true)
+  });
+
+  const ask = useMutation({
+    mutationFn: async () => {
+      const items = await queryAndEnrich(question, 10, namespace);
+      setResults(items);
+      setLastQuestion(question);
+      return items;
+    }
+  });
+
+  const answer = useMemo(() => composeRetrievalAnswer(lastQuestion, results), [lastQuestion, results]);
+
+  return (
+    <section className="page-grid">
+      <div className="page-header">
+        <div>
+          <h1>Conversation Lab</h1>
+          <p>Store turns, trigger extraction, then verify facts through retrieval.</p>
+        </div>
+      </div>
+
+      <section className="split-layout">
+        <div className="tool-panel">
+          <div className="two-col">
+            <FormField label="Session ID">
+              <input value={sessionId} onChange={(event) => setSessionId(event.target.value)} />
+            </FormField>
+            <FormField label="Namespace">
+              <input value={namespace} onChange={(event) => setNamespace(event.target.value)} placeholder="optional" />
+            </FormField>
+          </div>
+          <FormField label="Role">
+            <select value={role} onChange={(event) => setRole(event.target.value)}>
+              <option value="user">user</option>
+              <option value="assistant">assistant</option>
+              <option value="system">system</option>
+            </select>
+          </FormField>
+          <FormField label="Turn content">
+            <textarea value={content} onChange={(event) => setContent(event.target.value)} rows={6} />
+          </FormField>
+          <div className="button-row">
+            <button className="primary-button" type="button" onClick={() => addTurn.mutate()} disabled={addTurn.isPending}>
+              <CirclePlus size={16} />
+              <span>Add Turn</span>
+            </button>
+            <button className="secondary-button" type="button" onClick={() => closeSession.mutate()} disabled={closeSession.isPending}>
+              <SquareCheckBig size={16} />
+              <span>Close</span>
+            </button>
+            <button className="secondary-button" type="button" onClick={() => forceExtract.mutate()} disabled={forceExtract.isPending}>
+              <ScanSearch size={16} />
+              <span>Extract</span>
+            </button>
+          </div>
+          <FormField label="Question">
+            <input value={question} onChange={(event) => setQuestion(event.target.value)} />
+          </FormField>
+          <button className="primary-button" type="button" onClick={() => ask.mutate()} disabled={ask.isPending}>
+            <Send size={16} />
+            <span>Ask Memory</span>
+          </button>
+        </div>
+
+        <div className="stack">
+          <JsonPanel title="Add Turn Result" value={addTurn.data ?? addTurn.error?.message ?? "No turn added yet."} />
+          <JsonPanel title="Close / Extract Result" value={closeSession.data ?? forceExtract.data ?? closeSession.error?.message ?? forceExtract.error?.message ?? "No extraction action yet."} />
+        </div>
+      </section>
+
+      {ask.data ? (
+        <section className="answer-band">
+          <h2>Fact Check</h2>
+          <p>{answer}</p>
+        </section>
+      ) : null}
+      <section className="result-grid">
+        {results.map((item) => (
+          <ResultCard key={item.result.slug} item={item} />
+        ))}
+      </section>
+    </section>
+  );
+}

--- a/playground/src/pages/FilesPage.tsx
+++ b/playground/src/pages/FilesPage.tsx
@@ -1,0 +1,82 @@
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { FormField } from "../components/FormField";
+import { JsonPanel } from "../components/JsonPanel";
+import { MarkdownView } from "../components/MarkdownView";
+import { TreeView } from "../components/TreeView";
+import { apiGet } from "../lib/api";
+import type { ApiStatus, TreeNode } from "../lib/types";
+
+type ViewerState = {
+  title: string;
+  markdown?: string;
+  raw?: unknown;
+};
+
+export function FilesPage() {
+  const { data: status } = useQuery<ApiStatus>({ queryKey: ["status"], queryFn: () => apiGet("/status") });
+  const { data: dbTree = [] } = useQuery<TreeNode[]>({ queryKey: ["db-tree"], queryFn: () => apiGet("/db/tree") });
+  const [root, setRoot] = useState("");
+  const liveTree = useQuery<TreeNode>({
+    queryKey: ["live-tree", root],
+    queryFn: () => apiGet(`/files/tree?root=${encodeURIComponent(root)}`),
+    enabled: Boolean(root)
+  });
+  const [viewer, setViewer] = useState<ViewerState>({ title: "Viewer", markdown: "" });
+
+  async function selectNode(node: TreeNode) {
+    if (node.type === "page") {
+      const slug = String(node.meta?.collection_name ? `${node.meta.collection_name}::${node.meta.slug}` : node.meta?.slug ?? node.label);
+      const page = await apiGet<{ markdown: string; title: string }>(`/db/page?slug=${encodeURIComponent(slug)}`);
+      setViewer({ title: page.title, markdown: page.markdown, raw: page });
+      return;
+    }
+    if (node.type === "raw-import") {
+      const rawId = Number(node.meta?.id);
+      const raw = await apiGet<{ content: string; filePath: string }>(`/db/raw-file?id=${rawId}`);
+      setViewer({ title: raw.filePath, markdown: raw.content, raw });
+      return;
+    }
+    if (node.type === "file" && node.path) {
+      const file = await apiGet<{ content: string; path: string }>(`/files/read?path=${encodeURIComponent(node.path)}`);
+      setViewer({ title: file.path, markdown: file.content, raw: file });
+    }
+  }
+
+  return (
+    <section className="page-grid">
+      <div className="page-header">
+        <div>
+          <h1>Files</h1>
+          <p>Browse DB-backed raw imports, pages, and live collection files.</p>
+        </div>
+      </div>
+
+      <section className="file-layout">
+        <div className="browser-pane">
+          <h2>Database</h2>
+          <TreeView nodes={dbTree} onSelect={selectNode} />
+        </div>
+        <div className="browser-pane">
+          <h2>Live Collection</h2>
+          <FormField label="Root">
+            <select value={root} onChange={(event) => setRoot(event.target.value)}>
+              <option value="">Select root</option>
+              {status?.database.collections.map((collection) => (
+                <option key={collection.id} value={collection.root_path}>
+                  {collection.name}
+                </option>
+              ))}
+            </select>
+          </FormField>
+          {liveTree.data ? <TreeView nodes={[liveTree.data]} onSelect={selectNode} /> : <div className="empty-state">Select a collection root.</div>}
+        </div>
+        <div className="viewer-pane">
+          <h2>{viewer.title}</h2>
+          <MarkdownView markdown={viewer.markdown ?? ""} />
+          <JsonPanel title="Metadata" value={viewer.raw ?? "No file selected."} />
+        </div>
+      </section>
+    </section>
+  );
+}

--- a/playground/src/pages/GraphPage.tsx
+++ b/playground/src/pages/GraphPage.tsx
@@ -1,0 +1,90 @@
+import { useQuery } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+import ForceGraph2D from "react-force-graph-2d";
+import { FormField } from "../components/FormField";
+import { apiGet } from "../lib/api";
+import type { GraphData } from "../lib/types";
+
+type ForceNode = {
+  id?: string;
+  label?: string;
+  title?: string;
+  type?: string;
+  x?: number;
+  y?: number;
+};
+
+type ForceLink = {
+  label?: string;
+};
+
+export function GraphPage() {
+  const [scope, setScope] = useState<"whole" | "focused">("whole");
+  const [slug, setSlug] = useState("");
+  const [depth, setDepth] = useState(2);
+
+  const query = useQuery<GraphData>({
+    queryKey: ["graph", scope, slug, depth],
+    queryFn: () => {
+      const params = new URLSearchParams({ scope, depth: String(depth) });
+      if (slug) {
+        params.set("slug", slug);
+      }
+      return apiGet(`/db/graph?${params.toString()}`);
+    },
+    enabled: scope === "whole" || Boolean(slug)
+  });
+
+  const graphData = useMemo(() => query.data ?? { nodes: [], links: [] }, [query.data]);
+
+  return (
+    <section className="page-grid graph-page">
+      <div className="page-header">
+        <div>
+          <h1>Knowledge Graph</h1>
+          <p>Inspect focused neighborhoods or the whole DB graph.</p>
+        </div>
+      </div>
+
+      <section className="toolbar-band">
+        <FormField label="Scope">
+          <select value={scope} onChange={(event) => setScope(event.target.value as "whole" | "focused")}>
+            <option value="whole">whole KB</option>
+            <option value="focused">focused page</option>
+          </select>
+        </FormField>
+        <FormField label="Slug">
+          <input value={slug} onChange={(event) => setSlug(event.target.value)} disabled={scope === "whole"} placeholder="people/alice" />
+        </FormField>
+        <FormField label="Depth">
+          <input type="number" min={0} max={4} value={depth} onChange={(event) => setDepth(Number(event.target.value))} />
+        </FormField>
+      </section>
+
+      {query.error ? <div className="notice error">{query.error.message}</div> : null}
+
+      <div className="graph-canvas">
+        <ForceGraph2D
+          graphData={graphData}
+          width={Math.min(window.innerWidth - 360, 1100)}
+          height={640}
+          nodeLabel={(node: ForceNode) => `${node.title ?? node.label} (${node.type ?? "page"})`}
+          linkLabel={(link: ForceLink) => link.label ?? "related"}
+          nodeCanvasObject={(node: ForceNode, ctx: CanvasRenderingContext2D, globalScale: number) => {
+            const label = String(node.label ?? node.id);
+            const fontSize = Math.max(3.5, 11 / globalScale);
+            ctx.font = `${fontSize}px Inter, sans-serif`;
+            ctx.fillStyle = node.type === "person" ? "#0f766e" : node.type === "project" ? "#9a3412" : "#334155";
+            ctx.beginPath();
+            ctx.arc(Number(node.x ?? 0), Number(node.y ?? 0), 4.5, 0, 2 * Math.PI, false);
+            ctx.fill();
+            ctx.fillStyle = "#111827";
+            ctx.fillText(label, Number(node.x ?? 0) + 7, Number(node.y ?? 0) + 4);
+          }}
+          linkDirectionalArrowLength={3.5}
+          linkDirectionalArrowRelPos={1}
+        />
+      </div>
+    </section>
+  );
+}

--- a/playground/src/pages/ModelPage.tsx
+++ b/playground/src/pages/ModelPage.tsx
@@ -1,0 +1,167 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Download, Play, RefreshCcw, SlidersHorizontal } from "lucide-react";
+import { useState } from "react";
+import { FormField } from "../components/FormField";
+import { JsonPanel } from "../components/JsonPanel";
+import { apiGet, apiPost, runCli } from "../lib/api";
+import type { ApiStatus, EmbeddingProfile } from "../lib/types";
+
+const slmPresets = ["phi-3.5-mini", "gemma-3-1b", "gemma-3-4b", "custom"];
+const embeddingPresets = ["small", "base", "large", "m3", "custom"];
+
+export function ModelPage() {
+  const queryClient = useQueryClient();
+  const { data: status } = useQuery<ApiStatus>({ queryKey: ["status"], queryFn: () => apiGet("/status") });
+  const { data: profiles = [] } = useQuery<EmbeddingProfile[]>({ queryKey: ["profiles"], queryFn: () => apiGet("/profiles") });
+  const [slmPreset, setSlmPreset] = useState("phi-3.5-mini");
+  const [customSlm, setCustomSlm] = useState("");
+  const [embeddingPreset, setEmbeddingPreset] = useState("small");
+  const [customEmbedding, setCustomEmbedding] = useState("");
+  const [profileName, setProfileName] = useState("small-test");
+  const [selectedProfile, setSelectedProfile] = useState("");
+  const [compareQuery, setCompareQuery] = useState("What is my preferred beverage?");
+
+  const selectedSlm = slmPreset === "custom" ? customSlm : slmPreset;
+  const selectedEmbedding = embeddingPreset === "custom" ? customEmbedding : embeddingPreset;
+
+  const cliMutation = useMutation({
+    mutationFn: ({ id, params }: { id: string; params?: Record<string, unknown> }) => runCli(id, params ?? {}, true),
+    onSettled: () => queryClient.invalidateQueries({ queryKey: ["status"] })
+  });
+
+  const createProfile = useMutation({
+    mutationFn: () => apiPost<EmbeddingProfile>("/profiles/create", { name: profileName, modelAlias: selectedEmbedding }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["profiles"] })
+  });
+
+  const embedProfile = useMutation({
+    mutationFn: () => apiPost("/profiles/embed", { name: selectedProfile }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["profiles"] })
+  });
+
+  const compare = useMutation({
+    mutationFn: async () => {
+      const targets = profiles.length ? profiles : [];
+      return Promise.all(
+        targets.map((profile) => apiPost("/profiles/query", { name: profile.name, query: compareQuery, limit: 8 }))
+      );
+    }
+  });
+
+  return (
+    <section className="page-grid">
+      <div className="page-header">
+        <div>
+          <h1>Model Lab</h1>
+          <p>Switch extraction SLMs and compare embedding-model profile databases.</p>
+        </div>
+      </div>
+
+      <section className="split-layout">
+        <div className="tool-panel">
+          <h2>Fact Extraction SLM</h2>
+          <div className="two-col">
+            <FormField label="Preset">
+              <select value={slmPreset} onChange={(event) => setSlmPreset(event.target.value)}>
+                {slmPresets.map((preset) => (
+                  <option key={preset} value={preset}>
+                    {preset}
+                  </option>
+                ))}
+              </select>
+            </FormField>
+            <FormField label="Custom alias">
+              <input value={customSlm} onChange={(event) => setCustomSlm(event.target.value)} disabled={slmPreset !== "custom"} />
+            </FormField>
+          </div>
+          <div className="button-row">
+            <button className="primary-button" type="button" onClick={() => cliMutation.mutate({ id: "model.pull", params: { alias: selectedSlm } })}>
+              <Download size={16} />
+              <span>Download</span>
+            </button>
+            <button className="secondary-button" type="button" onClick={() => cliMutation.mutate({ id: "config.set", params: { key: "extraction.model_alias", value: selectedSlm } })}>
+              <SlidersHorizontal size={16} />
+              <span>Select</span>
+            </button>
+            <button className="secondary-button" type="button" onClick={() => cliMutation.mutate({ id: "extraction.enable" })}>
+              <Play size={16} />
+              <span>Enable</span>
+            </button>
+            <button className="secondary-button" type="button" onClick={() => apiPost("/runtime/restart").then(() => queryClient.invalidateQueries({ queryKey: ["status"] }))}>
+              <RefreshCcw size={16} />
+              <span>Restart</span>
+            </button>
+          </div>
+          <dl className="metadata-grid wide">
+            <div>
+              <dt>Configured</dt>
+              <dd>{status?.database.config["extraction.model_alias"] ?? "-"}</dd>
+            </div>
+            <div>
+              <dt>Enabled</dt>
+              <dd>{status?.database.config["extraction.enabled"] ?? "-"}</dd>
+            </div>
+            <div>
+              <dt>Queue</dt>
+              <dd>{status?.database.extractionQueue ?? 0}</dd>
+            </div>
+            <div>
+              <dt>Runtime</dt>
+              <dd>{status?.runtime.mode ?? "-"}</dd>
+            </div>
+          </dl>
+        </div>
+
+        <div className="tool-panel">
+          <h2>Embedding Profiles</h2>
+          <div className="two-col">
+            <FormField label="Profile name">
+              <input value={profileName} onChange={(event) => setProfileName(event.target.value)} />
+            </FormField>
+            <FormField label="Embedding model">
+              <select value={embeddingPreset} onChange={(event) => setEmbeddingPreset(event.target.value)}>
+                {embeddingPresets.map((preset) => (
+                  <option key={preset} value={preset}>
+                    {preset}
+                  </option>
+                ))}
+              </select>
+            </FormField>
+          </div>
+          {embeddingPreset === "custom" ? (
+            <FormField label="Custom embedding ID">
+              <input value={customEmbedding} onChange={(event) => setCustomEmbedding(event.target.value)} />
+            </FormField>
+          ) : null}
+          <div className="button-row">
+            <button className="primary-button" type="button" onClick={() => createProfile.mutate()} disabled={createProfile.isPending}>
+              Create Profile
+            </button>
+            <select value={selectedProfile} onChange={(event) => setSelectedProfile(event.target.value)}>
+              <option value="">Select profile</option>
+              {profiles.map((profile) => (
+                <option key={profile.name} value={profile.name}>
+                  {profile.name} ({profile.modelAlias})
+                </option>
+              ))}
+            </select>
+            <button className="secondary-button" type="button" onClick={() => embedProfile.mutate()} disabled={!selectedProfile || embedProfile.isPending}>
+              Embed All
+            </button>
+          </div>
+          <FormField label="Compare query">
+            <input value={compareQuery} onChange={(event) => setCompareQuery(event.target.value)} />
+          </FormField>
+          <button className="secondary-button" type="button" onClick={() => compare.mutate()} disabled={!profiles.length || compare.isPending}>
+            Compare Profiles
+          </button>
+        </div>
+      </section>
+
+      <section className="split-layout">
+        <JsonPanel title="Last model command" value={cliMutation.data ?? cliMutation.error?.message ?? "No command run yet."} />
+        <JsonPanel title="Profile output" value={createProfile.data ?? embedProfile.data ?? compare.data ?? createProfile.error?.message ?? embedProfile.error?.message ?? compare.error?.message ?? profiles} />
+      </section>
+    </section>
+  );
+}

--- a/playground/src/pages/OpsPage.tsx
+++ b/playground/src/pages/OpsPage.tsx
@@ -1,0 +1,84 @@
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { Play } from "lucide-react";
+import { useMemo, useState } from "react";
+import { FormField } from "../components/FormField";
+import { JsonPanel } from "../components/JsonPanel";
+import { apiGet, callMcp, runCli } from "../lib/api";
+import type { CliCommandSpec } from "../lib/types";
+
+export function OpsPage() {
+  const { data: commands = [] } = useQuery<CliCommandSpec[]>({ queryKey: ["cli-catalog"], queryFn: () => apiGet("/cli/catalog") });
+  const [tool, setTool] = useState("memory_stats");
+  const [toolArgs, setToolArgs] = useState("{}");
+  const [commandId, setCommandId] = useState("status.json");
+  const [commandParams, setCommandParams] = useState("{}");
+
+  const selectedCommand = useMemo(() => commands.find((command) => command.id === commandId), [commands, commandId]);
+
+  const mcpMutation = useMutation({
+    mutationFn: () => callMcp(tool, JSON.parse(toolArgs || "{}"))
+  });
+
+  const cliMutation = useMutation({
+    mutationFn: () => {
+      const params = JSON.parse(commandParams || "{}") as Record<string, unknown>;
+      const confirmed = selectedCommand?.risky ? window.confirm(`Run ${selectedCommand.label}?`) : false;
+      if (selectedCommand?.risky && !confirmed) {
+        throw new Error("Command cancelled.");
+      }
+      return runCli(commandId, params, confirmed);
+    }
+  });
+
+  return (
+    <section className="page-grid">
+      <div className="page-header">
+        <div>
+          <h1>Ops Console</h1>
+          <p>Raw MCP and allowlisted CLI controls for advanced testing.</p>
+        </div>
+      </div>
+
+      <section className="split-layout">
+        <div className="tool-panel">
+          <h2>MCP Tool</h2>
+          <FormField label="Tool name">
+            <input value={tool} onChange={(event) => setTool(event.target.value)} />
+          </FormField>
+          <FormField label="Arguments JSON">
+            <textarea value={toolArgs} onChange={(event) => setToolArgs(event.target.value)} rows={8} />
+          </FormField>
+          <button className="primary-button" type="button" onClick={() => mcpMutation.mutate()} disabled={mcpMutation.isPending}>
+            <Play size={16} />
+            <span>Call Tool</span>
+          </button>
+        </div>
+        <div className="tool-panel">
+          <h2>CLI Bridge</h2>
+          <FormField label="Command">
+            <select value={commandId} onChange={(event) => setCommandId(event.target.value)}>
+              {commands.map((command) => (
+                <option key={command.id} value={command.id}>
+                  {command.label}
+                </option>
+              ))}
+            </select>
+          </FormField>
+          <p className="muted">{selectedCommand?.description}</p>
+          <FormField label="Parameters JSON">
+            <textarea value={commandParams} onChange={(event) => setCommandParams(event.target.value)} rows={8} />
+          </FormField>
+          <button className="primary-button" type="button" onClick={() => cliMutation.mutate()} disabled={cliMutation.isPending}>
+            <Play size={16} />
+            <span>Run Command</span>
+          </button>
+        </div>
+      </section>
+
+      <section className="split-layout">
+        <JsonPanel title="MCP Result" value={mcpMutation.data ?? mcpMutation.error?.message ?? "No MCP call yet."} />
+        <JsonPanel title="CLI Result" value={cliMutation.data ?? cliMutation.error?.message ?? "No CLI command yet."} />
+      </section>
+    </section>
+  );
+}

--- a/playground/src/styles.css
+++ b/playground/src/styles.css
@@ -1,0 +1,670 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  background: #f6f7f3;
+  color: #111827;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  --panel: #ffffff;
+  --panel-muted: #f8fafc;
+  --line: #d7ddd4;
+  --line-strong: #b8c2b6;
+  --ink: #111827;
+  --muted: #667085;
+  --teal: #0f766e;
+  --teal-dark: #115e59;
+  --amber: #b45309;
+  --red: #b42318;
+  --blue: #1d4ed8;
+  --radius: 8px;
+  --shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  min-height: 100%;
+  margin: 0;
+}
+
+body {
+  min-width: 320px;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.app-shell {
+  display: grid;
+  grid-template-columns: 292px minmax(0, 1fr);
+  min-height: 100vh;
+}
+
+.sidebar {
+  position: sticky;
+  top: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  height: 100vh;
+  padding: 20px;
+  border-right: 1px solid var(--line);
+  background: #fbfcf8;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-height: 44px;
+  color: var(--teal-dark);
+}
+
+.brand strong,
+.brand span {
+  display: block;
+  line-height: 1.1;
+}
+
+.brand strong {
+  font-size: 1rem;
+}
+
+.brand span {
+  margin-top: 2px;
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+.nav-list {
+  display: grid;
+  gap: 6px;
+}
+
+.nav-link {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 40px;
+  padding: 0 10px;
+  border: 1px solid transparent;
+  border-radius: var(--radius);
+  color: #263238;
+  text-decoration: none;
+}
+
+.nav-link:hover {
+  border-color: var(--line);
+  background: #f2f7f3;
+}
+
+.nav-link.active {
+  border-color: #9dcac4;
+  background: #e8f5f3;
+  color: var(--teal-dark);
+}
+
+.status-panel {
+  display: grid;
+  gap: 8px;
+  margin-top: auto;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--panel);
+  box-shadow: var(--shadow);
+}
+
+.status-panel.error {
+  color: var(--red);
+}
+
+.status-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-width: 0;
+  font-size: 0.82rem;
+}
+
+.status-row span {
+  color: var(--muted);
+}
+
+.status-row strong {
+  max-width: 142px;
+  overflow: hidden;
+  color: var(--ink);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.runtime-actions {
+  display: flex;
+  gap: 8px;
+  padding-top: 4px;
+}
+
+.icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--panel-muted);
+  color: var(--ink);
+}
+
+.icon-button:hover {
+  border-color: var(--line-strong);
+  background: #eef2f6;
+}
+
+.path-readout {
+  max-width: 100%;
+  overflow: hidden;
+  color: var(--muted);
+  font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+  font-size: 0.72rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.runtime-log {
+  border-top: 1px solid var(--line);
+  padding-top: 8px;
+}
+
+.runtime-log summary {
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 0.78rem;
+}
+
+.runtime-log pre {
+  overflow: auto;
+  max-height: 180px;
+  margin: 8px 0 0;
+  padding: 8px;
+  border-radius: var(--radius);
+  background: #101828;
+  color: #e4edf7;
+  font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+  font-size: 0.72rem;
+  white-space: pre-wrap;
+}
+
+.main-pane {
+  min-width: 0;
+  padding: 28px;
+}
+
+.page-grid {
+  display: grid;
+  gap: 18px;
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  border-bottom: 1px solid var(--line);
+  padding-bottom: 16px;
+}
+
+.page-header h1 {
+  margin: 0;
+  font-size: clamp(1.35rem, 2vw, 1.85rem);
+  letter-spacing: 0;
+}
+
+.page-header p,
+.muted {
+  margin: 6px 0 0;
+  color: var(--muted);
+}
+
+.chat-surface,
+.tool-panel,
+.browser-pane,
+.viewer-pane,
+.answer-band,
+.json-panel,
+.empty-state,
+.toolbar-band {
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--panel);
+}
+
+.chat-surface,
+.tool-panel,
+.browser-pane,
+.viewer-pane,
+.answer-band,
+.empty-state,
+.toolbar-band {
+  padding: 16px;
+}
+
+.question-box {
+  display: grid;
+  gap: 12px;
+}
+
+textarea,
+input,
+select {
+  width: 100%;
+  min-height: 38px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius);
+  background: #fff;
+  color: var(--ink);
+}
+
+input,
+select {
+  padding: 0 10px;
+}
+
+textarea {
+  padding: 10px;
+  resize: vertical;
+}
+
+textarea:focus,
+input:focus,
+select:focus {
+  border-color: var(--teal);
+  outline: 3px solid rgba(15, 118, 110, 0.16);
+}
+
+.question-controls,
+.button-row,
+.toolbar-band {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 10px;
+}
+
+.form-field {
+  display: grid;
+  gap: 6px;
+  min-width: 160px;
+  color: var(--ink);
+  font-size: 0.86rem;
+  font-weight: 650;
+}
+
+.form-field small {
+  color: var(--muted);
+  font-weight: 400;
+}
+
+.primary-button,
+.secondary-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 38px;
+  border-radius: var(--radius);
+  padding: 0 13px;
+  white-space: nowrap;
+}
+
+.primary-button {
+  border: 1px solid var(--teal-dark);
+  background: var(--teal);
+  color: #fff;
+}
+
+.primary-button:hover {
+  background: var(--teal-dark);
+}
+
+.secondary-button {
+  border: 1px solid var(--line-strong);
+  background: #fff;
+  color: var(--ink);
+}
+
+.secondary-button:hover {
+  background: #f3f6f2;
+}
+
+.answer-band {
+  border-left: 4px solid var(--teal);
+}
+
+.answer-band h2,
+.tool-panel h2,
+.browser-pane h2,
+.viewer-pane h2,
+.json-panel header {
+  margin: 0 0 10px;
+  font-size: 1rem;
+  letter-spacing: 0;
+}
+
+.answer-band p {
+  margin: 0;
+  line-height: 1.55;
+}
+
+.result-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 14px;
+}
+
+.result-card {
+  display: grid;
+  gap: 12px;
+  min-height: 220px;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--panel);
+}
+
+.result-card header {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  min-width: 0;
+}
+
+.result-card h3 {
+  margin: 0;
+  overflow-wrap: anywhere;
+  font-size: 1rem;
+  letter-spacing: 0;
+}
+
+.result-card header span {
+  display: block;
+  margin-top: 3px;
+  overflow-wrap: anywhere;
+  color: var(--muted);
+  font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+  font-size: 0.76rem;
+}
+
+.result-card p {
+  margin: 0;
+  color: #344054;
+  line-height: 1.5;
+}
+
+.metadata-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  margin: 0;
+}
+
+.metadata-grid.wide {
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+}
+
+.metadata-grid div {
+  min-width: 0;
+  padding: 8px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--panel-muted);
+}
+
+.metadata-grid dt {
+  color: var(--muted);
+  font-size: 0.72rem;
+}
+
+.metadata-grid dd {
+  margin: 3px 0 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.inline-error,
+.notice.error {
+  color: var(--red);
+}
+
+.notice {
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: #fff8f6;
+}
+
+.split-layout {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.two-col {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.stack {
+  display: grid;
+  gap: 14px;
+}
+
+.file-layout {
+  display: grid;
+  grid-template-columns: minmax(220px, 300px) minmax(220px, 300px) minmax(0, 1fr);
+  gap: 16px;
+  align-items: start;
+}
+
+.browser-pane,
+.viewer-pane {
+  min-height: 620px;
+  overflow: hidden;
+}
+
+.viewer-pane {
+  display: grid;
+  grid-template-rows: auto minmax(240px, 1fr) auto;
+  gap: 12px;
+}
+
+.tree-view {
+  max-height: 540px;
+  overflow: auto;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: #fff;
+}
+
+.tree-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  min-height: 30px;
+  border: 0;
+  border-bottom: 1px solid #edf0ed;
+  background: transparent;
+  color: #263238;
+  text-align: left;
+}
+
+.tree-row:hover {
+  background: #f3f6f2;
+}
+
+.tree-row svg {
+  flex: 0 0 auto;
+  transition: transform 120ms ease;
+}
+
+.tree-row svg.open {
+  transform: rotate(90deg);
+}
+
+.tree-row.page,
+.tree-row.raw-import,
+.tree-row.file {
+  color: #1f3a5f;
+}
+
+.markdown-view {
+  min-height: 220px;
+  max-height: 430px;
+  overflow: auto;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: #fff;
+  line-height: 1.55;
+}
+
+.markdown-view h1,
+.markdown-view h2,
+.markdown-view h3 {
+  letter-spacing: 0;
+}
+
+.markdown-view pre,
+.json-panel pre {
+  overflow: auto;
+  max-width: 100%;
+  padding: 12px;
+  border-radius: var(--radius);
+  background: #101828;
+  color: #e4edf7;
+  font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+  font-size: 0.82rem;
+}
+
+.json-panel {
+  min-width: 0;
+  overflow: hidden;
+}
+
+.json-panel header {
+  padding: 12px 14px 0;
+}
+
+.json-panel pre {
+  min-height: 160px;
+  max-height: 340px;
+  margin: 0 14px 14px;
+}
+
+.graph-canvas {
+  width: 100%;
+  min-height: 640px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: #fff;
+}
+
+.empty-state {
+  color: var(--muted);
+  text-align: center;
+}
+
+.mobile-status {
+  display: none;
+}
+
+@media (max-width: 1040px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    position: static;
+    height: auto;
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .status-panel {
+    margin-top: 0;
+  }
+
+  .nav-list {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .split-layout,
+  .file-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 680px) {
+  .main-pane,
+  .sidebar {
+    padding: 14px;
+  }
+
+  .nav-list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .question-controls,
+  .button-row,
+  .toolbar-band,
+  .two-col {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .form-field {
+    min-width: 0;
+  }
+
+  .mobile-status {
+    display: flex;
+    position: fixed;
+    right: 10px;
+    bottom: 10px;
+    align-items: center;
+    gap: 8px;
+    max-width: calc(100vw - 20px);
+    padding: 8px 10px;
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    background: var(--panel);
+    color: var(--muted);
+    box-shadow: var(--shadow);
+    font-size: 0.78rem;
+  }
+}

--- a/playground/src/test/setup.ts
+++ b/playground/src/test/setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/playground/src/vite-env.d.ts
+++ b/playground/src/vite-env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="vite/client" />
+
+declare module "react-force-graph-2d";

--- a/playground/tests/components/ResultCard.test.tsx
+++ b/playground/tests/components/ResultCard.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ResultCard } from "../../src/components/ResultCard";
+
+describe("ResultCard", () => {
+  it("renders result metadata", () => {
+    render(
+      <ResultCard
+        item={{
+          result: { slug: "people/alice", score: 0.91 },
+          page: {
+            slug: "people/alice",
+            canonicalSlug: "default::people/alice",
+            title: "Alice",
+            type: "person",
+            summary: "Knows the retrieval system.",
+            compiled_truth: "",
+            timeline: "",
+            wing: "work",
+            room: "",
+            version: 2,
+            updated_at: "2026-05-16T00:00:00Z"
+          }
+        }}
+      />
+    );
+
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+    expect(screen.getByText("0.910")).toBeInTheDocument();
+    expect(screen.getByText("person")).toBeInTheDocument();
+  });
+});

--- a/playground/tests/e2e/playground.spec.ts
+++ b/playground/tests/e2e/playground.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from "@playwright/test";
+
+test("opens the playground shell", async ({ page }) => {
+  await page.goto("/chat");
+  await expect(page.getByRole("heading", { name: "Memory Search" })).toBeVisible();
+  await expect(page.getByRole("navigation", { name: "Playground sections" })).toBeVisible();
+});
+
+test("conversation extraction scenario", async ({ page }) => {
+  test.skip(process.env.QUAID_E2E !== "1", "Set QUAID_E2E=1 with a disposable QUAID_DB to run the full Quaid extraction flow.");
+
+  await page.goto("/conversation");
+  await page.getByRole("button", { name: /Add Turn/i }).click();
+  await page.getByRole("button", { name: /^Close$/i }).click();
+  await page.getByRole("button", { name: /Extract/i }).click();
+  await page.getByRole("button", { name: /Ask Memory/i }).click();
+  await expect(page.getByText(/coffee/i)).toBeVisible();
+});

--- a/playground/tests/unit/cli.test.ts
+++ b/playground/tests/unit/cli.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { buildCliArgs, CLI_COMMANDS } from "../../server/cli";
+
+describe("CLI allowlist", () => {
+  it("exposes only known command ids", () => {
+    expect(CLI_COMMANDS.map((command) => command.id)).toEqual(
+      expect.arrayContaining(["model.pull", "extraction.status", "config.set", "mcp.call"])
+    );
+  });
+
+  it("builds model pull without a database flag", () => {
+    expect(buildCliArgs({ id: "model.pull", params: { alias: "phi-3.5-mini" }, confirmed: true })).toEqual([
+      "model",
+      "pull",
+      "phi-3.5-mini"
+    ]);
+  });
+
+  it("validates raw MCP params JSON before building args", () => {
+    expect(() =>
+      buildCliArgs({
+        id: "mcp.call",
+        params: { tool: "memory_stats", params: "{not-json" },
+        confirmed: true
+      })
+    ).toThrow();
+  });
+});

--- a/playground/tests/unit/pathSafety.test.ts
+++ b/playground/tests/unit/pathSafety.test.ts
@@ -1,0 +1,20 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { isPathInside, safeSegment } from "../../server/pathSafety";
+
+describe("path safety", () => {
+  it("allows the root itself and descendants", () => {
+    const root = path.resolve("vault");
+    expect(isPathInside(root, root)).toBe(true);
+    expect(isPathInside(root, path.join(root, "notes", "a.md"))).toBe(true);
+  });
+
+  it("rejects sibling paths", () => {
+    const root = path.resolve("vault");
+    expect(isPathInside(root, path.resolve("vault-other", "a.md"))).toBe(false);
+  });
+
+  it("sanitizes profile names into path segments", () => {
+    expect(safeSegment("../base model")).toBe(".._base_model");
+  });
+});

--- a/playground/tests/unit/search.test.ts
+++ b/playground/tests/unit/search.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { composeRetrievalAnswer, normalizeSearchResults } from "../../src/lib/search";
+
+describe("search helpers", () => {
+  it("normalizes direct result arrays", () => {
+    expect(normalizeSearchResults([{ slug: "concept/a" }, { nope: true }])).toEqual([{ slug: "concept/a" }]);
+  });
+
+  it("builds a retrieval answer from enriched snippets", () => {
+    const answer = composeRetrievalAnswer("What do I drink?", [
+      {
+        result: { slug: "conversation/session", score: 0.8 },
+        page: {
+          slug: "conversation/session",
+          title: "Session",
+          type: "source",
+          summary: "The user prefers coffee over tea.",
+          compiled_truth: "",
+          timeline: "",
+          wing: "",
+          room: "",
+          version: 1,
+          updated_at: "2026-05-16T00:00:00Z"
+        }
+      }
+    ]);
+    expect(answer).toContain("coffee");
+  });
+});

--- a/playground/tsconfig.app.json
+++ b/playground/tsconfig.app.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src"]
+}

--- a/playground/tsconfig.json
+++ b/playground/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/playground/tsconfig.node.json
+++ b/playground/tsconfig.node.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node", "vitest/globals"],
+    "noEmit": true
+  },
+  "include": ["vite.config.ts", "server/**/*.ts", "playwright.config.ts"]
+}

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -1,0 +1,28 @@
+import react from "@vitejs/plugin-react";
+import type { Plugin } from "vite";
+import { defineConfig } from "vitest/config";
+import { createPlaygroundApiMiddleware } from "./server/index";
+
+function playgroundApiPlugin(): Plugin {
+  return {
+    name: "quaid-playground-api",
+    configureServer(server) {
+      server.middlewares.use("/api", createPlaygroundApiMiddleware());
+    }
+  };
+}
+
+export default defineConfig({
+  plugins: [react(), playgroundApiPlugin()],
+  server: {
+    host: "127.0.0.1",
+    port: 5174,
+    strictPort: false
+  },
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./src/test/setup.ts"],
+    exclude: ["node_modules/**", "dist/**", "tests/e2e/**"]
+  }
+});

--- a/src/commands/call.rs
+++ b/src/commands/call.rs
@@ -240,7 +240,7 @@ mod tests {
         let rows = result.as_array().expect("collections array");
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0]["name"], json!("default"));
-        assert_eq!(rows[0]["state"], json!("detached"));
+        assert_eq!(rows[0]["state"], json!("active"));
     }
 
     #[test]

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -18,6 +18,8 @@ use anyhow::{anyhow, Result};
 use clap::Subcommand;
 use rusqlite::Connection;
 
+#[cfg(unix)]
+use crate::commands::shutdown::ShutdownSignal;
 use crate::core::vault_sync;
 use crate::mcp::http::{DEFAULT_HTTP_BIND, DEFAULT_HTTP_PORT};
 use crate::mcp::HttpConfig;
@@ -139,6 +141,9 @@ async fn run_foreground(db: Connection, http_config: Option<HttpConfig>) -> Resu
     let db_path = vault_sync::database_path(&db)?;
     drop(db);
 
+    #[cfg(unix)]
+    let mut shutdown_signal = ShutdownSignal::arm();
+
     let runtime = match vault_sync::start_daemon_runtime(db_path.clone()) {
         Ok(rt) => rt,
         Err(err) => {
@@ -163,17 +168,35 @@ async fn run_foreground(db: Connection, http_config: Option<HttpConfig>) -> Resu
             move || crate::core::db::open(&db_path_for_factory).map_err(anyhow::Error::from);
         // Block on the SSE listener; the supervisor + worker run in
         // their own threads owned by `runtime`.
-        tokio::select! {
-            result = crate::mcp::http::run_http(factory, config) => {
-                if let Err(err) = result {
-                    eprintln!("daemon_http_transport_failed error={err}");
-                    return Ok(1);
+        #[cfg(unix)]
+        {
+            tokio::select! {
+                result = crate::mcp::http::run_http(factory, config) => {
+                    if let Err(err) = result {
+                        eprintln!("daemon_http_transport_failed error={err}");
+                        return Ok(1);
+                    }
                 }
+                () = shutdown_signal.recv() => {}
             }
-            () = wait_for_runtime(&runtime) => {}
+        }
+        #[cfg(not(unix))]
+        {
+            tokio::select! {
+                result = crate::mcp::http::run_http(factory, config) => {
+                    if let Err(err) = result {
+                        eprintln!("daemon_http_transport_failed error={err}");
+                        return Ok(1);
+                    }
+                }
+                () = wait_for_runtime(&runtime) => {}
+            }
         }
     } else {
         // No transport: block until the supervisor thread joins (SIGTERM).
+        #[cfg(unix)]
+        wait_for_runtime(&runtime, &mut shutdown_signal).await;
+        #[cfg(not(unix))]
         wait_for_runtime(&runtime).await;
     }
 
@@ -183,37 +206,19 @@ async fn run_foreground(db: Connection, http_config: Option<HttpConfig>) -> Resu
 
 /// Block until the supervisor thread exits. Used when no MCP transport
 /// is open and we still need the foreground task to wait for shutdown.
-async fn wait_for_runtime(_runtime: &vault_sync::ServeRuntime) {
-    #[cfg(unix)]
-    {
-        let mut sigterm =
-            match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
-                Ok(signal) => signal,
-                Err(_) => {
-                    std::future::pending::<()>().await;
-                    return;
-                }
-            };
-        let mut sigint =
-            match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt()) {
-                Ok(signal) => signal,
-                Err(_) => {
-                    let _ = sigterm.recv().await;
-                    return;
-                }
-            };
+#[cfg(unix)]
+async fn wait_for_runtime(
+    _runtime: &vault_sync::ServeRuntime,
+    shutdown_signal: &mut ShutdownSignal,
+) {
+    shutdown_signal.recv().await;
+}
 
-        tokio::select! {
-            _ = sigterm.recv() => {}
-            _ = sigint.recv() => {}
-        }
-    }
-    #[cfg(not(unix))]
-    {
-        // Fallback: block forever on a stalled future (the supervisor
-        // thread keeps the process alive; Ctrl-C tears the binary down).
-        std::future::pending::<()>().await;
-    }
+#[cfg(not(unix))]
+async fn wait_for_runtime(_runtime: &vault_sync::ServeRuntime) {
+    // Fallback: block forever on a stalled future (the supervisor
+    // thread keeps the process alive; Ctrl-C tears the binary down).
+    std::future::pending::<()>().await;
 }
 
 fn install_action(

--- a/src/commands/extraction.rs
+++ b/src/commands/extraction.rs
@@ -444,3 +444,208 @@ struct FailedJobStatus {
     attempts: i64,
     last_error: String,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::types::TurnRole;
+
+    fn configured_db() -> (tempfile::TempDir, Connection, PathBuf) {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let db_path = dir.path().join("memory.db");
+        let conn = db::open(db_path.to_str().expect("utf8 db path")).expect("open db");
+        let vault_root = dir.path().join("vault");
+        fs::create_dir_all(&vault_root).expect("vault root");
+        conn.execute(
+            "UPDATE collections
+             SET root_path = ?1,
+                 state = 'active',
+                 writable = 1,
+                 is_write_target = 1
+             WHERE id = 1",
+            [vault_root.display().to_string()],
+        )
+        .expect("configure root");
+        (dir, conn, vault_root)
+    }
+
+    #[test]
+    fn queue_counts_and_recent_failed_jobs_report_status_breakdown() {
+        let (_dir, conn, _root) = configured_db();
+        conn.execute_batch(
+            "INSERT INTO extraction_queue
+                 (session_id, conversation_path, trigger_kind, enqueued_at, scheduled_for, attempts, last_error, status)
+             VALUES
+                 ('pending', 'conversations/2026-05-03/pending.md', 'debounce', strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), 0, NULL, 'pending'),
+                 ('running', 'conversations/2026-05-03/running.md', 'debounce', strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), 1, NULL, 'running'),
+                 ('failed', 'conversations/2026-05-03/failed.md', 'debounce', strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), 2, 'abcdefghijklmnopqrstuvwxyz', 'failed')",
+        )
+        .expect("seed queue");
+
+        let counts = queue_counts(&conn).expect("queue counts");
+        let failed = recent_failed_jobs(&conn).expect("failed jobs");
+
+        assert_eq!(counts.pending, 1);
+        assert_eq!(counts.running, 1);
+        assert_eq!(counts.failed_recent, 1);
+        assert_eq!(failed[0].session_id, "failed");
+        assert_eq!(failed[0].attempts, 2);
+    }
+
+    #[test]
+    fn session_summaries_merge_namespaced_and_daily_conversations() {
+        let (_dir, conn, _root) = configured_db();
+        turn_writer::append_turn(
+            &conn,
+            "session-a",
+            TurnRole::User,
+            "first",
+            "2026-05-03T09:14:22Z",
+            None,
+            None,
+        )
+        .expect("append first");
+        turn_writer::append_turn(
+            &conn,
+            "session-a",
+            TurnRole::Assistant,
+            "second",
+            "2026-05-04T09:14:22Z",
+            None,
+            Some("alpha"),
+        )
+        .expect("append namespaced");
+
+        let summaries = session_summaries(&conn).expect("session summaries");
+        let paths = conversation_paths(&turn_writer::resolve_memory_root(&conn).unwrap().root_path)
+            .expect("conversation paths");
+
+        assert!(summaries
+            .iter()
+            .any(|summary| summary.display_name == "session-a"));
+        assert!(summaries
+            .iter()
+            .any(|summary| summary.display_name == "alpha/session-a"));
+        assert_eq!(
+            paths,
+            vec![
+                "alpha/conversations/2026-05-04/session-a.md".to_owned(),
+                "conversations/2026-05-03/session-a.md".to_owned(),
+            ]
+        );
+    }
+
+    #[test]
+    fn active_sessions_filters_closed_and_idle_sessions() {
+        let (_dir, conn, _root) = configured_db();
+        let sessions = vec![
+            SessionSummary {
+                display_name: "recent".to_owned(),
+                last_turn_at: "2999-01-01T00:00:00Z".to_owned(),
+                last_extracted_at: None,
+                status: ConversationStatus::Open,
+            },
+            SessionSummary {
+                display_name: "closed".to_owned(),
+                last_turn_at: "2999-01-01T00:00:00Z".to_owned(),
+                last_extracted_at: Some("2026-05-03T00:00:00Z".to_owned()),
+                status: ConversationStatus::Closed,
+            },
+            SessionSummary {
+                display_name: "idle".to_owned(),
+                last_turn_at: "2000-01-01T00:00:00Z".to_owned(),
+                last_extracted_at: None,
+                status: ConversationStatus::Open,
+            },
+        ];
+
+        let active = active_sessions(&conn, &sessions, 60_000).expect("active sessions");
+
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].display_name, "recent");
+    }
+
+    #[test]
+    fn helper_formatters_and_config_parsing_are_stable() {
+        let (_dir, conn, _root) = configured_db();
+        set_extraction_enabled(&conn, true).expect("enable extraction");
+        conn.execute(
+            "INSERT OR REPLACE INTO config(key, value) VALUES ('test.invalid', 'abc')",
+            [],
+        )
+        .expect("set invalid config");
+
+        assert!(extraction_enabled(&conn).expect("enabled"));
+        assert!(parse_i64_config(&conn, "test.invalid", 42).is_err());
+        assert_eq!(parse_i64_config(&conn, "test.missing", 42).unwrap(), 42);
+        assert_eq!(session_key(Some("alpha"), "s1"), "alpha::s1");
+        assert_eq!(session_key(None, "s1"), "s1");
+        assert_eq!(session_display_name(Some("alpha"), "s1"), "alpha/s1");
+        assert_eq!(session_display_name(None, "s1"), "s1");
+        assert_eq!(truncate_chars("abcdef", 3), "abc…");
+        assert_eq!(human_duration_ms(90_000), "1m30s");
+        assert_eq!(estimated_resident_memory("gemma-3-1b"), "~600 MiB");
+        assert_eq!(yes_no(true), "yes");
+        assert_eq!(yes_no(false), "no");
+    }
+
+    #[test]
+    fn status_and_disable_commands_run_without_model_downloads() {
+        let (_dir, conn, _root) = configured_db();
+
+        run(&conn, ExtractionAction::Status).expect("status");
+        run(&conn, ExtractionAction::Disable).expect("disable");
+
+        assert!(!extraction_enabled(&conn).expect("disabled"));
+    }
+
+    #[test]
+    fn enabled_status_prints_active_sessions_failed_jobs_and_blocked_runtime() {
+        let (_dir, conn, _root) = configured_db();
+        set_extraction_enabled(&conn, true).expect("enable extraction");
+        turn_writer::append_turn(
+            &conn,
+            "live-session",
+            TurnRole::User,
+            "hello",
+            "2999-01-01T00:00:00Z",
+            None,
+            None,
+        )
+        .expect("append active turn");
+        conn.execute_batch(
+            "INSERT INTO extraction_queue
+                 (session_id, conversation_path, trigger_kind, enqueued_at, scheduled_for, attempts, last_error, status)
+             VALUES
+                 ('failed-now', 'conversations/2999-01-01/live-session.md', 'manual', strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), 3, 'model cache missing', 'failed')",
+        )
+        .expect("seed failed job");
+
+        run(&conn, ExtractionAction::Status).expect("enabled status");
+
+        let sessions = session_summaries(&conn).expect("sessions");
+        assert!(runtime_state(true, "org/missing-model", &sessions).contains("blocked"));
+        assert_eq!(active_sessions(&conn, &sessions, 60_000).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn print_helpers_cover_non_empty_rows_and_short_durations() {
+        print_active_sessions(
+            30_000,
+            &[ActiveSessionStatus {
+                display_name: "session".to_owned(),
+                idle_seconds: 12,
+                last_extracted_at: Some("2026-05-03T00:00:00Z".to_owned()),
+            }],
+        );
+        print_failed_jobs(&[FailedJobStatus {
+            session_id: "session".to_owned(),
+            attempts: 2,
+            last_error: "failed".to_owned(),
+        }]);
+
+        assert_eq!(human_duration_seconds(12), "12s");
+        assert_eq!(estimated_resident_memory("gemma-3-4b"), "~2.0 GiB+");
+        assert_eq!(estimated_resident_memory("custom"), "unknown");
+    }
+}

--- a/src/commands/extraction.rs
+++ b/src/commands/extraction.rs
@@ -40,7 +40,7 @@ pub fn run(db: &Connection, action: ExtractionAction) -> Result<()> {
 
 fn enable(db: &Connection) -> Result<()> {
     let alias = db::read_config_value_or(db, "extraction.model_alias", "phi-3.5-mini")?;
-    let mut progress = ConsoleProgressReporter;
+    let mut progress = ConsoleProgressReporter::default();
     let cache_dir = tokio::task::block_in_place(|| download_model(&alias, &mut progress))?;
     set_extraction_enabled(db, true)?;
     println!("Extraction enabled: yes");

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -22,6 +22,8 @@ pub mod put;
 pub mod query;
 pub mod search;
 pub mod serve;
+#[cfg(unix)]
+pub(crate) mod shutdown;
 pub mod skills;
 pub mod stats;
 pub mod status;

--- a/src/commands/model.rs
+++ b/src/commands/model.rs
@@ -268,3 +268,197 @@ fn human_duration(duration: std::time::Duration) -> String {
         format!("{seconds:.1} s")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::conversation::model_lifecycle::{ModelCacheFamily, ModelCacheState};
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let previous = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            if let Some(value) = self.previous.as_ref() {
+                std::env::set_var(self.key, value);
+            } else {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
+
+    fn entry(
+        state: ModelCacheState,
+        cleanup_eligible: bool,
+        complete_cache: bool,
+    ) -> ModelCacheEntry {
+        ModelCacheEntry {
+            family: ModelCacheFamily::Extraction,
+            alias: Some("phi-3.5-mini".to_owned()),
+            cache_key: format!("{state}"),
+            path: std::path::PathBuf::from(format!("/tmp/{state}")),
+            state,
+            reason: state.to_string(),
+            file_count: 0,
+            size_bytes: 0,
+            modified_unix: None,
+            cleanup_eligible,
+            complete_cache,
+        }
+    }
+
+    #[test]
+    fn cleanup_candidates_selects_safe_entries_for_each_mode() {
+        let stale = entry(ModelCacheState::StaleTemporary, true, false);
+        let complete = entry(ModelCacheState::Complete, false, true);
+        let missing = entry(ModelCacheState::Missing, false, false);
+        let entries = vec![stale.clone(), complete.clone(), missing];
+
+        assert_eq!(
+            cleanup_candidates(&entries, false, false),
+            vec![stale.clone()]
+        );
+        assert_eq!(
+            cleanup_candidates(&entries, false, true),
+            vec![stale.clone()]
+        );
+        assert_eq!(
+            cleanup_candidates(&entries, true, false),
+            vec![stale, complete]
+        );
+    }
+
+    #[test]
+    fn human_formatters_use_binary_units_and_seconds() {
+        assert_eq!(human_bytes(512), "512 B");
+        assert_eq!(human_bytes(1536), "1.5 KiB");
+        assert_eq!(human_bytes(1024 * 1024), "1.0 MiB");
+        assert_eq!(
+            human_duration(std::time::Duration::from_millis(250)),
+            "250 ms"
+        );
+        assert_eq!(
+            human_duration(std::time::Duration::from_millis(1250)),
+            "1.2 s"
+        );
+    }
+
+    #[test]
+    fn collect_cache_files_recurses_and_uses_relative_slash_paths() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let nested = dir.path().join("nested");
+        std::fs::create_dir_all(&nested).expect("nested dir");
+        std::fs::write(dir.path().join("root.bin"), [1_u8, 2]).expect("root file");
+        std::fs::write(nested.join("child.bin"), [3_u8, 4, 5]).expect("child file");
+
+        let mut files = Vec::new();
+        collect_cache_files(dir.path(), dir.path(), &mut files);
+        files.sort_by(|left, right| left.0.cmp(&right.0));
+
+        assert_eq!(
+            files,
+            vec![
+                ("nested/child.bin".to_owned(), 3),
+                ("root.bin".to_owned(), 2)
+            ]
+        );
+    }
+
+    #[test]
+    fn print_helpers_accept_empty_and_populated_reports() {
+        print_cache_entries(&[], "empty", false);
+        print_cache_entries(
+            &[entry(ModelCacheState::Complete, false, true)],
+            "empty",
+            true,
+        );
+        print_clean_report(&ModelCacheCleanReport {
+            removed: vec![
+                crate::core::conversation::model_lifecycle::ModelCacheRemoval {
+                    path: std::path::PathBuf::from("/tmp/removed"),
+                    size_bytes: 2048,
+                    error: None,
+                },
+            ],
+            failed: vec![
+                crate::core::conversation::model_lifecycle::ModelCacheRemoval {
+                    path: std::path::PathBuf::from("/tmp/failed"),
+                    size_bytes: 0,
+                    error: Some("nope".to_owned()),
+                },
+            ],
+            bytes_freed: 2048,
+        });
+    }
+
+    #[test]
+    fn run_status_and_clean_list_paths_do_not_require_downloads() {
+        run(ModelAction::Status {
+            alias: Some("phi-3.5-mini".to_owned()),
+            verbose: false,
+            verify: false,
+        })
+        .expect("status should inspect local cache only");
+
+        clean(None, false, false, false).expect("default clean lists candidates only");
+
+        let error = clean(Some("phi-3.5-mini"), false, true, false)
+            .expect_err("alias and all are mutually exclusive");
+        assert!(error.to_string().contains("either an alias or --all"));
+    }
+
+    #[test]
+    fn run_pull_and_verified_status_paths_do_not_download_without_feature() {
+        if cfg!(feature = "online-model") {
+            return;
+        }
+
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let error = runtime
+            .block_on(async {
+                run(ModelAction::Pull {
+                    alias: "phi-3.5-mini".to_owned(),
+                })
+            })
+            .expect_err("offline build reports unsupported downloads");
+        assert!(error.to_string().contains("online-model"));
+
+        run(ModelAction::Status {
+            alias: Some("phi-3.5-mini".to_owned()),
+            verbose: false,
+            verify: true,
+        })
+        .expect("verified status should inspect local cache only");
+    }
+
+    #[test]
+    fn clean_force_removes_alias_cache_from_temp_root() {
+        let cache_root = tempfile::TempDir::new().expect("cache root");
+        let _cache_root = EnvVarGuard::set("QUAID_MODEL_CACHE_DIR", cache_root.path());
+        let cache_dir = cache_root.path().join("org-test-model");
+        std::fs::create_dir(&cache_dir).expect("cache dir");
+
+        run(ModelAction::Clean {
+            alias: Some("org/test-model".to_owned()),
+            list: false,
+            all: false,
+            force: true,
+        })
+        .expect("clean removes corrupt alias cache");
+
+        assert!(!cache_dir.exists());
+    }
+}

--- a/src/commands/model.rs
+++ b/src/commands/model.rs
@@ -3,24 +3,268 @@
     reason = "CLI command prints user-facing output to stdout by design"
 )]
 
-use anyhow::Result;
+use std::io::{self, Write};
+use std::path::Path;
+use std::time::Instant;
+
+use anyhow::{bail, Result};
 use clap::Subcommand;
 
-use crate::core::conversation::model_lifecycle::{download_model, ConsoleProgressReporter};
+use crate::core::conversation::model_lifecycle::{
+    download_model, inspect_model_caches, remove_model_cache_entries, ConsoleProgressReporter,
+    ModelCacheCleanReport, ModelCacheEntry,
+};
 
 #[derive(Clone, Debug, PartialEq, Eq, Subcommand)]
 pub enum ModelAction {
-    /// Download a local SLM into the Quaid model cache
+    /// Download a local extraction SLM into the Quaid model cache
     Pull { alias: String },
+    /// Show model cache status for extraction and embedding models
+    Status {
+        /// Optional model alias or repo id to inspect
+        alias: Option<String>,
+        /// Show cache keys, mtimes, cleanup eligibility, and file paths
+        #[arg(long)]
+        verbose: bool,
+        /// Verify file hashes instead of using fast metadata validation
+        #[arg(long)]
+        verify: bool,
+    },
+    /// Remove incomplete, stale, or explicitly selected model cache entries
+    Clean {
+        /// Optional model alias or repo id to clean
+        alias: Option<String>,
+        /// List removal candidates without deleting anything
+        #[arg(long)]
+        list: bool,
+        /// Clean all stale temporary and invalid cache entries
+        #[arg(long)]
+        all: bool,
+        /// Skip the interactive confirmation prompt
+        #[arg(long)]
+        force: bool,
+    },
 }
 
 pub fn run(action: ModelAction) -> Result<()> {
     match action {
         ModelAction::Pull { alias } => {
-            let mut progress = ConsoleProgressReporter;
+            let mut progress = ConsoleProgressReporter::default();
             let cache_dir = tokio::task::block_in_place(|| download_model(&alias, &mut progress))?;
             println!("Model cached at {}", cache_dir.display());
             Ok(())
         }
+        ModelAction::Status {
+            alias,
+            verbose,
+            verify,
+        } => {
+            let started = Instant::now();
+            let entries = inspect_model_caches(alias.as_deref(), verify)?;
+            print_cache_entries(&entries, "No model caches found.", verbose);
+            if verify {
+                println!(
+                    "Verification completed in {}.",
+                    human_duration(started.elapsed())
+                );
+            }
+            Ok(())
+        }
+        ModelAction::Clean {
+            alias,
+            list,
+            all,
+            force,
+        } => clean(alias.as_deref(), list, all, force),
+    }
+}
+
+fn clean(alias: Option<&str>, list: bool, all: bool, force: bool) -> Result<()> {
+    if alias.is_some() && all {
+        bail!("use either an alias or --all, not both");
+    }
+
+    let entries = inspect_model_caches(alias, false)?;
+    let candidates = cleanup_candidates(&entries, alias.is_some(), all);
+    if list || (!all && alias.is_none()) {
+        println!("Would remove:");
+        print_cache_entries(&candidates, "No cleanup candidates found.", false);
+        if !all && alias.is_none() {
+            println!("No caches removed. Use `quaid model clean --all` to remove these entries.");
+        }
+        return Ok(());
+    }
+
+    if candidates.is_empty() {
+        println!("No cleanup candidates found.");
+        return Ok(());
+    }
+
+    println!("Will remove:");
+    print_cache_entries(&candidates, "No cleanup candidates found.", false);
+    if !force && !confirm_cleanup(candidates.len(), all, alias)? {
+        println!("No caches removed.");
+        return Ok(());
+    }
+
+    let report = remove_model_cache_entries(&candidates);
+    print_clean_report(&report);
+    if !report.failed.is_empty() {
+        bail!("failed to remove {} cache entrie(s)", report.failed.len());
+    }
+    Ok(())
+}
+
+fn cleanup_candidates(
+    entries: &[ModelCacheEntry],
+    alias_specific: bool,
+    all: bool,
+) -> Vec<ModelCacheEntry> {
+    entries
+        .iter()
+        .filter(|entry| {
+            if all {
+                entry.cleanup_eligible
+            } else if alias_specific {
+                entry.cleanup_eligible || entry.complete_cache
+            } else {
+                entry.cleanup_eligible
+            }
+        })
+        .cloned()
+        .collect()
+}
+
+fn print_cache_entries(entries: &[ModelCacheEntry], empty_message: &str, verbose: bool) {
+    if entries.is_empty() {
+        println!("{empty_message}");
+        return;
+    }
+
+    println!(
+        "{:<10} {:<12} {:<14} {:>5} {:>10} {:>12}  Path",
+        "Family", "Alias/Key", "State", "Files", "Size", "Modified"
+    );
+    for entry in entries {
+        let alias_or_key = entry.alias.as_deref().unwrap_or(&entry.cache_key);
+        println!(
+            "{:<10} {:<12} {:<14} {:>5} {:>10} {:>12}  {}",
+            entry.family,
+            alias_or_key,
+            entry.state,
+            entry.file_count,
+            human_bytes(entry.size_bytes),
+            entry
+                .modified_unix
+                .map(|modified| modified.to_string())
+                .unwrap_or_else(|| "-".to_owned()),
+            entry.path.display()
+        );
+        println!("  {}", entry.reason);
+        if verbose {
+            println!("  Cache key: {}", entry.cache_key);
+            println!("  Cleanup eligible: {}", entry.cleanup_eligible);
+            print_cache_files(&entry.path);
+        }
+    }
+    let total = entries
+        .iter()
+        .fold(0_u64, |total, entry| total.saturating_add(entry.size_bytes));
+    println!("Total size: {}", human_bytes(total));
+}
+
+fn print_clean_report(report: &ModelCacheCleanReport) {
+    for removed in &report.removed {
+        println!(
+            "Removed {} ({})",
+            removed.path.display(),
+            human_bytes(removed.size_bytes)
+        );
+    }
+    for failed in &report.failed {
+        println!(
+            "Failed {}: {}",
+            failed.path.display(),
+            failed.error.as_deref().unwrap_or("unknown error")
+        );
+    }
+    println!("Freed {}", human_bytes(report.bytes_freed));
+}
+
+fn confirm_cleanup(count: usize, all: bool, alias: Option<&str>) -> Result<bool> {
+    let scope = if all {
+        "all stale or invalid model cache entries".to_owned()
+    } else if let Some(alias) = alias {
+        format!("cache entries for `{alias}`")
+    } else {
+        "selected model cache entries".to_owned()
+    };
+    eprint!("Remove {count} {scope}? [y/N] ");
+    io::stderr().flush()?;
+
+    let mut answer = String::new();
+    io::stdin().read_line(&mut answer)?;
+    Ok(matches!(
+        answer.trim().to_ascii_lowercase().as_str(),
+        "y" | "yes"
+    ))
+}
+
+fn human_bytes(bytes: u64) -> String {
+    const UNITS: [&str; 5] = ["B", "KiB", "MiB", "GiB", "TiB"];
+    let mut value = bytes as f64;
+    let mut unit = 0_usize;
+    while value >= 1024.0 && unit + 1 < UNITS.len() {
+        value /= 1024.0;
+        unit += 1;
+    }
+    if unit == 0 {
+        format!("{bytes} {}", UNITS[unit])
+    } else {
+        format!("{value:.1} {}", UNITS[unit])
+    }
+}
+
+fn print_cache_files(path: &Path) {
+    let mut files = Vec::new();
+    collect_cache_files(path, path, &mut files);
+    files.sort_by(|left, right| left.0.cmp(&right.0));
+    for (relative, size_bytes) in files {
+        println!("  - {relative} ({})", human_bytes(size_bytes));
+    }
+}
+
+fn collect_cache_files(root: &Path, current: &Path, files: &mut Vec<(String, u64)>) {
+    let Ok(metadata) = std::fs::symlink_metadata(current) else {
+        return;
+    };
+    if metadata.is_file() {
+        let relative = current
+            .strip_prefix(root)
+            .ok()
+            .and_then(|path| path.to_str())
+            .filter(|path| !path.is_empty())
+            .unwrap_or_else(|| current.to_str().unwrap_or("<non-utf8>"))
+            .replace('\\', "/");
+        files.push((relative, metadata.len()));
+        return;
+    }
+    if !metadata.is_dir() {
+        return;
+    }
+    let Ok(read_dir) = std::fs::read_dir(current) else {
+        return;
+    };
+    for entry in read_dir.filter_map(Result::ok) {
+        collect_cache_files(root, &entry.path(), files);
+    }
+}
+
+fn human_duration(duration: std::time::Duration) -> String {
+    let seconds = duration.as_secs_f64();
+    if seconds < 1.0 {
+        format!("{:.0} ms", seconds * 1000.0)
+    } else {
+        format!("{seconds:.1} s")
     }
 }

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -1,6 +1,8 @@
 use anyhow::{anyhow, Result};
 use rusqlite::Connection;
 
+#[cfg(unix)]
+use crate::commands::shutdown::ShutdownSignal;
 use crate::mcp::HttpConfig;
 
 /// Run `quaid serve` — start the live vault-sync supervisor (when this
@@ -16,6 +18,9 @@ pub async fn run(db: Connection, http_config: Option<HttpConfig>) -> Result<()> 
         crate::mcp::http::bind_with_token_guard(config)?;
     }
 
+    #[cfg(unix)]
+    let mut shutdown_signal = ShutdownSignal::arm();
+
     let db_path = crate::core::vault_sync::database_path(&db)?;
     // `start_serve_runtime` registers as `serve` and attempts to promote
     // to `serve_host`. If a `daemon` is live it returns a transport-only
@@ -26,7 +31,14 @@ pub async fn run(db: Connection, http_config: Option<HttpConfig>) -> Result<()> 
     match http_config {
         None => {
             drop(db);
-            run_stdio_until_shutdown(db_path).await
+            #[cfg(unix)]
+            {
+                run_stdio_until_shutdown(db_path, &mut shutdown_signal).await
+            }
+            #[cfg(not(unix))]
+            {
+                run_stdio_until_shutdown(db_path).await
+            }
         }
         Some(config) => {
             // The HTTP transport opens its own DB connection(s) per
@@ -35,34 +47,43 @@ pub async fn run(db: Connection, http_config: Option<HttpConfig>) -> Result<()> 
             // returns. `db_path` is captured by value in the factory.
             drop(db);
             let factory = move || crate::core::db::open(&db_path).map_err(anyhow::Error::from);
-            run_http_until_shutdown(factory, config).await
+            #[cfg(unix)]
+            {
+                run_http_until_shutdown(factory, config, &mut shutdown_signal).await
+            }
+            #[cfg(not(unix))]
+            {
+                run_http_until_shutdown(factory, config).await
+            }
         }
     }
 }
 
-async fn run_stdio_until_shutdown(db_path: String) -> Result<()> {
-    #[cfg(unix)]
-    {
-        let (sender, receiver) = tokio::sync::oneshot::channel();
-        std::thread::Builder::new()
-            .name("quaid-mcp-stdio".to_owned())
-            .spawn(move || {
-                let result = run_stdio_blocking(db_path);
-                let _ = sender.send(result);
-            })
-            .map_err(|error| anyhow!("failed to spawn MCP stdio thread: {error}"))?;
+#[cfg(unix)]
+async fn run_stdio_until_shutdown(
+    db_path: String,
+    shutdown_signal: &mut ShutdownSignal,
+) -> Result<()> {
+    let (sender, receiver) = tokio::sync::oneshot::channel();
+    std::thread::Builder::new()
+        .name("quaid-mcp-stdio".to_owned())
+        .spawn(move || {
+            let result = run_stdio_blocking(db_path);
+            let _ = sender.send(result);
+        })
+        .map_err(|error| anyhow!("failed to spawn MCP stdio thread: {error}"))?;
 
-        tokio::select! {
-            result = receiver => result
-                .map_err(|_| anyhow!("MCP stdio thread terminated without reporting a result"))?,
-            () = shutdown_signal() => Ok(()),
-        }
+    tokio::select! {
+        result = receiver => result
+            .map_err(|_| anyhow!("MCP stdio thread terminated without reporting a result"))?,
+        () = shutdown_signal.recv() => Ok(()),
     }
-    #[cfg(not(unix))]
-    {
-        let db = crate::core::db::open(&db_path)?;
-        crate::mcp::server::run_stdio(db).await
-    }
+}
+
+#[cfg(not(unix))]
+async fn run_stdio_until_shutdown(db_path: String) -> Result<()> {
+    let db = crate::core::db::open(&db_path)?;
+    crate::mcp::server::run_stdio(db).await
 }
 
 #[cfg(unix)]
@@ -75,44 +96,25 @@ fn run_stdio_blocking(db_path: String) -> Result<()> {
         .block_on(crate::mcp::server::run_stdio(db))
 }
 
+#[cfg(unix)]
+async fn run_http_until_shutdown<F>(
+    factory: F,
+    config: HttpConfig,
+    shutdown_signal: &mut ShutdownSignal,
+) -> Result<()>
+where
+    F: Fn() -> Result<Connection> + Send + Sync + 'static,
+{
+    tokio::select! {
+        result = crate::mcp::http::run_http(factory, config) => result,
+        () = shutdown_signal.recv() => Ok(()),
+    }
+}
+
+#[cfg(not(unix))]
 async fn run_http_until_shutdown<F>(factory: F, config: HttpConfig) -> Result<()>
 where
     F: Fn() -> Result<Connection> + Send + Sync + 'static,
 {
-    #[cfg(unix)]
-    {
-        tokio::select! {
-            result = crate::mcp::http::run_http(factory, config) => result,
-            () = shutdown_signal() => Ok(()),
-        }
-    }
-    #[cfg(not(unix))]
-    {
-        crate::mcp::http::run_http(factory, config).await
-    }
-}
-
-#[cfg(unix)]
-async fn shutdown_signal() {
-    let mut sigterm = match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
-    {
-        Ok(signal) => signal,
-        Err(_) => {
-            std::future::pending::<()>().await;
-            return;
-        }
-    };
-    let mut sigint = match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())
-    {
-        Ok(signal) => signal,
-        Err(_) => {
-            let _ = sigterm.recv().await;
-            return;
-        }
-    };
-
-    tokio::select! {
-        _ = sigterm.recv() => {}
-        _ = sigint.recv() => {}
-    }
+    crate::mcp::http::run_http(factory, config).await
 }

--- a/src/commands/shutdown.rs
+++ b/src/commands/shutdown.rs
@@ -1,0 +1,33 @@
+#![cfg(unix)]
+
+pub(crate) struct ShutdownSignal {
+    sigterm: Option<tokio::signal::unix::Signal>,
+    sigint: Option<tokio::signal::unix::Signal>,
+}
+
+impl ShutdownSignal {
+    pub(crate) fn arm() -> Self {
+        let sigterm =
+            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()).ok();
+        let sigint = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt()).ok();
+        Self { sigterm, sigint }
+    }
+
+    pub(crate) async fn recv(&mut self) {
+        match (&mut self.sigterm, &mut self.sigint) {
+            (Some(sigterm), Some(sigint)) => {
+                tokio::select! {
+                    _ = sigterm.recv() => {}
+                    _ = sigint.recv() => {}
+                }
+            }
+            (Some(sigterm), None) => {
+                let _ = sigterm.recv().await;
+            }
+            (None, Some(sigint)) => {
+                let _ = sigint.recv().await;
+            }
+            (None, None) => std::future::pending::<()>().await,
+        }
+    }
+}

--- a/src/commands/stats.rs
+++ b/src/commands/stats.rs
@@ -220,7 +220,9 @@ mod tests {
         assert_eq!(stats.collection_totals.quarantined_pages, 0);
         assert_eq!(stats.collection_totals.embedding_jobs_pending, 0);
         assert_eq!(stats.collection_totals.embedding_jobs_failed, 0);
-        assert!(stats.collections.is_empty());
+        assert_eq!(stats.collections.len(), 1);
+        assert_eq!(stats.collections[0].name, "default");
+        assert_eq!(stats.collections[0].page_count, 0);
     }
 
     #[test]

--- a/src/core/conversation/model_lifecycle.rs
+++ b/src/core/conversation/model_lifecycle.rs
@@ -14,16 +14,16 @@
 
 #[cfg(feature = "online-model")]
 use std::collections::BTreeSet;
+use std::fmt;
 use std::fs::{self, File};
 use std::io::Read;
 #[cfg(feature = "online-model")]
 use std::io::Write;
 use std::path::{Component, Path, PathBuf};
-#[cfg(feature = "online-model")]
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "online-model")]
+#[cfg(any(feature = "online-model", test, feature = "test-harness"))]
 use sha1::Sha1;
 use sha2::{Digest, Sha256};
 use thiserror::Error;
@@ -33,9 +33,11 @@ const DEFAULT_HUGGINGFACE_BASE_URL: &str = "https://huggingface.co";
 const MODEL_CACHE_ROOT_ENV: &str = "QUAID_MODEL_CACHE_DIR";
 #[cfg(feature = "online-model")]
 const HUGGINGFACE_BASE_URL_ENV: &str = "QUAID_HF_BASE_URL";
+const STALE_CACHE_TTL_ENV: &str = "QUAID_STALE_MODEL_CACHE_TTL_SECS";
 const MANIFEST_FILE_NAME: &str = "manifest.json";
-#[cfg(feature = "online-model")]
-const STALE_DOWNLOAD_TTL: Duration = Duration::from_secs(6 * 60 * 60);
+const DOWNLOAD_HEARTBEAT_FILE: &str = ".downloading";
+const MANIFEST_VERSION: u32 = 1;
+const DEFAULT_STALE_DOWNLOAD_TTL: Duration = Duration::from_secs(6 * 60 * 60);
 
 const PHI_35_MINI_REVISION: &str = "2fe192450127e6a83f7441aef6e3ca586c338b77";
 const GEMMA_3_1B_REVISION: &str = "dcc83ea841ab6100d6b47a070329e1ba4cf78752";
@@ -112,13 +114,27 @@ pub trait ProgressReporter {
 
 /// Human-readable stderr reporter for CLI commands.
 #[derive(Debug, Default)]
-pub struct ConsoleProgressReporter;
+pub struct ConsoleProgressReporter {
+    started_at: Option<Instant>,
+    current_file_started_at: Option<Instant>,
+    last_progress_at: Option<Instant>,
+    planned_files: usize,
+    finished_files: usize,
+}
 
 impl ProgressReporter for ConsoleProgressReporter {
     fn planned(&mut self, alias: &ResolvedModelAlias, file_count: usize) {
+        self.started_at = Some(Instant::now());
+        self.planned_files = file_count;
         eprintln!(
-            "Downloading model `{}` from {} ({} file(s))",
-            alias.requested_alias, alias.repo_id, file_count
+            "Downloading model `{}` from {}{} ({} file(s))",
+            alias.requested_alias,
+            alias.repo_id,
+            alias
+                .revision
+                .as_deref()
+                .map_or_else(String::new, |revision| { format!(" @ {revision}") }),
+            file_count
         );
     }
 
@@ -127,14 +143,78 @@ impl ProgressReporter for ConsoleProgressReporter {
     }
 
     fn file_started(&mut self, file_name: &str, bytes_total: Option<u64>) {
+        self.current_file_started_at = Some(Instant::now());
+        self.last_progress_at = None;
         match bytes_total {
-            Some(bytes_total) => eprintln!("  → {file_name} ({bytes_total} bytes)"),
-            None => eprintln!("  → {file_name}"),
+            Some(bytes_total) => eprintln!("  -> {file_name} ({})", human_bytes(bytes_total)),
+            None => eprintln!("  -> {file_name}"),
         }
     }
 
-    fn file_finished(&mut self, file_name: &str, _actual_sha256: &str) {
-        eprintln!("  ✓ {file_name}");
+    fn file_progress(&mut self, file_name: &str, downloaded_bytes: u64, bytes_total: Option<u64>) {
+        let now = Instant::now();
+        if self
+            .last_progress_at
+            .is_some_and(|last| now.duration_since(last) < Duration::from_secs(1))
+            && bytes_total != Some(downloaded_bytes)
+        {
+            return;
+        }
+        self.last_progress_at = Some(now);
+
+        let elapsed = self
+            .current_file_started_at
+            .map(|started| now.duration_since(started))
+            .unwrap_or_default();
+        let speed = if elapsed.as_secs_f64() > 0.0 {
+            downloaded_bytes as f64 / elapsed.as_secs_f64()
+        } else {
+            0.0
+        };
+        let eta = bytes_total.and_then(|total| {
+            if speed > 0.0 && total > downloaded_bytes {
+                Some(Duration::from_secs_f64(
+                    (total - downloaded_bytes) as f64 / speed,
+                ))
+            } else {
+                None
+            }
+        });
+
+        match (bytes_total, eta) {
+            (Some(total), Some(eta)) => eprintln!(
+                "     {file_name}: {} / {} ({}/s, ~{} remaining)",
+                human_bytes(downloaded_bytes),
+                human_bytes(total),
+                human_bytes(speed as u64),
+                human_duration(eta)
+            ),
+            (Some(total), None) => eprintln!(
+                "     {file_name}: {} / {}",
+                human_bytes(downloaded_bytes),
+                human_bytes(total)
+            ),
+            (None, _) => eprintln!("     {file_name}: {}", human_bytes(downloaded_bytes)),
+        }
+    }
+
+    fn file_finished(&mut self, file_name: &str, actual_sha256: &str) {
+        self.finished_files += 1;
+        let elapsed = self
+            .started_at
+            .map(|started| human_duration(started.elapsed()))
+            .unwrap_or_else(|| "unknown time".to_owned());
+        let digest_prefix = actual_sha256.get(..12).unwrap_or(actual_sha256);
+        eprintln!(
+            "  ok {file_name} (SHA-256: {digest_prefix}..., {}/{}, {elapsed})",
+            self.finished_files, self.planned_files
+        );
+        if self.planned_files > 0 && self.finished_files >= self.planned_files {
+            eprintln!(
+                "Download complete: {} file(s) verified in {elapsed}",
+                self.finished_files
+            );
+        }
     }
 }
 
@@ -143,6 +223,36 @@ impl ProgressReporter for ConsoleProgressReporter {
 pub struct NoopProgressReporter;
 
 impl ProgressReporter for NoopProgressReporter {}
+
+fn human_bytes(bytes: u64) -> String {
+    const UNITS: [&str; 5] = ["B", "KiB", "MiB", "GiB", "TiB"];
+    let mut value = bytes as f64;
+    let mut unit = 0;
+    while value >= 1024.0 && unit + 1 < UNITS.len() {
+        value /= 1024.0;
+        unit += 1;
+    }
+    if unit == 0 {
+        format!("{bytes} {}", UNITS[unit])
+    } else {
+        format!("{value:.1} {}", UNITS[unit])
+    }
+}
+
+fn human_duration(duration: Duration) -> String {
+    let seconds = duration.as_secs();
+    if seconds < 60 {
+        return format!("{seconds}s");
+    }
+    let minutes = seconds / 60;
+    let remainder = seconds % 60;
+    if minutes < 60 {
+        return format!("{minutes}m{remainder:02}s");
+    }
+    let hours = minutes / 60;
+    let minutes = minutes % 60;
+    format!("{hours}h{minutes:02}m")
+}
 
 /// Result of resolving a user-supplied alias to the concrete HuggingFace
 /// repo, revision, and cache key that the lifecycle code operates on.
@@ -175,6 +285,121 @@ pub struct CachedModelStatus {
     /// `true` when every file in the manifest was verified against a
     /// source-pinned digest, not a server-supplied hash.
     pub source_pinned: bool,
+}
+
+/// High-level family for a cache entry discovered under the shared model
+/// cache root.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModelCacheFamily {
+    /// Chat/extraction SLM cache managed by `quaid model pull`.
+    Extraction,
+    /// Embedding model cache managed by semantic indexing/query paths.
+    Embedding,
+}
+
+impl ModelCacheFamily {
+    /// Stable lowercase label for CLI output.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Extraction => "extraction",
+            Self::Embedding => "embedding",
+        }
+    }
+}
+
+impl fmt::Display for ModelCacheFamily {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// Validation state for a discovered model cache path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModelCacheState {
+    /// A complete cache passed the requested validation level.
+    Complete,
+    /// The expected cache path is absent.
+    Missing,
+    /// The cache path exists but is missing required files or metadata.
+    Incomplete,
+    /// The cache path exists but validation detected corrupt or mismatched content.
+    Corrupted,
+    /// A temporary download path is older than the stale-download threshold.
+    StaleTemporary,
+    /// A temporary download path still has a fresh heartbeat or mtime.
+    ActiveTemporary,
+}
+
+impl ModelCacheState {
+    /// Stable lowercase label for CLI output.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Complete => "complete",
+            Self::Missing => "missing",
+            Self::Incomplete => "incomplete",
+            Self::Corrupted => "corrupted",
+            Self::StaleTemporary => "stale-temp",
+            Self::ActiveTemporary => "active-temp",
+        }
+    }
+}
+
+impl fmt::Display for ModelCacheState {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// Snapshot of one extraction or embedding cache path discovered for
+/// operator-facing status and cleanup commands.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModelCacheEntry {
+    /// Cache family.
+    pub family: ModelCacheFamily,
+    /// User-facing alias when the path can be mapped to one.
+    pub alias: Option<String>,
+    /// Sanitized cache key under the shared cache root.
+    pub cache_key: String,
+    /// Filesystem path represented by the entry.
+    pub path: PathBuf,
+    /// Validation state for the path.
+    pub state: ModelCacheState,
+    /// Human-readable detail about the state.
+    pub reason: String,
+    /// Number of regular files under the path.
+    pub file_count: usize,
+    /// Total bytes occupied by regular files under the path.
+    pub size_bytes: u64,
+    /// Latest observed mtime, represented as seconds since the Unix epoch.
+    pub modified_unix: Option<u64>,
+    /// `true` when cleanup may remove this entry without deleting a verified
+    /// complete cache.
+    pub cleanup_eligible: bool,
+    /// `true` when the entry represents a complete cache that should only be
+    /// removed when an alias-specific forced clean explicitly targets it.
+    pub complete_cache: bool,
+}
+
+/// Result for a single cleanup removal attempt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModelCacheRemoval {
+    /// Filesystem path targeted by the removal attempt.
+    pub path: PathBuf,
+    /// Bytes that were counted for the entry before removal.
+    pub size_bytes: u64,
+    /// Error message when removal failed.
+    pub error: Option<String>,
+}
+
+/// Summary returned after removing one or more cache entries.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ModelCacheCleanReport {
+    /// Successful removals.
+    pub removed: Vec<ModelCacheRemoval>,
+    /// Failed removals.
+    pub failed: Vec<ModelCacheRemoval>,
+    /// Sum of `size_bytes` for successful removals.
+    pub bytes_freed: u64,
 }
 
 #[cfg(any(feature = "online-model", test, feature = "test-harness"))]
@@ -412,9 +637,13 @@ pub enum ModelLifecycleError {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 struct CacheManifest {
+    #[serde(default)]
+    manifest_version: Option<u32>,
     requested_alias: String,
     repo_id: String,
     revision: Option<String>,
+    #[serde(default)]
+    created_at_unix: Option<u64>,
     files: Vec<CachedFile>,
 }
 
@@ -422,6 +651,10 @@ struct CacheManifest {
 struct CachedFile {
     path: String,
     sha256: String,
+    #[serde(default)]
+    size_bytes: Option<u64>,
+    #[serde(default)]
+    modified_unix: Option<u64>,
     verified_from_source: bool,
 }
 
@@ -443,6 +676,52 @@ struct DownloadedArtifact {
     relative_path: String,
     sha256: String,
     verified_from_source: bool,
+}
+
+#[cfg(feature = "online-model")]
+#[derive(Debug)]
+struct TempDirCleanupGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+#[cfg(feature = "online-model")]
+impl TempDirCleanupGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+
+    fn cleanup_now(&mut self) -> Result<(), String> {
+        if self.path.exists() {
+            fs::remove_dir_all(&self.path)
+                .map_err(|error| format!("remove {}: {error}", self.path.display()))?;
+        }
+        self.disarm();
+        Ok(())
+    }
+}
+
+#[cfg(feature = "online-model")]
+impl Drop for TempDirCleanupGuard {
+    fn drop(&mut self) {
+        if !self.armed || !self.path.exists() {
+            return;
+        }
+        if let Err(error) = fs::remove_dir_all(&self.path) {
+            eprintln!(
+                "Warning: failed to remove temporary model cache at {}: {error}. Run `quaid model clean --all --force` after the download exits.",
+                self.path.display()
+            );
+        }
+    }
 }
 
 /// Map a user-facing alias (curated short name or raw `<org>/<model>` repo
@@ -532,6 +811,621 @@ pub fn cached_model_status(alias: &str) -> Result<CachedModelStatus, ModelLifecy
         verified,
         source_pinned,
     })
+}
+
+/// Inspect extraction and embedding cache entries under the shared model
+/// cache root.
+///
+/// When `alias` is `Some`, the result includes missing expected paths for
+/// matching families. When `verify_hashes` is `true`, complete caches must
+/// pass full digest verification instead of fast metadata validation.
+pub fn inspect_model_caches(
+    alias: Option<&str>,
+    verify_hashes: bool,
+) -> Result<Vec<ModelCacheEntry>, ModelLifecycleError> {
+    let cache_root = cache_root_dir()?;
+    let mode = if verify_hashes {
+        ManifestValidation::Full
+    } else {
+        ManifestValidation::Fast
+    };
+    let mut entries = Vec::new();
+
+    if let Some(selector) = alias {
+        let mut matched = false;
+        if let Ok(resolved) = resolve_model_alias(selector) {
+            matched = true;
+            inspect_extraction_alias(&mut entries, &cache_root, &resolved, mode)?;
+        }
+
+        #[cfg(feature = "online-model")]
+        if let Some(model) = crate::core::inference::resolve_known_embedding_model(selector) {
+            matched = true;
+            inspect_embedding_model(&mut entries, &cache_root, &model, true, verify_hashes);
+        }
+
+        if !matched {
+            resolve_model_alias(selector)?;
+        }
+    } else {
+        inspect_extraction_cache_root(&mut entries, &cache_root, mode)?;
+
+        #[cfg(feature = "online-model")]
+        for model in crate::core::inference::known_embedding_models() {
+            inspect_embedding_model(&mut entries, &cache_root, &model, false, verify_hashes);
+        }
+    }
+
+    entries.sort_by(|left, right| {
+        left.family
+            .as_str()
+            .cmp(right.family.as_str())
+            .then_with(|| left.cache_key.cmp(&right.cache_key))
+            .then_with(|| left.path.cmp(&right.path))
+    });
+    Ok(entries)
+}
+
+/// Remove cache entries that were selected by an operator-facing cleanup
+/// command.
+///
+/// The removal is constrained to the resolved model cache root. Symlinks are
+/// removed as symlinks; directories are removed recursively.
+pub fn remove_model_cache_entries(entries: &[ModelCacheEntry]) -> ModelCacheCleanReport {
+    let mut report = ModelCacheCleanReport::default();
+    let Ok(cache_root) = cache_root_dir() else {
+        for entry in entries {
+            report.failed.push(ModelCacheRemoval {
+                path: entry.path.clone(),
+                size_bytes: entry.size_bytes,
+                error: Some("could not resolve model cache root".to_owned()),
+            });
+        }
+        return report;
+    };
+
+    for entry in entries {
+        if !entry.cleanup_eligible && !entry.complete_cache {
+            report.failed.push(ModelCacheRemoval {
+                path: entry.path.clone(),
+                size_bytes: entry.size_bytes,
+                error: Some("entry is not eligible for cleanup".to_owned()),
+            });
+            continue;
+        }
+        if !path_is_within_cache_root(&cache_root, &entry.path) {
+            report.failed.push(ModelCacheRemoval {
+                path: entry.path.clone(),
+                size_bytes: entry.size_bytes,
+                error: Some("refusing to remove a path outside the model cache root".to_owned()),
+            });
+            continue;
+        }
+
+        match remove_cache_path(&entry.path) {
+            Ok(()) => {
+                report.bytes_freed = report.bytes_freed.saturating_add(entry.size_bytes);
+                report.removed.push(ModelCacheRemoval {
+                    path: entry.path.clone(),
+                    size_bytes: entry.size_bytes,
+                    error: None,
+                });
+            }
+            Err(error) => report.failed.push(ModelCacheRemoval {
+                path: entry.path.clone(),
+                size_bytes: entry.size_bytes,
+                error: Some(error),
+            }),
+        }
+    }
+
+    report
+}
+
+fn inspect_extraction_alias(
+    entries: &mut Vec<ModelCacheEntry>,
+    cache_root: &Path,
+    alias: &ResolvedModelAlias,
+    mode: ManifestValidation,
+) -> Result<(), ModelLifecycleError> {
+    let cache_dir = cache_root.join(&alias.cache_key);
+    entries.push(inspect_extraction_cache_dir(
+        cache_dir,
+        &alias.cache_key,
+        Some(alias),
+        mode,
+    ));
+    inspect_extraction_temp_dirs(entries, cache_root, Some(&alias.cache_key))?;
+    Ok(())
+}
+
+fn inspect_extraction_cache_root(
+    entries: &mut Vec<ModelCacheEntry>,
+    cache_root: &Path,
+    mode: ManifestValidation,
+) -> Result<(), ModelLifecycleError> {
+    let read_dir = match fs::read_dir(cache_root) {
+        Ok(read_dir) => read_dir,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(ModelLifecycleError::CacheInvalid {
+                cache_dir: cache_root.display().to_string(),
+                message: format!("read cache root: {error}"),
+            });
+        }
+    };
+
+    for entry in read_dir.filter_map(Result::ok) {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if !file_type.is_dir() {
+            continue;
+        }
+        let file_name = entry.file_name().to_string_lossy().into_owned();
+        if extraction_temp_cache_key(&file_name).is_some() {
+            continue;
+        }
+        if is_known_embedding_cache_key(&file_name) {
+            continue;
+        }
+        let path = entry.path();
+        if !path.join(MANIFEST_FILE_NAME).is_file() {
+            continue;
+        }
+        match read_manifest(&path) {
+            Ok(manifest) => match resolve_model_alias(&manifest.requested_alias) {
+                Ok(alias) => entries.push(inspect_extraction_cache_dir(
+                    path,
+                    &alias.cache_key,
+                    Some(&alias),
+                    mode,
+                )),
+                Err(error) => entries.push(cache_entry(
+                    CacheEntryParams::new(
+                        ModelCacheFamily::Extraction,
+                        file_name,
+                        path,
+                        ModelCacheState::Corrupted,
+                        format!("manifest alias is invalid: {error}"),
+                    )
+                    .alias(Some(manifest.requested_alias))
+                    .cleanup_eligible(true),
+                )),
+            },
+            Err(error) => entries.push(cache_entry(
+                CacheEntryParams::new(
+                    ModelCacheFamily::Extraction,
+                    file_name,
+                    path,
+                    ModelCacheState::Corrupted,
+                    error,
+                )
+                .cleanup_eligible(true),
+            )),
+        }
+    }
+
+    inspect_extraction_temp_dirs(entries, cache_root, None)
+}
+
+fn inspect_extraction_cache_dir(
+    path: PathBuf,
+    cache_key: &str,
+    alias: Option<&ResolvedModelAlias>,
+    mode: ManifestValidation,
+) -> ModelCacheEntry {
+    if !path.exists() {
+        return cache_entry(
+            CacheEntryParams::new(
+                ModelCacheFamily::Extraction,
+                cache_key,
+                path,
+                ModelCacheState::Missing,
+                "cache directory is not present",
+            )
+            .alias(alias.map(|alias| alias.requested_alias.clone())),
+        );
+    }
+    if !path.is_dir() {
+        return cache_entry(
+            CacheEntryParams::new(
+                ModelCacheFamily::Extraction,
+                cache_key,
+                path,
+                ModelCacheState::Corrupted,
+                "cache path is not a directory",
+            )
+            .alias(alias.map(|alias| alias.requested_alias.clone()))
+            .cleanup_eligible(true),
+        );
+    }
+
+    let validation = alias
+        .ok_or_else(|| ModelLifecycleError::CacheInvalid {
+            cache_dir: path.display().to_string(),
+            message: "manifest alias is missing".to_owned(),
+        })
+        .and_then(|alias| ensure_cache_manifest(&path, alias, mode));
+    match validation {
+        Ok(manifest) => cache_entry(
+            CacheEntryParams::new(
+                ModelCacheFamily::Extraction,
+                cache_key,
+                path,
+                ModelCacheState::Complete,
+                if mode == ManifestValidation::Full {
+                    "manifest and file hashes verified"
+                } else {
+                    "manifest verified"
+                },
+            )
+            .alias(Some(manifest.requested_alias))
+            .complete_cache(true),
+        ),
+        Err(error) => {
+            let state = cache_state_from_validation_error(&error);
+            cache_entry(
+                CacheEntryParams::new(
+                    ModelCacheFamily::Extraction,
+                    cache_key,
+                    path,
+                    state,
+                    error.to_string(),
+                )
+                .alias(alias.map(|alias| alias.requested_alias.clone()))
+                .cleanup_eligible(matches!(
+                    state,
+                    ModelCacheState::Incomplete | ModelCacheState::Corrupted
+                )),
+            )
+        }
+    }
+}
+
+fn inspect_extraction_temp_dirs(
+    entries: &mut Vec<ModelCacheEntry>,
+    cache_root: &Path,
+    cache_key_filter: Option<&str>,
+) -> Result<(), ModelLifecycleError> {
+    let read_dir = match fs::read_dir(cache_root) {
+        Ok(read_dir) => read_dir,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(ModelLifecycleError::CacheInvalid {
+                cache_dir: cache_root.display().to_string(),
+                message: format!("read cache root: {error}"),
+            });
+        }
+    };
+    let ttl = stale_temp_ttl();
+    for entry in read_dir.filter_map(Result::ok) {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if !file_type.is_dir() {
+            continue;
+        }
+        let file_name = entry.file_name().to_string_lossy().into_owned();
+        let Some(cache_key) = extraction_temp_cache_key(&file_name) else {
+            continue;
+        };
+        if cache_key_filter.is_some_and(|filter| filter != cache_key) {
+            continue;
+        }
+        let active = download_temp_is_active(&entry.path(), ttl);
+        let state = if active {
+            ModelCacheState::ActiveTemporary
+        } else {
+            ModelCacheState::StaleTemporary
+        };
+        entries.push(cache_entry(
+            CacheEntryParams::new(
+                ModelCacheFamily::Extraction,
+                cache_key,
+                entry.path(),
+                state,
+                if active {
+                    "temporary download has a fresh heartbeat or mtime"
+                } else {
+                    "temporary download is older than the stale threshold"
+                },
+            )
+            .cleanup_eligible(!active),
+        ));
+    }
+    Ok(())
+}
+
+fn extraction_temp_cache_key(file_name: &str) -> Option<String> {
+    let rest = file_name.strip_prefix('.')?;
+    let (cache_key, suffix) = rest.rsplit_once("-download-")?;
+    (!cache_key.is_empty() && !suffix.is_empty()).then(|| cache_key.to_owned())
+}
+
+#[cfg(feature = "online-model")]
+fn inspect_embedding_model(
+    entries: &mut Vec<ModelCacheEntry>,
+    cache_root: &Path,
+    model: &crate::core::inference::ModelConfig,
+    include_missing: bool,
+    verify_hashes: bool,
+) {
+    let cache_key = crate::core::inference::embedding_model_cache_key(model);
+    let cache_dir = cache_root.join(&cache_key);
+    if include_missing || cache_dir.exists() {
+        entries.push(inspect_embedding_cache_dir(
+            cache_dir.clone(),
+            &cache_key,
+            model,
+            verify_hashes,
+        ));
+    }
+    inspect_embedding_temp_files(entries, &cache_dir, &cache_key, model);
+}
+
+#[cfg(feature = "online-model")]
+fn inspect_embedding_cache_dir(
+    path: PathBuf,
+    cache_key: &str,
+    model: &crate::core::inference::ModelConfig,
+    verify_hashes: bool,
+) -> ModelCacheEntry {
+    if !path.exists() {
+        return cache_entry(
+            CacheEntryParams::new(
+                ModelCacheFamily::Embedding,
+                cache_key,
+                path,
+                ModelCacheState::Missing,
+                "cache directory is not present",
+            )
+            .alias(Some(model.alias.clone())),
+        );
+    }
+    if !path.is_dir() {
+        return cache_entry(
+            CacheEntryParams::new(
+                ModelCacheFamily::Embedding,
+                cache_key,
+                path,
+                ModelCacheState::Corrupted,
+                "cache path is not a directory",
+            )
+            .alias(Some(model.alias.clone()))
+            .cleanup_eligible(true),
+        );
+    }
+
+    match crate::core::inference::verify_embedding_model_cache(model, &path, verify_hashes) {
+        Ok(()) => cache_entry(
+            CacheEntryParams::new(
+                ModelCacheFamily::Embedding,
+                cache_key,
+                path,
+                ModelCacheState::Complete,
+                if verify_hashes {
+                    "required files and file hashes verified"
+                } else {
+                    "required files are present"
+                },
+            )
+            .alias(Some(model.alias.clone()))
+            .complete_cache(true),
+        ),
+        Err(error) => {
+            let state = if error.contains("missing required file") {
+                ModelCacheState::Incomplete
+            } else {
+                ModelCacheState::Corrupted
+            };
+            cache_entry(
+                CacheEntryParams::new(ModelCacheFamily::Embedding, cache_key, path, state, error)
+                    .alias(Some(model.alias.clone()))
+                    .cleanup_eligible(true),
+            )
+        }
+    }
+}
+
+#[cfg(feature = "online-model")]
+fn inspect_embedding_temp_files(
+    entries: &mut Vec<ModelCacheEntry>,
+    cache_dir: &Path,
+    cache_key: &str,
+    model: &crate::core::inference::ModelConfig,
+) {
+    let Ok(read_dir) = fs::read_dir(cache_dir) else {
+        return;
+    };
+    let ttl = stale_temp_ttl();
+    for entry in read_dir.filter_map(Result::ok) {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if !file_type.is_file() {
+            continue;
+        }
+        let file_name = entry.file_name().to_string_lossy().into_owned();
+        if !file_name.contains(".download-") {
+            continue;
+        }
+        let active = recent_path_mtime(&entry.path(), ttl);
+        let state = if active {
+            ModelCacheState::ActiveTemporary
+        } else {
+            ModelCacheState::StaleTemporary
+        };
+        entries.push(cache_entry(
+            CacheEntryParams::new(
+                ModelCacheFamily::Embedding,
+                cache_key,
+                entry.path(),
+                state,
+                if active {
+                    "temporary download file has a fresh mtime"
+                } else {
+                    "temporary download file is older than the stale threshold"
+                },
+            )
+            .alias(Some(model.alias.clone()))
+            .cleanup_eligible(!active),
+        ));
+    }
+}
+
+#[cfg(feature = "online-model")]
+fn is_known_embedding_cache_key(cache_key: &str) -> bool {
+    crate::core::inference::known_embedding_models()
+        .iter()
+        .any(|model| crate::core::inference::embedding_model_cache_key(model) == cache_key)
+}
+
+#[cfg(not(feature = "online-model"))]
+fn is_known_embedding_cache_key(_cache_key: &str) -> bool {
+    false
+}
+
+fn cache_state_from_validation_error(error: &ModelLifecycleError) -> ModelCacheState {
+    let message = error.to_string().to_ascii_lowercase();
+    if message.contains("missing")
+        || message.contains("did not record")
+        || message.contains("not a regular file")
+        || message.contains("manifest.json is missing")
+    {
+        ModelCacheState::Incomplete
+    } else {
+        ModelCacheState::Corrupted
+    }
+}
+
+struct CacheEntryParams {
+    family: ModelCacheFamily,
+    alias: Option<String>,
+    cache_key: String,
+    path: PathBuf,
+    state: ModelCacheState,
+    reason: String,
+    cleanup_eligible: bool,
+    complete_cache: bool,
+}
+
+impl CacheEntryParams {
+    fn new(
+        family: ModelCacheFamily,
+        cache_key: impl Into<String>,
+        path: PathBuf,
+        state: ModelCacheState,
+        reason: impl Into<String>,
+    ) -> Self {
+        Self {
+            family,
+            alias: None,
+            cache_key: cache_key.into(),
+            path,
+            state,
+            reason: reason.into(),
+            cleanup_eligible: false,
+            complete_cache: false,
+        }
+    }
+
+    fn alias(mut self, alias: Option<String>) -> Self {
+        self.alias = alias;
+        self
+    }
+
+    fn cleanup_eligible(mut self, cleanup_eligible: bool) -> Self {
+        self.cleanup_eligible = cleanup_eligible;
+        self
+    }
+
+    fn complete_cache(mut self, complete_cache: bool) -> Self {
+        self.complete_cache = complete_cache;
+        self
+    }
+}
+
+fn cache_entry(params: CacheEntryParams) -> ModelCacheEntry {
+    let CacheEntryParams {
+        family,
+        alias,
+        cache_key,
+        path,
+        state,
+        reason,
+        cleanup_eligible,
+        complete_cache,
+    } = params;
+    let (file_count, size_bytes, modified_unix) = path_tree_stats(&path);
+    ModelCacheEntry {
+        family,
+        alias,
+        cache_key,
+        path,
+        state,
+        reason,
+        file_count,
+        size_bytes,
+        modified_unix,
+        cleanup_eligible,
+        complete_cache,
+    }
+}
+
+fn path_tree_stats(path: &Path) -> (usize, u64, Option<u64>) {
+    let mut file_count = 0_usize;
+    let mut size_bytes = 0_u64;
+    let mut modified_unix = None;
+    let mut stack = vec![path.to_path_buf()];
+
+    while let Some(current) = stack.pop() {
+        let Ok(metadata) = fs::symlink_metadata(&current) else {
+            continue;
+        };
+        if let Some(modified) = metadata.modified().ok().and_then(system_time_secs_fallback) {
+            modified_unix =
+                Some(modified_unix.map_or(modified, |current: u64| current.max(modified)));
+        }
+        if metadata.is_file() {
+            file_count += 1;
+            size_bytes = size_bytes.saturating_add(metadata.len());
+        } else if metadata.is_dir() {
+            let Ok(entries) = fs::read_dir(&current) else {
+                continue;
+            };
+            stack.extend(entries.filter_map(Result::ok).map(|entry| entry.path()));
+        }
+    }
+
+    (file_count, size_bytes, modified_unix)
+}
+
+fn path_is_within_cache_root(cache_root: &Path, path: &Path) -> bool {
+    let Ok(root) = cache_root.canonicalize() else {
+        return false;
+    };
+    match path.canonicalize() {
+        Ok(target) => target != root && target.starts_with(&root),
+        Err(_) => path
+            .parent()
+            .and_then(|parent| parent.canonicalize().ok())
+            .is_some_and(|parent| parent == root || parent.starts_with(&root)),
+    }
+}
+
+fn remove_cache_path(path: &Path) -> Result<(), String> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(format!("metadata {}: {error}", path.display())),
+    };
+
+    if metadata.is_dir() && !metadata.file_type().is_symlink() {
+        fs::remove_dir_all(path).map_err(|error| format!("remove {}: {error}", path.display()))
+    } else {
+        fs::remove_file(path).map_err(|error| format!("remove {}: {error}", path.display()))
+    }
 }
 
 /// Returns a verified local cache directory without touching the network.
@@ -654,11 +1548,17 @@ fn download_model_online(
         alias: alias.requested_alias.clone(),
         message: format!("create temporary cache {}: {error}", temp_dir.display()),
     })?;
+    let mut temp_guard = TempDirCleanupGuard::new(temp_dir);
+    touch_download_heartbeat(temp_guard.path());
 
     let install_result = match source_pins_for_alias(&alias) {
-        Some(files) => {
-            install_source_pinned_model_into_dir(&client, &alias, files, &temp_dir, progress)
-        }
+        Some(files) => install_source_pinned_model_into_dir(
+            &client,
+            &alias,
+            files,
+            temp_guard.path(),
+            progress,
+        ),
         None => {
             let Some(metadata) = metadata.as_ref() else {
                 return Err(ModelLifecycleError::Metadata {
@@ -667,30 +1567,29 @@ fn download_model_online(
                 });
             };
             let files = select_files_to_download(metadata, &alias)?;
-            install_model_into_dir(&client, &alias, &files, &temp_dir, progress)
+            install_model_into_dir(&client, &alias, &files, temp_guard.path(), progress)
         }
     };
-    if let Err(error) = install_result {
-        let _ = fs::remove_dir_all(&temp_dir);
-        return Err(error);
-    }
+    install_result?;
 
-    if let Err(error) = fs::rename(&temp_dir, &cache_dir) {
+    if let Err(error) = fs::rename(temp_guard.path(), &cache_dir) {
         if cache_dir.is_dir() && verify_cache_manifest(&cache_dir, &alias).is_ok() {
-            let _ = fs::remove_dir_all(&temp_dir);
+            let _ = temp_guard.cleanup_now();
             progress.cache_hit(&cache_dir);
             return Ok(cache_dir);
         }
-        let _ = fs::remove_dir_all(&temp_dir);
         return Err(ModelLifecycleError::Download {
             alias: alias.requested_alias.clone(),
             message: format!(
-                "promote verified cache {} -> {}: {error}",
-                temp_dir.display(),
-                cache_dir.display()
+                "promote verified cache {} -> {}: {error}; run `quaid model clean {} --force` and retry `quaid model pull {}`",
+                temp_guard.path().display(),
+                cache_dir.display(),
+                alias.requested_alias,
+                alias.requested_alias
             ),
         });
     }
+    temp_guard.disarm();
 
     Ok(cache_dir)
 }
@@ -707,22 +1606,20 @@ fn install_model_into_dir(
 
     for relative_path in files {
         let artifact = download_artifact(client, alias, relative_path, temp_dir, progress)?;
-        manifest_files.push(CachedFile {
-            path: artifact.relative_path,
-            sha256: artifact.sha256,
-            verified_from_source: artifact.verified_from_source,
-        });
+        manifest_files.push(cached_file_from_artifact(temp_dir, artifact, alias)?);
     }
 
     manifest_files.sort_by(|left, right| left.path.cmp(&right.path));
     let manifest = CacheManifest {
+        manifest_version: Some(MANIFEST_VERSION),
         requested_alias: alias.requested_alias.clone(),
         repo_id: alias.repo_id.clone(),
         revision: alias.revision.clone(),
+        created_at_unix: Some(download_timestamp_secs()),
         files: manifest_files,
     };
     write_manifest(temp_dir, &manifest, alias)?;
-    verify_cache_manifest(temp_dir, alias)?;
+    verify_cache_manifest_full(temp_dir, alias)?;
     Ok(())
 }
 
@@ -739,23 +1636,49 @@ fn install_source_pinned_model_into_dir(
     for pinned_file in files {
         let artifact =
             download_source_pinned_artifact(client, alias, pinned_file, temp_dir, progress)?;
-        manifest_files.push(CachedFile {
-            path: artifact.relative_path,
-            sha256: artifact.sha256,
-            verified_from_source: artifact.verified_from_source,
-        });
+        manifest_files.push(cached_file_from_artifact(temp_dir, artifact, alias)?);
     }
 
     manifest_files.sort_by(|left, right| left.path.cmp(&right.path));
     let manifest = CacheManifest {
+        manifest_version: Some(MANIFEST_VERSION),
         requested_alias: alias.requested_alias.clone(),
         repo_id: alias.repo_id.clone(),
         revision: alias.revision.clone(),
+        created_at_unix: Some(download_timestamp_secs()),
         files: manifest_files,
     };
     write_manifest(temp_dir, &manifest, alias)?;
-    verify_cache_manifest(temp_dir, alias)?;
+    verify_cache_manifest_full(temp_dir, alias)?;
     Ok(())
+}
+
+#[cfg(feature = "online-model")]
+fn cached_file_from_artifact(
+    cache_dir: &Path,
+    artifact: DownloadedArtifact,
+    alias: &ResolvedModelAlias,
+) -> Result<CachedFile, ModelLifecycleError> {
+    let path = cache_dir.join(&artifact.relative_path);
+    let metadata = path
+        .metadata()
+        .map_err(|error| ModelLifecycleError::Download {
+            alias: alias.requested_alias.clone(),
+            message: format!("metadata {}: {error}", path.display()),
+        })?;
+    let modified_unix = metadata
+        .modified()
+        .ok()
+        .and_then(system_time_secs)
+        .unwrap_or_else(download_timestamp_secs);
+
+    Ok(CachedFile {
+        path: artifact.relative_path,
+        sha256: artifact.sha256,
+        size_bytes: Some(metadata.len()),
+        modified_unix: Some(modified_unix),
+        verified_from_source: artifact.verified_from_source,
+    })
 }
 
 #[cfg(feature = "online-model")]
@@ -813,7 +1736,11 @@ fn download_artifact(
             .read(&mut buffer)
             .map_err(|error| ModelLifecycleError::Download {
                 alias: alias.requested_alias.clone(),
-                message: format!("read {url}: {error}"),
+                message: format!(
+                    "read {url} for {relative_path}: {error} after {} received; retry with `quaid model pull {}`",
+                    human_bytes(downloaded),
+                    alias.requested_alias
+                ),
             })?;
         if read == 0 {
             break;
@@ -825,6 +1752,7 @@ fn download_artifact(
             })?;
         hasher.update(&buffer[..read]);
         downloaded += read as u64;
+        touch_download_heartbeat(temp_dir);
         progress.file_progress(&relative_path, downloaded, total_bytes);
     }
     file.flush()
@@ -840,8 +1768,8 @@ fn download_artifact(
             return Err(ModelLifecycleError::Download {
                 alias: alias.requested_alias.clone(),
                 message: format!(
-                    "integrity check failed for {}: expected SHA-256 {}, got {}",
-                    relative_path, expected_sha256, actual_sha256
+                    "integrity check failed for {}: expected SHA-256 {}, got {}; run `quaid model clean {} --force` and retry `quaid model pull {}`",
+                    relative_path, expected_sha256, actual_sha256, alias.requested_alias, alias.requested_alias
                 ),
             });
         }
@@ -909,7 +1837,11 @@ fn download_source_pinned_artifact(
             .read(&mut buffer)
             .map_err(|error| ModelLifecycleError::Download {
                 alias: alias.requested_alias.clone(),
-                message: format!("read {url}: {error}"),
+                message: format!(
+                    "read {url} for {relative_path}: {error} after {} received; retry with `quaid model pull {}`",
+                    human_bytes(downloaded),
+                    alias.requested_alias
+                ),
             })?;
         if read == 0 {
             break;
@@ -922,6 +1854,7 @@ fn download_source_pinned_artifact(
         })?;
         sha256.update(&buffer[..read]);
         downloaded += read as u64;
+        touch_download_heartbeat(temp_dir);
         progress.file_progress(&relative_path, downloaded, total_bytes);
     }
     std::io::Write::flush(&mut file).map_err(|error| ModelLifecycleError::Download {
@@ -1003,6 +1936,46 @@ fn download_timestamp_secs() -> u64 {
         .as_secs()
 }
 
+#[cfg(feature = "online-model")]
+fn system_time_secs(time: SystemTime) -> Option<u64> {
+    time.duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|duration| duration.as_secs())
+}
+
+fn download_timestamp_secs_fallback() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn system_time_secs_fallback(time: SystemTime) -> Option<u64> {
+    time.duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|duration| duration.as_secs())
+}
+
+#[cfg(feature = "online-model")]
+fn stale_download_ttl() -> Duration {
+    stale_temp_ttl()
+}
+
+fn stale_temp_ttl() -> Duration {
+    std::env::var(STALE_CACHE_TTL_ENV)
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|seconds| *seconds > 0)
+        .map(Duration::from_secs)
+        .unwrap_or(DEFAULT_STALE_DOWNLOAD_TTL)
+}
+
+#[cfg(feature = "online-model")]
+fn touch_download_heartbeat(temp_dir: &Path) {
+    let heartbeat_path = temp_dir.join(DOWNLOAD_HEARTBEAT_FILE);
+    let _ = fs::write(heartbeat_path, download_timestamp_secs().to_string());
+}
+
 #[cfg(any(feature = "online-model", test, feature = "test-harness"))]
 fn source_pins_for_alias(alias: &ResolvedModelAlias) -> Option<&'static [SourcePinnedFile]> {
     match alias.requested_alias.to_ascii_lowercase().as_str() {
@@ -1021,6 +1994,7 @@ fn scavenge_stale_download_dirs(cache_root: &Path, cache_key: &str) {
         return;
     };
     let now = download_timestamp_secs();
+    let ttl = stale_download_ttl();
     for entry in entries.filter_map(Result::ok) {
         let Ok(file_type) = entry.file_type() else {
             continue;
@@ -1034,10 +2008,17 @@ fn scavenge_stale_download_dirs(cache_root: &Path, cache_key: &str) {
         else {
             continue;
         };
-        if now.saturating_sub(created_at) < STALE_DOWNLOAD_TTL.as_secs() {
+        if download_temp_is_active(&entry.path(), ttl)
+            || now.saturating_sub(created_at) < ttl.as_secs()
+        {
             continue;
         }
-        let _ = fs::remove_dir_all(entry.path());
+        if let Err(error) = fs::remove_dir_all(entry.path()) {
+            eprintln!(
+                "Warning: failed to remove stale model download directory {}: {error}",
+                entry.path().display()
+            );
+        }
     }
 }
 
@@ -1055,8 +2036,21 @@ fn parse_download_timestamp(file_name: &str, cache_key: &str, path: &Path) -> Op
         .ok()
         .and_then(|metadata| metadata.modified().ok())
         .and_then(|modified| SystemTime::now().duration_since(modified).ok())
-        .filter(|age| *age >= STALE_DOWNLOAD_TTL)
+        .filter(|age| *age >= stale_download_ttl())
         .map(|age| download_timestamp_secs().saturating_sub(age.as_secs()))
+}
+
+fn download_temp_is_active(path: &Path, ttl: Duration) -> bool {
+    let heartbeat = path.join(DOWNLOAD_HEARTBEAT_FILE);
+    recent_path_mtime(&heartbeat, ttl) || recent_path_mtime(path, ttl)
+}
+
+fn recent_path_mtime(path: &Path, ttl: Duration) -> bool {
+    path.metadata()
+        .ok()
+        .and_then(|metadata| metadata.modified().ok())
+        .and_then(|modified| SystemTime::now().duration_since(modified).ok())
+        .is_some_and(|age| age < ttl)
 }
 
 #[cfg(feature = "online-model")]
@@ -1105,7 +2099,7 @@ fn verify_source_pin(
     Ok(())
 }
 
-#[cfg(feature = "online-model")]
+#[cfg(any(feature = "online-model", test, feature = "test-harness"))]
 fn git_blob_sha1_for_file(path: &Path, byte_len: u64) -> Result<String, String> {
     let mut file = File::open(path).map_err(|error| format!("open {}: {error}", path.display()))?;
     let mut hasher = Sha1::new();
@@ -1279,7 +2273,16 @@ fn verify_cache_manifest(
     cache_dir: &Path,
     alias: &ResolvedModelAlias,
 ) -> Result<(), ModelLifecycleError> {
-    let _ = validated_manifest(cache_dir, alias)?;
+    let _ = ensure_cache_manifest(cache_dir, alias, ManifestValidation::Fast)?;
+    Ok(())
+}
+
+#[cfg(feature = "online-model")]
+fn verify_cache_manifest_full(
+    cache_dir: &Path,
+    alias: &ResolvedModelAlias,
+) -> Result<(), ModelLifecycleError> {
+    let _ = ensure_cache_manifest(cache_dir, alias, ManifestValidation::Full)?;
     Ok(())
 }
 
@@ -1287,12 +2290,42 @@ fn validated_manifest(
     cache_dir: &Path,
     alias: &ResolvedModelAlias,
 ) -> Result<CacheManifest, ModelLifecycleError> {
+    ensure_cache_manifest(cache_dir, alias, ManifestValidation::Fast)
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ManifestValidation {
+    Fast,
+    Full,
+}
+
+fn ensure_cache_manifest(
+    cache_dir: &Path,
+    alias: &ResolvedModelAlias,
+    mode: ManifestValidation,
+) -> Result<CacheManifest, ModelLifecycleError> {
+    if !cache_dir.join(MANIFEST_FILE_NAME).is_file() {
+        return generate_manifest_from_trusted_sources(cache_dir, alias);
+    }
+
     let manifest =
         read_manifest(cache_dir).map_err(|message| ModelLifecycleError::CacheInvalid {
             cache_dir: cache_dir.display().to_string(),
             message,
         })?;
+    let (manifest, should_upgrade) = validate_manifest_contents(cache_dir, alias, manifest, mode)?;
+    if should_upgrade {
+        try_upgrade_manifest(cache_dir, &manifest, alias);
+    }
+    Ok(manifest)
+}
 
+fn validate_manifest_contents(
+    cache_dir: &Path,
+    alias: &ResolvedModelAlias,
+    mut manifest: CacheManifest,
+    mode: ManifestValidation,
+) -> Result<(CacheManifest, bool), ModelLifecycleError> {
     if manifest.requested_alias != alias.requested_alias {
         return Err(ModelLifecycleError::CacheInvalid {
             cache_dir: cache_dir.display().to_string(),
@@ -1320,6 +2353,18 @@ fn validated_manifest(
             ),
         });
     }
+    if manifest
+        .manifest_version
+        .is_some_and(|version| version > MANIFEST_VERSION)
+    {
+        return Err(ModelLifecycleError::CacheInvalid {
+            cache_dir: cache_dir.display().to_string(),
+            message: format!(
+                "unsupported manifest version {:?}; upgrade Quaid or re-pull `{}`",
+                manifest.manifest_version, alias.requested_alias
+            ),
+        });
+    }
     if manifest.files.is_empty() {
         return Err(ModelLifecycleError::CacheInvalid {
             cache_dir: cache_dir.display().to_string(),
@@ -1327,7 +2372,13 @@ fn validated_manifest(
         });
     }
 
-    for file in &manifest.files {
+    let mut should_upgrade =
+        manifest.manifest_version != Some(MANIFEST_VERSION) || manifest.created_at_unix.is_none();
+    if manifest.created_at_unix.is_none() {
+        manifest.created_at_unix = Some(download_timestamp_secs_fallback());
+    }
+
+    for file in &mut manifest.files {
         let relative_path = normalize_relative_path(&file.path).map_err(|message| {
             ModelLifecycleError::CacheInvalid {
                 cache_dir: cache_dir.display().to_string(),
@@ -1335,22 +2386,190 @@ fn validated_manifest(
             }
         })?;
         let path = cache_dir.join(relative_path);
-        let actual = file_sha256(&path).map_err(|message| ModelLifecycleError::CacheInvalid {
-            cache_dir: cache_dir.display().to_string(),
-            message,
-        })?;
-        if actual != file.sha256 {
+        let metadata = path
+            .metadata()
+            .map_err(|error| ModelLifecycleError::CacheInvalid {
+                cache_dir: cache_dir.display().to_string(),
+                message: format!("metadata {}: {error}", path.display()),
+            })?;
+        if !metadata.is_file() {
             return Err(ModelLifecycleError::CacheInvalid {
                 cache_dir: cache_dir.display().to_string(),
-                message: format!(
-                    "file hash mismatch for {}: expected {}, got {}",
-                    file.path, file.sha256, actual
-                ),
+                message: format!("manifest path {} is not a regular file", file.path),
             });
+        }
+        let modified_unix = metadata
+            .modified()
+            .ok()
+            .and_then(system_time_secs_fallback)
+            .unwrap_or_else(download_timestamp_secs_fallback);
+        let metadata_mismatch =
+            file.size_bytes != Some(metadata.len()) || file.modified_unix != Some(modified_unix);
+        let must_hash = mode == ManifestValidation::Full || metadata_mismatch;
+        if must_hash {
+            let actual =
+                file_sha256(&path).map_err(|message| ModelLifecycleError::CacheInvalid {
+                    cache_dir: cache_dir.display().to_string(),
+                    message,
+                })?;
+            if actual != file.sha256 {
+                return Err(ModelLifecycleError::CacheInvalid {
+                    cache_dir: cache_dir.display().to_string(),
+                    message: format!(
+                        "file hash mismatch for {}: expected {}, got {}; run `quaid model clean {} --force` and retry `quaid model pull {}`",
+                        file.path, file.sha256, actual, alias.requested_alias, alias.requested_alias
+                    ),
+                });
+            }
+        }
+        if metadata_mismatch {
+            should_upgrade = true;
+            file.size_bytes = Some(metadata.len());
+            file.modified_unix = Some(modified_unix);
         }
     }
 
-    Ok(manifest)
+    manifest.manifest_version = Some(MANIFEST_VERSION);
+    Ok((manifest, should_upgrade))
+}
+
+fn generate_manifest_from_trusted_sources(
+    cache_dir: &Path,
+    alias: &ResolvedModelAlias,
+) -> Result<CacheManifest, ModelLifecycleError> {
+    #[cfg(any(feature = "online-model", test, feature = "test-harness"))]
+    {
+        if let Some(files) = source_pins_for_alias(alias) {
+            let manifest = manifest_from_source_pins(cache_dir, alias, files)?;
+            try_upgrade_manifest(cache_dir, &manifest, alias);
+            return Ok(manifest);
+        }
+    }
+
+    Err(ModelLifecycleError::CacheInvalid {
+        cache_dir: cache_dir.display().to_string(),
+        message: format!(
+            "manifest.json is missing and `{}` has no trusted source pins; run `quaid model clean {} --force` and retry `quaid model pull {}`",
+            alias.requested_alias, alias.requested_alias, alias.requested_alias
+        ),
+    })
+}
+
+#[cfg(any(feature = "online-model", test, feature = "test-harness"))]
+fn manifest_from_source_pins(
+    cache_dir: &Path,
+    alias: &ResolvedModelAlias,
+    files: &[SourcePinnedFile],
+) -> Result<CacheManifest, ModelLifecycleError> {
+    let mut manifest_files = Vec::with_capacity(files.len());
+    for pinned_file in files {
+        let relative_path = normalize_relative_path(pinned_file.path).map_err(|message| {
+            ModelLifecycleError::CacheInvalid {
+                cache_dir: cache_dir.display().to_string(),
+                message,
+            }
+        })?;
+        let path = cache_dir.join(&relative_path);
+        let metadata = path
+            .metadata()
+            .map_err(|error| ModelLifecycleError::CacheInvalid {
+                cache_dir: cache_dir.display().to_string(),
+                message: format!("metadata {}: {error}", path.display()),
+            })?;
+        let actual_sha256 =
+            file_sha256(&path).map_err(|message| ModelLifecycleError::CacheInvalid {
+                cache_dir: cache_dir.display().to_string(),
+                message,
+            })?;
+        verify_source_pin_for_cache(
+            &relative_path,
+            metadata.len(),
+            pinned_file.digest,
+            &actual_sha256,
+            &path,
+            alias,
+            cache_dir,
+        )?;
+        let modified_unix = metadata
+            .modified()
+            .ok()
+            .and_then(system_time_secs_fallback)
+            .unwrap_or_else(download_timestamp_secs_fallback);
+        manifest_files.push(CachedFile {
+            path: relative_path,
+            sha256: actual_sha256,
+            size_bytes: Some(metadata.len()),
+            modified_unix: Some(modified_unix),
+            verified_from_source: true,
+        });
+    }
+    manifest_files.sort_by(|left, right| left.path.cmp(&right.path));
+    Ok(CacheManifest {
+        manifest_version: Some(MANIFEST_VERSION),
+        requested_alias: alias.requested_alias.clone(),
+        repo_id: alias.repo_id.clone(),
+        revision: alias.revision.clone(),
+        created_at_unix: Some(download_timestamp_secs_fallback()),
+        files: manifest_files,
+    })
+}
+
+#[cfg(any(feature = "online-model", test, feature = "test-harness"))]
+fn verify_source_pin_for_cache(
+    relative_path: &str,
+    byte_len: u64,
+    digest: PinnedDigest,
+    actual_sha256: &str,
+    path: &Path,
+    alias: &ResolvedModelAlias,
+    cache_dir: &Path,
+) -> Result<(), ModelLifecycleError> {
+    match digest {
+        PinnedDigest::Sha256(expected) if actual_sha256 == expected => Ok(()),
+        PinnedDigest::Sha256(expected) => Err(ModelLifecycleError::CacheInvalid {
+            cache_dir: cache_dir.display().to_string(),
+            message: format!(
+                "file hash mismatch for {relative_path}: expected SHA-256 {expected}, got {actual_sha256}; run `quaid model clean {} --force` and retry `quaid model pull {}`",
+                alias.requested_alias, alias.requested_alias
+            ),
+        }),
+        PinnedDigest::GitBlobSha1(expected) => {
+            let actual = git_blob_sha1_for_file(path, byte_len).map_err(|message| {
+                ModelLifecycleError::CacheInvalid {
+                    cache_dir: cache_dir.display().to_string(),
+                    message,
+                }
+            })?;
+            if actual == expected {
+                Ok(())
+            } else {
+                Err(ModelLifecycleError::CacheInvalid {
+                    cache_dir: cache_dir.display().to_string(),
+                    message: format!(
+                        "file hash mismatch for {relative_path}: expected git blob SHA-1 {expected}, got {actual}; run `quaid model clean {} --force` and retry `quaid model pull {}`",
+                        alias.requested_alias, alias.requested_alias
+                    ),
+                })
+            }
+        }
+    }
+}
+
+fn try_upgrade_manifest(cache_dir: &Path, manifest: &CacheManifest, alias: &ResolvedModelAlias) {
+    #[cfg(feature = "online-model")]
+    if let Err(error) = write_manifest(cache_dir, manifest, alias) {
+        eprintln!(
+            "Warning: failed to write upgraded manifest for `{}` at {}: {error}",
+            alias.requested_alias,
+            cache_dir.display()
+        );
+    }
+    #[cfg(not(feature = "online-model"))]
+    {
+        let _ = cache_dir;
+        let _ = manifest;
+        let _ = alias;
+    }
 }
 
 #[cfg(feature = "online-model")]

--- a/src/core/conversation/model_lifecycle.rs
+++ b/src/core/conversation/model_lifecycle.rs
@@ -2640,6 +2640,42 @@ fn expected_sha256_from_headers(headers: &reqwest::header::HeaderMap) -> Option<
 mod tests {
     use super::*;
 
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let previous = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            if let Some(value) = self.previous.as_ref() {
+                std::env::set_var(self.key, value);
+            } else {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
+
+    fn write_test_pinned_files(cache_dir: &Path) {
+        std::fs::create_dir_all(cache_dir).expect("cache dir");
+        std::fs::write(cache_dir.join("config.json"), br#"{"model_type":"phi3"}"#).expect("config");
+        std::fs::write(cache_dir.join("model.safetensors"), b"tiny-test-weights").expect("weights");
+        std::fs::write(cache_dir.join("tokenizer.json"), br#"{"version":"1.0"}"#)
+            .expect("tokenizer");
+    }
+
+    fn write_manifest(cache_dir: &Path, manifest: &CacheManifest) {
+        let bytes = serde_json::to_vec(manifest).expect("serialize manifest");
+        std::fs::write(cache_dir.join(MANIFEST_FILE_NAME), bytes).expect("write manifest");
+    }
+
     #[test]
     fn resolve_model_alias_maps_standard_aliases_to_pinned_repos() {
         let phi = resolve_model_alias("phi-3.5-mini").expect("resolve phi");
@@ -2701,6 +2737,395 @@ mod tests {
     fn sanitize_cache_key_normalizes_path_separators() {
         assert_eq!(sanitize_cache_key("org/model"), "org-model");
         assert_eq!(sanitize_cache_key("phi-3.5-mini"), "phi-3.5-mini");
+    }
+
+    #[test]
+    fn inspect_model_caches_reports_missing_alias_and_temporary_entries() {
+        let cache_root = tempfile::TempDir::new().expect("cache root");
+        let _cache_root = EnvVarGuard::set(MODEL_CACHE_ROOT_ENV, cache_root.path());
+        std::fs::create_dir(cache_root.path().join(".phi-3.5-mini-download-active"))
+            .expect("temp download dir");
+
+        let entries = inspect_model_caches(Some("phi-3.5-mini"), false).expect("inspect caches");
+
+        assert!(entries.iter().any(|entry| {
+            entry.family == ModelCacheFamily::Extraction
+                && entry.state == ModelCacheState::Missing
+                && entry.cache_key == "phi-3.5-mini"
+        }));
+        assert!(entries.iter().any(|entry| {
+            entry.family == ModelCacheFamily::Extraction
+                && entry.state == ModelCacheState::ActiveTemporary
+                && !entry.cleanup_eligible
+        }));
+    }
+
+    #[test]
+    fn trusted_source_pin_cache_loads_status_and_root_inspection() {
+        let cache_root = tempfile::TempDir::new().expect("cache root");
+        let _cache_root = EnvVarGuard::set(MODEL_CACHE_ROOT_ENV, cache_root.path());
+        let alias = resolve_model_alias(TEST_PINNED_ALIAS).expect("resolve test alias");
+        let cache_dir = cache_root.path().join(&alias.cache_key);
+        write_test_pinned_files(&cache_dir);
+
+        assert_eq!(
+            load_model_from_local_cache(TEST_PINNED_ALIAS).expect("load source-pinned cache"),
+            cache_dir
+        );
+
+        let manifest = manifest_from_source_pins(&cache_dir, &alias, TEST_CURATED_FILES)
+            .expect("source-pinned manifest");
+        write_manifest(&cache_dir, &manifest);
+        let status = cached_model_status(TEST_PINNED_ALIAS).expect("cached status");
+        assert!(status.is_cached);
+        assert!(status.verified);
+        assert!(status.source_pinned);
+
+        let entries = inspect_model_caches(None, true).expect("inspect root");
+        assert!(entries.iter().any(|entry| {
+            entry.cache_key == alias.cache_key
+                && entry.state == ModelCacheState::Complete
+                && entry.complete_cache
+        }));
+    }
+
+    #[test]
+    fn corrupted_and_incomplete_extraction_cache_entries_are_classified() {
+        let cache_root = tempfile::TempDir::new().expect("cache root");
+        let alias = resolve_model_alias("phi-3.5-mini").expect("resolve alias");
+        std::fs::write(cache_root.path().join("phi-3.5-mini"), b"not a directory")
+            .expect("file cache path");
+        let file_entry = inspect_extraction_cache_dir(
+            cache_root.path().join("phi-3.5-mini"),
+            "phi-3.5-mini",
+            Some(&alias),
+            ManifestValidation::Fast,
+        );
+        assert_eq!(file_entry.state, ModelCacheState::Corrupted);
+        assert!(file_entry.cleanup_eligible);
+
+        let broken_manifest_dir = cache_root.path().join("broken");
+        std::fs::create_dir(&broken_manifest_dir).expect("broken dir");
+        std::fs::write(
+            broken_manifest_dir.join(MANIFEST_FILE_NAME),
+            b"{not valid json",
+        )
+        .expect("broken manifest");
+        let mut entries = Vec::new();
+        inspect_extraction_cache_root(&mut entries, cache_root.path(), ManifestValidation::Fast)
+            .expect("inspect root");
+        assert!(entries.iter().any(|entry| {
+            entry.cache_key == "broken"
+                && entry.state == ModelCacheState::Corrupted
+                && entry.cleanup_eligible
+        }));
+    }
+
+    #[test]
+    fn manifest_validation_rejects_mismatches_and_hash_drift() {
+        let cache_root = tempfile::TempDir::new().expect("cache root");
+        let alias = resolve_model_alias(TEST_PINNED_ALIAS).expect("resolve test alias");
+        let cache_dir = cache_root.path().join(&alias.cache_key);
+        write_test_pinned_files(&cache_dir);
+        let manifest = manifest_from_source_pins(&cache_dir, &alias, TEST_CURATED_FILES)
+            .expect("source-pinned manifest");
+
+        let mut wrong_alias = manifest.clone();
+        wrong_alias.requested_alias = "phi-3.5-mini".to_owned();
+        assert!(validate_manifest_contents(
+            &cache_dir,
+            &alias,
+            wrong_alias,
+            ManifestValidation::Fast,
+        )
+        .unwrap_err()
+        .to_string()
+        .contains("alias mismatch"));
+
+        let mut empty_manifest = manifest.clone();
+        empty_manifest.files.clear();
+        assert!(validate_manifest_contents(
+            &cache_dir,
+            &alias,
+            empty_manifest,
+            ManifestValidation::Fast,
+        )
+        .unwrap_err()
+        .to_string()
+        .contains("did not record"));
+
+        let mut wrong_hash = manifest;
+        wrong_hash.files[0].sha256 = "0".repeat(64);
+        assert!(validate_manifest_contents(
+            &cache_dir,
+            &alias,
+            wrong_hash,
+            ManifestValidation::Full,
+        )
+        .unwrap_err()
+        .to_string()
+        .contains("hash mismatch"));
+
+        assert_eq!(
+            cache_state_from_validation_error(&ModelLifecycleError::CacheInvalid {
+                cache_dir: cache_dir.display().to_string(),
+                message: "manifest.json is missing".to_owned(),
+            }),
+            ModelCacheState::Incomplete
+        );
+    }
+
+    #[test]
+    fn utility_helpers_cover_edge_paths() {
+        assert!(resolve_model_alias("   ").is_err());
+        assert!(resolve_model_alias("org/model/extra").is_err());
+        assert_eq!(extraction_temp_cache_key("plain"), None);
+        assert_eq!(extraction_temp_cache_key(".model-download-"), None);
+        assert_eq!(stale_temp_ttl(), DEFAULT_STALE_DOWNLOAD_TTL);
+
+        let _ttl = EnvVarGuard::set(STALE_CACHE_TTL_ENV, "3");
+        assert_eq!(stale_temp_ttl(), Duration::from_secs(3));
+
+        let file = tempfile::NamedTempFile::new().expect("temp file");
+        std::fs::write(file.path(), b"abc").expect("write file");
+        let blob_sha = git_blob_sha1_for_file(file.path(), 3).expect("blob sha");
+        assert_eq!(blob_sha, "f2ba8f84ab5c1bce84a7b441cb1959cfc7093b7f");
+
+        assert!(path_is_within_cache_root(
+            file.path().parent().unwrap(),
+            &file.path().parent().unwrap().join("future")
+        ));
+        assert!(remove_cache_path(&file.path().parent().unwrap().join("missing")).is_ok());
+    }
+
+    #[test]
+    fn progress_reporters_and_download_unsupported_paths_are_covered() {
+        let alias = resolve_model_alias("phi-3.5-mini").expect("resolve alias");
+        let cache_root = tempfile::TempDir::new().expect("cache root");
+        let cache_dir = cache_root.path().join("phi-3.5-mini");
+        let mut reporter = ConsoleProgressReporter::default();
+        reporter.planned(&alias, 2);
+        reporter.cache_hit(&cache_dir);
+        reporter.file_started("config.json", Some(1536));
+        reporter.file_progress("config.json", 1536, Some(1536));
+        reporter.file_finished("config.json", "abcdef1234567890");
+        reporter.file_started("tokenizer.json", None);
+        reporter.file_progress("tokenizer.json", 42, None);
+        reporter.file_finished("tokenizer.json", "abc");
+
+        let mut noop = NoopProgressReporter;
+        noop.planned(&alias, 0);
+        noop.cache_hit(&cache_dir);
+        noop.file_started("file", None);
+        noop.file_progress("file", 1, None);
+        noop.file_finished("file", "sha");
+
+        assert_eq!(human_bytes(1536), "1.5 KiB");
+        assert_eq!(human_duration(Duration::from_millis(250)), "0s");
+        assert_eq!(human_duration(Duration::from_secs(2)), "2s");
+        if !cfg!(feature = "online-model") {
+            assert!(matches!(
+                download_model("phi-3.5-mini", &mut noop),
+                Err(ModelLifecycleError::DownloadsUnsupported)
+            ));
+        }
+    }
+
+    #[test]
+    fn lifecycle_edge_paths_cover_validation_and_cleanup_branches() {
+        let alias = resolve_model_alias("org/model").expect("resolve raw alias");
+        assert!(cache_dir_for_alias("org/model").is_ok());
+        assert!(resolve_model_alias("org/model#bad").is_err());
+        assert!(validate_repo_id(" org/model").is_err());
+        assert!(validate_repo_id("org/model?rev=main").is_err());
+        assert!(validate_repo_id("org/model/extra").is_err());
+        assert!(validate_repo_id("./model").is_err());
+        assert!(validate_repo_id("org/..").is_err());
+        assert!(normalize_relative_path("/absolute.bin").is_err());
+        assert!(normalize_relative_path(".").is_err());
+        assert_eq!(normalize_relative_path("a/./b.bin").unwrap(), "a/b.bin");
+
+        let mut reporter = ConsoleProgressReporter::default();
+        reporter.planned(&alias, 1);
+        reporter.file_started("weights.bin", Some(4096));
+        reporter.last_progress_at = Some(Instant::now());
+        reporter.file_progress("weights.bin", 1024, Some(4096));
+        reporter.current_file_started_at = Some(Instant::now() - Duration::from_secs(2));
+        reporter.last_progress_at = Some(Instant::now() - Duration::from_secs(2));
+        reporter.file_progress("weights.bin", 1024, Some(4096));
+        assert_eq!(human_duration(Duration::from_secs(61)), "1m01s");
+        assert_eq!(human_duration(Duration::from_secs(3661)), "1h01m");
+
+        let cache_root = tempfile::TempDir::new().expect("cache root");
+        let _cache_root = EnvVarGuard::set(MODEL_CACHE_ROOT_ENV, cache_root.path());
+        let malformed = cache_root.path().join("malformed");
+        std::fs::create_dir(&malformed).expect("malformed dir");
+        write_manifest(
+            &malformed,
+            &CacheManifest {
+                manifest_version: Some(MANIFEST_VERSION),
+                requested_alias: "bad alias?".to_owned(),
+                repo_id: "org/model".to_owned(),
+                revision: None,
+                created_at_unix: Some(1),
+                files: vec![CachedFile {
+                    path: "config.json".to_owned(),
+                    sha256: "abc".to_owned(),
+                    size_bytes: Some(0),
+                    modified_unix: Some(1),
+                    verified_from_source: false,
+                }],
+            },
+        );
+        let entries = inspect_model_caches(None, false).expect("inspect malformed root");
+        assert!(entries.iter().any(|entry| {
+            entry.cache_key == "malformed" && entry.state == ModelCacheState::Corrupted
+        }));
+
+        let existing = cache_root.path().join("existing");
+        std::fs::create_dir(&existing).expect("existing dir");
+        let missing_alias_entry = inspect_extraction_cache_dir(
+            existing.clone(),
+            "existing",
+            None,
+            ManifestValidation::Fast,
+        );
+        assert_eq!(missing_alias_entry.state, ModelCacheState::Incomplete);
+
+        let file_cache_root = tempfile::NamedTempFile::new().expect("file cache root");
+        let _file_cache_root = EnvVarGuard::set(MODEL_CACHE_ROOT_ENV, file_cache_root.path());
+        assert!(inspect_model_caches(None, false).is_err());
+        let report = remove_model_cache_entries(&[ModelCacheEntry {
+            family: ModelCacheFamily::Extraction,
+            alias: None,
+            cache_key: "missing-root".to_owned(),
+            path: cache_root.path().join("missing-root"),
+            state: ModelCacheState::StaleTemporary,
+            reason: "missing root".to_owned(),
+            file_count: 0,
+            size_bytes: 0,
+            modified_unix: None,
+            cleanup_eligible: true,
+            complete_cache: false,
+        }]);
+        assert_eq!(report.failed.len(), 1);
+        drop(_file_cache_root);
+
+        let removable_file = cache_root.path().join("removable-file");
+        std::fs::write(&removable_file, b"x").expect("removable file");
+        assert!(remove_cache_path(&removable_file).is_ok());
+        assert!(!removable_file.exists());
+        assert!(!path_is_within_cache_root(
+            &cache_root.path().join("does-not-exist"),
+            &existing
+        ));
+
+        let pin_error = verify_source_pin_for_cache(
+            "weights.bin",
+            3,
+            PinnedDigest::Sha256("0000"),
+            "1111",
+            &existing.join("missing.bin"),
+            &alias,
+            &existing,
+        )
+        .expect_err("sha mismatch");
+        assert!(pin_error.to_string().contains("SHA-256"));
+        std::fs::write(existing.join("blob.bin"), b"abc").expect("blob");
+        let pin_error = verify_source_pin_for_cache(
+            "blob.bin",
+            3,
+            PinnedDigest::GitBlobSha1("0000"),
+            "unused",
+            &existing.join("blob.bin"),
+            &alias,
+            &existing,
+        )
+        .expect_err("git blob mismatch");
+        assert!(pin_error.to_string().contains("git blob"));
+    }
+
+    #[test]
+    fn remove_model_cache_entries_removes_only_allowed_paths() {
+        let cache_root = tempfile::TempDir::new().expect("cache root");
+        let _cache_root = EnvVarGuard::set(MODEL_CACHE_ROOT_ENV, cache_root.path());
+        let removable = cache_root.path().join("stale");
+        std::fs::create_dir(&removable).expect("stale dir");
+        std::fs::write(removable.join("file.bin"), [1_u8, 2, 3]).expect("cache file");
+        let outside = tempfile::NamedTempFile::new().expect("outside file");
+        let protected = cache_root.path().join("protected");
+        std::fs::create_dir(&protected).expect("protected dir");
+
+        let report = remove_model_cache_entries(&[
+            ModelCacheEntry {
+                family: ModelCacheFamily::Extraction,
+                alias: None,
+                cache_key: "stale".to_owned(),
+                path: removable.clone(),
+                state: ModelCacheState::StaleTemporary,
+                reason: "stale".to_owned(),
+                file_count: 1,
+                size_bytes: 3,
+                modified_unix: None,
+                cleanup_eligible: true,
+                complete_cache: false,
+            },
+            ModelCacheEntry {
+                family: ModelCacheFamily::Extraction,
+                alias: None,
+                cache_key: "outside".to_owned(),
+                path: outside.path().to_path_buf(),
+                state: ModelCacheState::StaleTemporary,
+                reason: "outside".to_owned(),
+                file_count: 1,
+                size_bytes: 1,
+                modified_unix: None,
+                cleanup_eligible: true,
+                complete_cache: false,
+            },
+            ModelCacheEntry {
+                family: ModelCacheFamily::Extraction,
+                alias: None,
+                cache_key: "protected".to_owned(),
+                path: protected,
+                state: ModelCacheState::ActiveTemporary,
+                reason: "active".to_owned(),
+                file_count: 0,
+                size_bytes: 0,
+                modified_unix: None,
+                cleanup_eligible: false,
+                complete_cache: false,
+            },
+        ]);
+
+        assert_eq!(report.removed.len(), 1);
+        assert_eq!(report.bytes_freed, 3);
+        assert_eq!(report.failed.len(), 2);
+        assert!(!removable.exists());
+    }
+
+    #[test]
+    fn path_tree_stats_counts_nested_files_and_cache_root_checks_boundaries() {
+        let cache_root = tempfile::TempDir::new().expect("cache root");
+        let nested = cache_root.path().join("entry").join("nested");
+        std::fs::create_dir_all(&nested).expect("nested");
+        std::fs::write(cache_root.path().join("entry").join("a.bin"), [1_u8, 2]).expect("file a");
+        std::fs::write(nested.join("b.bin"), [3_u8]).expect("file b");
+
+        let (file_count, size_bytes, modified_unix) =
+            path_tree_stats(&cache_root.path().join("entry"));
+
+        assert_eq!(file_count, 2);
+        assert_eq!(size_bytes, 3);
+        assert!(modified_unix.is_some());
+        assert!(path_is_within_cache_root(
+            cache_root.path(),
+            &cache_root.path().join("entry")
+        ));
+        assert!(!path_is_within_cache_root(
+            cache_root.path(),
+            cache_root.path()
+        ));
     }
 
     // --- verify_source_pin unit tests (require online-model feature for the fn) ---

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -12,7 +12,7 @@
 )]
 
 use std::collections::HashSet;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Once;
 use std::time::Duration;
 
@@ -140,6 +140,15 @@ pub fn default_db_path() -> std::path::PathBuf {
 /// String form of [`default_db_path`] for use in error messages.
 pub fn default_db_path_string() -> String {
     default_db_path().display().to_string()
+}
+
+/// Returns the conventional first-run collection root at `~/.quaid/vault`.
+pub fn default_collection_root_path() -> Result<PathBuf, DbError> {
+    dirs::home_dir()
+        .map(|home| home.join(".quaid").join("vault"))
+        .ok_or_else(|| DbError::Schema {
+            message: "could not resolve home directory for default collection root".to_owned(),
+        })
 }
 
 /// Opens the database at `path` and ensures it is configured for
@@ -618,12 +627,72 @@ fn ensure_raw_import_hash_schema(conn: &Connection) -> Result<(), DbError> {
 /// `DEFAULT 1` routing them to this collection.  Called at every
 /// `open_connection()` so test-only in-memory databases are also covered.
 fn ensure_default_collection(conn: &Connection) -> Result<(), DbError> {
-    conn.execute_batch(
-        "INSERT OR IGNORE INTO collections \
-             (id, name, root_path, state, writable, is_write_target) \
-         VALUES (1, 'default', '', 'detached', 1, 1);",
+    if has_configured_write_target(conn)? {
+        return Ok(());
+    }
+
+    let default_root = prepare_default_collection_root()?;
+    let tx = conn.unchecked_transaction()?;
+    tx.execute(
+        "UPDATE collections SET is_write_target = 0 WHERE is_write_target != 0",
+        [],
     )?;
+    tx.execute(
+        "INSERT INTO collections \
+             (id, name, root_path, state, writable, is_write_target, needs_full_sync) \
+         VALUES (1, 'default', ?1, 'active', 1, 1, 0) \
+         ON CONFLICT(id) DO UPDATE SET \
+             root_path = CASE \
+                 WHEN trim(collections.root_path) = '' THEN excluded.root_path \
+                 ELSE collections.root_path \
+             END, \
+             state = CASE \
+                 WHEN trim(collections.root_path) = '' THEN 'active' \
+                 ELSE collections.state \
+             END, \
+             writable = CASE \
+                 WHEN trim(collections.root_path) = '' THEN 1 \
+                 ELSE collections.writable \
+             END, \
+             is_write_target = 1, \
+             needs_full_sync = CASE \
+                 WHEN trim(collections.root_path) = '' THEN 0 \
+                 ELSE collections.needs_full_sync \
+             END, \
+             updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')",
+        [default_root],
+    )?;
+    tx.commit()?;
     Ok(())
+}
+
+fn has_configured_write_target(conn: &Connection) -> Result<bool, DbError> {
+    let count: i64 = conn.query_row(
+        "SELECT COUNT(*)
+         FROM collections
+         WHERE is_write_target = 1
+           AND trim(root_path) != ''",
+        [],
+        |row| row.get(0),
+    )?;
+    Ok(count > 0)
+}
+
+fn prepare_default_collection_root() -> Result<String, DbError> {
+    let root = default_collection_root_path()?;
+    std::fs::create_dir_all(&root).map_err(|error| DbError::Schema {
+        message: format!(
+            "failed to create default collection root at {}: {error}",
+            root.display()
+        ),
+    })?;
+    let resolved = std::fs::canonicalize(&root).map_err(|error| DbError::Schema {
+        message: format!(
+            "failed to resolve default collection root at {}: {error}",
+            root.display()
+        ),
+    })?;
+    Ok(resolved.display().to_string())
 }
 
 fn ensure_embedding_model_registry(conn: &Connection, model: &ModelConfig) -> Result<(), DbError> {
@@ -692,13 +761,11 @@ fn recover_crash_partial_fresh_db(
 fn is_bootstrap_fresh_db(conn: &Connection) -> Result<bool, DbError> {
     let default_collection_count: i64 = conn.query_row(
         "SELECT COUNT(*)
-         FROM collections
-         WHERE id = 1
-           AND name = 'default'
-           AND root_path = ''
-           AND state = 'detached'
-           AND writable = 1
-           AND is_write_target = 1",
+                 FROM collections
+                 WHERE id = 1
+                     AND name = 'default'
+                     AND writable = 1
+                     AND is_write_target = 1",
         [],
         |row| row.get(0),
     )?;

--- a/src/core/inference.rs
+++ b/src/core/inference.rs
@@ -1720,6 +1720,25 @@ mod tests {
     }
 
     #[test]
+    fn known_model_helpers_cover_aliases_and_repo_ids() {
+        let aliases = known_embedding_models()
+            .into_iter()
+            .map(|model| model.alias)
+            .collect::<Vec<_>>();
+        assert_eq!(aliases, vec!["small", "base", "large", "m3"]);
+        assert_eq!(
+            resolve_known_embedding_model("BAAI/bge-base-en-v1.5")
+                .expect("known repo")
+                .alias,
+            "base"
+        );
+        assert!(resolve_known_embedding_model("org/custom").is_none());
+        assert_eq!(resolve_model("BAAI/bge-small-en-v1.5").alias, "small");
+        assert_eq!(resolve_model("BAAI/bge-base-en-v1.5").alias, "base");
+        assert_eq!(resolve_model("BAAI/bge-m3").alias, "m3");
+    }
+
+    #[test]
     fn model_config_helper_methods_reflect_aliases_and_dimensions() {
         let small = default_model();
         assert_eq!(small.vec_table(), "page_embeddings_vec_384");
@@ -1768,6 +1787,17 @@ mod tests {
 
         assert!(debug.contains("HashShim"));
         assert!(debug.contains("org/custom-model"));
+    }
+
+    #[test]
+    fn embedding_evidence_kind_reports_loaded_backend() {
+        configure_runtime_model(default_model());
+        let kind = embedding_evidence_kind().expect("evidence kind");
+
+        assert!(matches!(
+            kind,
+            EmbeddingEvidenceKind::Semantic | EmbeddingEvidenceKind::HashShim
+        ));
     }
 
     #[test]
@@ -1853,6 +1883,16 @@ mod tests {
             .expect("empty db search should succeed");
 
         assert!(results.is_empty());
+    }
+
+    #[test]
+    fn search_vec_short_circuits_blank_query_and_zero_limit() {
+        let conn = open_test_db();
+
+        assert!(search_vec("   ", 5, None, None, &conn).unwrap().is_empty());
+        assert!(search_vec("query", 0, None, None, &conn)
+            .unwrap()
+            .is_empty());
     }
 
     #[test]
@@ -1948,6 +1988,50 @@ mod tests {
             "unexpected score: {}",
             results[0].score
         );
+    }
+
+    #[test]
+    fn canonical_vector_search_applies_collection_and_namespace_filters() {
+        let conn = open_test_db();
+        conn.execute(
+            "INSERT INTO pages (slug, namespace, type, title, summary, compiled_truth, timeline, frontmatter, wing, room, version, collection_id) \
+             VALUES (?1, ?2, 'person', ?3, ?4, '', '', '{}', ?5, '', 1, 1)",
+            rusqlite::params!["people/alice", "alpha", "Alice", "Founder", "people"],
+        )
+        .expect("insert namespaced page");
+        let page_id: i64 = conn
+            .query_row(
+                "SELECT id FROM pages WHERE slug = 'people/alice'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("fetch page id");
+        let query_blob = embedding_to_blob(&embed("startup founder").expect("embed query"));
+        conn.execute(
+            "INSERT INTO page_embeddings_vec_384(rowid, embedding) VALUES (?1, ?2)",
+            rusqlite::params![1_i64, query_blob],
+        )
+        .expect("insert vec row");
+        conn.execute(
+            "INSERT INTO page_embeddings (page_id, model, vec_rowid, chunk_type, chunk_index, chunk_text, content_hash, token_count, heading_path) \
+             VALUES (?1, 'BAAI/bge-small-en-v1.5', 1, 'truth_section', 0, 'startup founder', 'hash', 2, 'State')",
+            rusqlite::params![page_id],
+        )
+        .expect("insert embedding metadata");
+
+        let results = search_vec_canonical_with_namespace_filtered(
+            "startup founder",
+            5,
+            Some("people"),
+            Some(1),
+            Some("alpha"),
+            true,
+            &conn,
+        )
+        .expect("canonical vector search");
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].slug, "default::people/alice");
     }
 
     #[test]

--- a/src/core/inference.rs
+++ b/src/core/inference.rs
@@ -34,8 +34,42 @@ use uuid::Uuid;
 use super::chunking::chunk_page;
 use super::types::{InferenceError, SearchError, SearchResult};
 
-#[cfg(all(feature = "embedded-model", feature = "online-model"))]
-compile_error!("Enable only one model channel: `embedded-model` or `online-model`.");
+#[cfg(feature = "online-model")]
+#[derive(Debug)]
+struct TempFileCleanupGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+#[cfg(feature = "online-model")]
+impl TempFileCleanupGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+#[cfg(feature = "online-model")]
+impl Drop for TempFileCleanupGuard {
+    fn drop(&mut self) {
+        if !self.armed || !self.path.exists() {
+            return;
+        }
+        if let Err(error) = std::fs::remove_file(&self.path) {
+            eprintln!(
+                "Warning: failed to remove temporary embedding model file {}: {error}. Run `quaid model clean --all --force` after the download exits.",
+                self.path.display()
+            );
+        }
+    }
+}
 
 const DEFAULT_MODEL_ALIAS: &str = "small";
 const DEFAULT_EMBEDDING_DIMENSIONS: usize = 384;
@@ -219,6 +253,28 @@ pub fn resolve_model(input: &str) -> ModelConfig {
     }
 }
 
+/// Returns the built-in embedding model aliases that use pinned file hashes.
+pub fn known_embedding_models() -> Vec<ModelConfig> {
+    ["small", "base", "large", "m3"]
+        .into_iter()
+        .map(resolve_model)
+        .collect()
+}
+
+/// Resolves a selector only when it names one of Quaid's pinned embedding
+/// model aliases or repository ids, avoiding custom-model warning output.
+pub fn resolve_known_embedding_model(input: &str) -> Option<ModelConfig> {
+    let normalized = input.trim().to_ascii_lowercase();
+    let alias = match normalized.as_str() {
+        "" | "small" | "baai/bge-small-en-v1.5" => "small",
+        "base" | "baai/bge-base-en-v1.5" => "base",
+        "large" | "baai/bge-large-en-v1.5" => "large",
+        "m3" | "baai/bge-m3" => "m3",
+        _ => return None,
+    };
+    Some(resolve_model(alias))
+}
+
 /// Resolves an optional user-supplied model selector, defaulting to the
 /// embedded model and coercing the result to what the current build channel
 /// can actually load.
@@ -384,21 +440,35 @@ impl EmbeddingModel {
     }
 
     fn try_load_candle(config: &ModelConfig) -> Result<EmbeddingBackend, String> {
-        #[cfg(feature = "embedded-model")]
+        #[cfg(all(feature = "online-model", feature = "test-harness"))]
         {
-            return load_embedded_backend(config);
+            load_online_backend(config)
         }
 
-        #[cfg(feature = "online-model")]
+        // When both release channels are enabled outside the test harness,
+        // prefer embedded so validation builds keep release-profile behavior.
+        #[cfg(all(
+            feature = "embedded-model",
+            not(all(feature = "online-model", feature = "test-harness"))
+        ))]
         {
-            return load_online_backend(config);
+            load_embedded_backend(config)
         }
 
-        #[expect(
-            unreachable_code,
-            reason = "either embedded-model or online-model feature returns above; this fallback only fires if neither is enabled at build time"
-        )]
-        Err("no model channel enabled".to_owned())
+        #[cfg(all(
+            not(feature = "embedded-model"),
+            feature = "online-model",
+            not(feature = "test-harness")
+        ))]
+        {
+            load_online_backend(config)
+        }
+
+        #[cfg(not(any(feature = "embedded-model", feature = "online-model")))]
+        {
+            let _ = config;
+            Err("no model channel enabled".to_owned())
+        }
     }
 
     fn embed(&self, text: &str) -> Result<Vec<f32>, InferenceError> {
@@ -427,7 +497,10 @@ impl EmbeddingModel {
     }
 }
 
-#[cfg(feature = "embedded-model")]
+#[cfg(all(
+    feature = "embedded-model",
+    not(all(feature = "online-model", feature = "test-harness"))
+))]
 fn load_embedded_backend(config: &ModelConfig) -> Result<EmbeddingBackend, String> {
     if !config.is_small() {
         return Err(format!(
@@ -763,7 +836,9 @@ fn download_model_file(
 ) -> Result<(), String> {
     let validated_model_id = validate_model_id(&model.model_id)?;
     let destination = cache_dir.join(file_name);
-    let (temp_destination, mut file) = create_temp_download_file(cache_dir, file_name)?;
+    let (temp_destination, file) = create_temp_download_file(cache_dir, file_name)?;
+    let mut temp_guard = TempFileCleanupGuard::new(temp_destination);
+    let mut file = file;
     let base_url = huggingface_base_url();
     // Use pinned revision for standard aliases; fall back to `main` only for
     // custom/unpinned models so upstream changes never silently break SHA checks.
@@ -786,22 +861,34 @@ fn download_model_file(
         .map_err(|e| format!("download {url}: {e}"))?;
 
     std::io::copy(&mut response, &mut file)
-        .map_err(|e| format!("write {}: {e}", temp_destination.display()))?;
+        .map_err(|e| format!("write {}: {e}", temp_guard.path().display()))?;
+    file.sync_all()
+        .map_err(|e| format!("flush {}: {e}", temp_guard.path().display()))?;
 
     if let Some(expected_hash) = expected_hash_for_file(model, file_name) {
-        verify_file_sha256(&temp_destination, expected_hash)?;
+        verify_file_sha256(temp_guard.path(), expected_hash).map_err(|error| {
+            format!(
+                "{error}; run `quaid model clean {} --force` and retry the operation",
+                model.alias
+            )
+        })?;
     }
 
-    if let Err(err) = std::fs::rename(&temp_destination, &destination) {
-        let _ = std::fs::remove_file(&temp_destination);
+    drop(file);
+    if let Err(err) = std::fs::rename(temp_guard.path(), &destination) {
         if destination.exists() {
             if let Some(expected_hash) = expected_hash_for_file(model, file_name) {
                 verify_file_sha256(&destination, expected_hash)?;
             }
             return Ok(());
         }
-        return Err(format!("rename {}: {err}", destination.display()));
+        return Err(format!(
+            "rename {}: {err}; temporary file {} will be removed",
+            destination.display(),
+            temp_guard.path().display()
+        ));
     }
+    temp_guard.disarm();
 
     Ok(())
 }
@@ -888,6 +975,44 @@ fn existing_model_paths(cache_dir: &Path) -> Option<(PathBuf, PathBuf, PathBuf)>
 
     (config.is_file() && tokenizer.is_file() && model.is_file())
         .then_some((config, tokenizer, model))
+}
+
+/// Returns the cache directory used for a resolved online embedding model.
+#[cfg(feature = "online-model")]
+pub fn embedding_model_cache_dir(model: &ModelConfig) -> Result<PathBuf, String> {
+    model_cache_dir(model)
+}
+
+/// Returns the sanitized cache key used for a resolved online embedding model.
+#[cfg(feature = "online-model")]
+pub fn embedding_model_cache_key(model: &ModelConfig) -> String {
+    cache_dir_name(model)
+}
+
+/// Returns the required file names for an online embedding model cache.
+#[cfg(feature = "online-model")]
+pub fn embedding_required_files() -> &'static [&'static str] {
+    &["config.json", "tokenizer.json", "model.safetensors"]
+}
+
+/// Validates the required files for an online embedding model cache, with
+/// optional SHA-256 verification for pinned models.
+#[cfg(feature = "online-model")]
+pub fn verify_embedding_model_cache(
+    model: &ModelConfig,
+    cache_dir: &Path,
+    verify_hashes: bool,
+) -> Result<(), String> {
+    for file_name in embedding_required_files() {
+        let path = cache_dir.join(file_name);
+        if !path.is_file() {
+            return Err(format!("missing required file {}", path.display()));
+        }
+    }
+    if verify_hashes {
+        verify_cached_model_integrity(model, cache_dir)?;
+    }
+    Ok(())
 }
 
 #[cfg(feature = "online-model")]

--- a/src/core/vault_sync/mod.rs
+++ b/src/core/vault_sync/mod.rs
@@ -2126,6 +2126,7 @@ pub fn wait_for_exact_ack(
     reload_generation: i64,
 ) -> Result<(), VaultSyncError> {
     let started = Instant::now();
+    let timeout = handshake_timeout();
     loop {
         let collection = load_collection_by_id(conn, collection_id)?;
         // Re-check owner via typed live_collection_owner so that a CLI lease or a
@@ -2157,7 +2158,7 @@ pub fn wait_for_exact_ack(
         {
             return Ok(());
         }
-        if started.elapsed() >= Duration::from_secs(HANDSHAKE_TIMEOUT_SECS) {
+        if started.elapsed() >= timeout {
             return Err(VaultSyncError::Restore(RestoreError::HandshakeTimeout {
                 collection_name: collection.name,
                 expected_session_id: expected_session_id.to_owned(),
@@ -2166,6 +2167,15 @@ pub fn wait_for_exact_ack(
         }
         thread::sleep(Duration::from_millis(HANDSHAKE_POLL_MS));
     }
+}
+
+fn handshake_timeout() -> Duration {
+    std::env::var("QUAID_HANDSHAKE_TIMEOUT_SECS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|secs| *secs > 0)
+        .map(Duration::from_secs)
+        .unwrap_or_else(|| Duration::from_secs(HANDSHAKE_TIMEOUT_SECS))
 }
 
 fn configured_full_hash_audit_days() -> i64 {

--- a/tests/cli_collection_truth_restore.rs
+++ b/tests/cli_collection_truth_restore.rs
@@ -552,7 +552,7 @@ fn online_restore_with_live_serve_rebinds_without_restarting_serve() {
             .expect("start serve runtime");
     thread::sleep(Duration::from_secs(1));
 
-    let output = run_quaid(
+    let output = run_quaid_with_env(
         &db_path,
         &[
             "--json",
@@ -562,6 +562,7 @@ fn online_restore_with_live_serve_rebinds_without_restarting_serve() {
             target_root.to_str().expect("utf-8 target"),
             "--online",
         ],
+        &[("QUAID_HANDSHAKE_TIMEOUT_SECS", "90")],
     );
 
     assert!(

--- a/tests/cli_init_defaults.rs
+++ b/tests/cli_init_defaults.rs
@@ -1,0 +1,210 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    reason = "integration test fixtures panic with useful command diagnostics"
+)]
+
+mod common;
+#[path = "common/subprocess.rs"]
+mod common_subprocess;
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use rusqlite::Connection;
+
+fn run_quaid_with_home(home: &Path, args: &[&str]) -> Output {
+    let mut command = Command::new(common::quaid_bin());
+    common_subprocess::configure_test_command(&mut command);
+    command
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .args(args)
+        .output()
+        .expect("run quaid")
+}
+
+fn assert_success(output: &Output) {
+    assert!(
+        output.status.success(),
+        "command failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn default_collection_row(db_path: &Path) -> (String, String, i64, i64) {
+    let conn = Connection::open(db_path).unwrap();
+    conn.query_row(
+        "SELECT root_path, state, writable, is_write_target
+         FROM collections
+         WHERE id = 1 AND name = 'default'",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+    )
+    .unwrap()
+}
+
+fn default_vault(home: &Path) -> PathBuf {
+    home.join(".quaid").join("vault")
+}
+
+#[test]
+fn init_creates_default_writable_collection_root_under_home() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let home = dir.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let db_path = dir.path().join("memory.db");
+
+    let output = run_quaid_with_home(&home, &["init", db_path.to_str().unwrap()]);
+
+    assert_success(&output);
+    let expected_root = fs::canonicalize(default_vault(&home)).unwrap();
+    let (root_path, state, writable, is_write_target) = default_collection_row(&db_path);
+    assert_eq!(PathBuf::from(root_path), expected_root);
+    assert_eq!(state, "active");
+    assert_eq!(writable, 1);
+    assert_eq!(is_write_target, 1);
+}
+
+#[test]
+fn init_preserves_existing_configured_write_target_root() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let first_home = dir.path().join("first-home");
+    let second_home = dir.path().join("second-home");
+    let custom_root = dir.path().join("custom-vault");
+    fs::create_dir_all(&first_home).unwrap();
+    fs::create_dir_all(&second_home).unwrap();
+    fs::create_dir_all(&custom_root).unwrap();
+    let custom_root = fs::canonicalize(custom_root).unwrap();
+    let db_path = dir.path().join("memory.db");
+
+    assert_success(&run_quaid_with_home(
+        &first_home,
+        &["init", db_path.to_str().unwrap()],
+    ));
+    let conn = Connection::open(&db_path).unwrap();
+    conn.execute(
+        "UPDATE collections
+         SET root_path = ?1,
+             state = 'active',
+             writable = 1,
+             is_write_target = 1
+         WHERE id = 1",
+        [custom_root.display().to_string()],
+    )
+    .unwrap();
+    drop(conn);
+
+    assert_success(&run_quaid_with_home(
+        &second_home,
+        &["init", db_path.to_str().unwrap()],
+    ));
+
+    let (root_path, state, writable, is_write_target) = default_collection_row(&db_path);
+    assert_eq!(PathBuf::from(root_path), custom_root);
+    assert_eq!(state, "active");
+    assert_eq!(writable, 1);
+    assert_eq!(is_write_target, 1);
+    assert!(!default_vault(&second_home).exists());
+}
+
+#[test]
+fn init_repairs_legacy_unconfigured_default_write_target() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let first_home = dir.path().join("first-home");
+    let repaired_home = dir.path().join("repaired-home");
+    fs::create_dir_all(&first_home).unwrap();
+    fs::create_dir_all(&repaired_home).unwrap();
+    let db_path = dir.path().join("memory.db");
+
+    assert_success(&run_quaid_with_home(
+        &first_home,
+        &["init", db_path.to_str().unwrap()],
+    ));
+    let conn = Connection::open(&db_path).unwrap();
+    conn.execute(
+        "UPDATE collections
+         SET root_path = '',
+             state = 'detached',
+             writable = 1,
+             is_write_target = 1
+         WHERE id = 1",
+        [],
+    )
+    .unwrap();
+    drop(conn);
+
+    assert_success(&run_quaid_with_home(
+        &repaired_home,
+        &["init", db_path.to_str().unwrap()],
+    ));
+
+    let expected_root = fs::canonicalize(default_vault(&repaired_home)).unwrap();
+    let (root_path, state, writable, is_write_target) = default_collection_row(&db_path);
+    assert_eq!(PathBuf::from(root_path), expected_root);
+    assert_eq!(state, "active");
+    assert_eq!(writable, 1);
+    assert_eq!(is_write_target, 1);
+}
+
+#[test]
+fn init_surfaces_clear_error_when_default_root_cannot_be_created() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let home_file = dir.path().join("not-a-directory");
+    fs::write(&home_file, "not a directory").unwrap();
+    let db_path = dir.path().join("memory.db");
+
+    let output = run_quaid_with_home(&home_file, &["init", db_path.to_str().unwrap()]);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("failed to create default collection root"));
+}
+
+#[test]
+fn memory_add_turn_writes_to_default_root_after_fresh_init() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let home = dir.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let db_path = dir.path().join("memory.db");
+
+    assert_success(&run_quaid_with_home(
+        &home,
+        &["init", db_path.to_str().unwrap()],
+    ));
+    let params = serde_json::json!({
+        "session_id": "fresh-session",
+        "role": "user",
+        "content": "hello from a fresh init",
+        "timestamp": "2026-05-03T09:14:22Z"
+    })
+    .to_string();
+
+    let output = run_quaid_with_home(
+        &home,
+        &[
+            "--db",
+            db_path.to_str().unwrap(),
+            "call",
+            "memory_add_turn",
+            &params,
+        ],
+    );
+
+    assert_success(&output);
+    let payload: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(payload["turn_id"], "fresh-session:1");
+    assert_eq!(
+        payload["conversation_path"],
+        "conversations/2026-05-03/fresh-session.md"
+    );
+    let conversation_path = default_vault(&home)
+        .join("conversations")
+        .join("2026-05-03")
+        .join("fresh-session.md");
+    let conversation = fs::read_to_string(conversation_path).unwrap();
+    assert!(conversation.contains("hello from a fresh init"));
+}

--- a/tests/command_surface_coverage.rs
+++ b/tests/command_surface_coverage.rs
@@ -65,11 +65,10 @@ fn run_quaid_in_dir(db_path: &Path, dir: &Path, args: &[&str], home_dir: &Path) 
 
 /// Provision a real vault root on the default collection (id=1).
 ///
-/// `quaid init` seeds the default collection with `root_path = ''` and
-/// `state = 'detached'`, which is fine for purely in-memory usage but breaks
-/// any code path that touches `vault_sync::with_write_slug_lock` because it
-/// tries to open the (empty) root directory.  Call this helper after
-/// `db::open` and before any `put` / write-through operation.
+/// Provision a real test-local vault root on the default collection (id=1).
+///
+/// Production init now provisions `~/.quaid/vault`, but these tests keep file
+/// writes inside the temp directory so subprocess assertions remain isolated.
 fn provision_vault(dir: &tempfile::TempDir, conn: &Connection) {
     let vault_root = dir.path().join("vault");
     fs::create_dir_all(&vault_root).unwrap();

--- a/tests/common/truth_fixtures.rs
+++ b/tests/common/truth_fixtures.rs
@@ -46,6 +46,21 @@ pub fn run_quaid(db_path: &Path, args: &[&str]) -> std::process::Output {
     command.output().expect("run quaid")
 }
 
+pub fn run_quaid_with_env(
+    db_path: &Path,
+    args: &[&str],
+    envs: &[(&str, &str)],
+) -> std::process::Output {
+    let mut command = Command::new(bin_path());
+    crate::common_subprocess::configure_test_command(&mut command);
+    command
+        .arg("--db")
+        .arg(db_path)
+        .args(args)
+        .envs(envs.iter().copied());
+    command.output().expect("run quaid")
+}
+
 pub fn run_quaid_with_stdin(db_path: &Path, args: &[&str], stdin: &str) -> std::process::Output {
     let mut command = Command::new(bin_path());
     crate::common_subprocess::configure_test_command(&mut command);

--- a/tests/entity_extraction.rs
+++ b/tests/entity_extraction.rs
@@ -527,15 +527,17 @@ fn partial_over_budget_route_preserves_existing_entity_assertions() {
     insert_page(&conn, "companies/acme", "Acme", "body");
     let patterns = entities::load_patterns_from(None, &conn).unwrap();
 
-    entities::run_for_page(
+    entities::run_for_page_with_deadline(
         &conn,
         source,
         1,
         "sources/note",
         "Alice founded Brex. Bob founded Acme.",
         &patterns,
+        Duration::from_secs(1),
     )
     .unwrap();
+    assert_eq!(count_assertions(&conn, source), 2);
     let partial_summary = entities::route_entity_matches_with_sync(
         &conn,
         source,

--- a/tests/mcp_server_shutdown.rs
+++ b/tests/mcp_server_shutdown.rs
@@ -81,11 +81,19 @@ fn terminate_child(child: &Child) {
 }
 
 fn assert_no_sessions(db_path: &std::path::Path) {
-    let conn = Connection::open(db_path).unwrap();
-    let count: i64 = conn
-        .query_row("SELECT COUNT(*) FROM serve_sessions", [], |row| row.get(0))
-        .unwrap();
-    assert_eq!(count, 0);
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut last_count = 0;
+    while Instant::now() < deadline {
+        let conn = Connection::open(db_path).unwrap();
+        last_count = conn
+            .query_row("SELECT COUNT(*) FROM serve_sessions", [], |row| row.get(0))
+            .unwrap();
+        if last_count == 0 {
+            return;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    assert_eq!(last_count, 0);
 }
 
 #[test]

--- a/tests/model_lifecycle.rs
+++ b/tests/model_lifecycle.rs
@@ -11,12 +11,14 @@ mod common;
 #[path = "common/subprocess.rs"]
 mod common_subprocess;
 
+use filetime::{set_file_mtime, FileTime};
 use quaid::core::{
     conversation::model_lifecycle::{
-        cache_dir_for_alias, cached_model_status, download_model, resolve_model_alias,
-        NoopProgressReporter, ProgressReporter,
+        cache_dir_for_alias, cached_model_status, download_model, inspect_model_caches,
+        remove_model_cache_entries, resolve_model_alias, ModelCacheState, NoopProgressReporter,
+        ProgressReporter,
     },
-    db,
+    db, inference,
 };
 use rusqlite::Connection;
 use sha2::{Digest, Sha256};
@@ -339,6 +341,10 @@ fn open_db(path: &Path) -> Connection {
     db::open(path.to_str().expect("utf8 db path")).expect("open db")
 }
 
+fn mark_path_old(path: &Path) {
+    set_file_mtime(path, FileTime::from_unix_time(1, 0)).expect("set old mtime");
+}
+
 #[test]
 fn resolve_model_alias_maps_gemma_3_4b() {
     let resolved = resolve_model_alias("gemma-3-4b").expect("resolve alias");
@@ -431,6 +437,42 @@ fn download_model_rejects_bad_integrity_and_cleans_partial_cache() {
 }
 
 #[test]
+fn embedding_download_removes_temp_file_after_hash_failure() {
+    let _lock = env_lock().lock().unwrap_or_else(|error| error.into_inner());
+    let model = inference::resolve_model("base");
+    let revision = model
+        .sha256_hashes
+        .and_then(|hashes| hashes.revision)
+        .expect("base revision");
+    let server = MockModelServer::start(&model.model_id, revision, mock_files(false));
+    let cache_root = tempfile::TempDir::new().expect("cache root");
+    let _env = EnvGuard::set_all(&[
+        ("QUAID_HF_BASE_URL", server.base_url.clone()),
+        (
+            "QUAID_MODEL_CACHE_DIR",
+            cache_root.path().display().to_string(),
+        ),
+        ("QUAID_FORCE_HASH_SHIM", "0".to_owned()),
+    ]);
+
+    inference::set_model_config(model.clone());
+    let embedding = inference::embed("force embedding download").expect("fallback embedding");
+    assert_eq!(embedding.len(), model.embedding_dim);
+
+    let cache_dir = inference::embedding_model_cache_dir(&model).expect("embedding cache dir");
+    let leftovers = std::fs::read_dir(&cache_dir)
+        .expect("read embedding cache dir")
+        .filter_map(Result::ok)
+        .map(|entry| entry.file_name().to_string_lossy().into_owned())
+        .filter(|name| name.contains(".download-"))
+        .collect::<Vec<_>>();
+    assert!(
+        leftovers.is_empty(),
+        "temporary embedding files should be removed, found {leftovers:?}"
+    );
+}
+
+#[test]
 fn download_model_succeeds_when_another_writer_populates_the_cache_first() {
     let _lock = env_lock().lock().unwrap_or_else(|error| error.into_inner());
     let repo_id = "org/test-model";
@@ -465,6 +507,38 @@ fn download_model_succeeds_when_another_writer_populates_the_cache_first() {
 }
 
 #[test]
+fn inspect_model_caches_generates_manifest_v1_from_trusted_source_pins() {
+    let _lock = env_lock().lock().unwrap_or_else(|error| error.into_inner());
+    let cache_root = tempfile::TempDir::new().expect("cache root");
+    let _env = EnvGuard::set_all(&[(
+        "QUAID_MODEL_CACHE_DIR",
+        cache_root.path().display().to_string(),
+    )]);
+    let cache_dir = cache_dir_for_alias("test-pinned").expect("cache dir");
+    std::fs::create_dir_all(&cache_dir).expect("create cache dir");
+    for (path, file) in mock_files(false) {
+        std::fs::write(cache_dir.join(path), file.content).expect("write cached file");
+    }
+
+    let entries = inspect_model_caches(Some("test-pinned"), true).expect("inspect caches");
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].state, ModelCacheState::Complete);
+    assert!(entries[0].complete_cache);
+
+    let manifest: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(cache_dir.join("manifest.json")).expect("read manifest"),
+    )
+    .expect("parse manifest");
+    assert_eq!(manifest["manifest_version"], 1);
+    assert!(manifest["created_at_unix"].as_u64().is_some());
+    for file in manifest["files"].as_array().expect("manifest files") {
+        assert!(file["size_bytes"].as_u64().is_some());
+        assert!(file["modified_unix"].as_u64().is_some());
+        assert_eq!(file["verified_from_source"], true);
+    }
+}
+
+#[test]
 fn download_model_scavenges_stale_download_dirs_without_touching_recent_ones() {
     let _lock = env_lock().lock().unwrap_or_else(|error| error.into_inner());
     let repo_id = "org/test-model";
@@ -479,6 +553,7 @@ fn download_model_scavenges_stale_download_dirs_without_touching_recent_ones() {
     std::fs::create_dir_all(&recent_dir).expect("create recent dir");
     std::fs::write(stale_dir.join("partial.bin"), b"stale").expect("write stale file");
     std::fs::write(recent_dir.join("partial.bin"), b"recent").expect("write recent file");
+    mark_path_old(&stale_dir);
 
     let _env = EnvGuard::set_all(&[
         ("QUAID_HF_BASE_URL", server.base_url.clone()),
@@ -493,6 +568,45 @@ fn download_model_scavenges_stale_download_dirs_without_touching_recent_ones() {
 
     assert!(!stale_dir.exists(), "stale dir should be scavenged");
     assert!(recent_dir.exists(), "recent dir should be preserved");
+}
+
+#[test]
+fn inspect_and_clean_preserves_active_temp_dirs() {
+    let _lock = env_lock().lock().unwrap_or_else(|error| error.into_inner());
+    let cache_root = tempfile::TempDir::new().expect("cache root");
+    let stale_dir = cache_root.path().join(".org-test-model-download-1-stale");
+    let active_dir = cache_root.path().join(".org-test-model-download-1-active");
+    std::fs::create_dir_all(&stale_dir).expect("create stale dir");
+    std::fs::create_dir_all(&active_dir).expect("create active dir");
+    std::fs::write(stale_dir.join("partial.bin"), b"stale").expect("write stale file");
+    std::fs::write(active_dir.join(".downloading"), b"active").expect("write heartbeat");
+    mark_path_old(&stale_dir);
+    let _env = EnvGuard::set_all(&[
+        (
+            "QUAID_MODEL_CACHE_DIR",
+            cache_root.path().display().to_string(),
+        ),
+        ("QUAID_STALE_MODEL_CACHE_TTL_SECS", "3600".to_owned()),
+    ]);
+
+    let entries = inspect_model_caches(None, false).expect("inspect caches");
+    assert!(entries
+        .iter()
+        .any(|entry| entry.path == stale_dir && entry.cleanup_eligible));
+    assert!(entries.iter().any(|entry| {
+        entry.path == active_dir
+            && entry.state == ModelCacheState::ActiveTemporary
+            && !entry.cleanup_eligible
+    }));
+
+    let candidates = entries
+        .into_iter()
+        .filter(|entry| entry.cleanup_eligible)
+        .collect::<Vec<_>>();
+    let report = remove_model_cache_entries(&candidates);
+    assert!(report.failed.is_empty(), "cleanup failures: {report:?}");
+    assert!(!stale_dir.exists(), "stale temp dir should be removed");
+    assert!(active_dir.exists(), "active temp dir should be preserved");
 }
 
 #[test]
@@ -588,6 +702,86 @@ fn cli_model_pull_caches_without_flipping_extraction_flag() {
     let enabled = quaid::core::db::read_config_value_or(&conn, "extraction.enabled", "false")
         .expect("read extraction flag");
     assert_eq!(enabled, "false");
+}
+
+#[test]
+fn cli_model_status_reports_verified_cache() {
+    let _lock = env_lock().lock().unwrap_or_else(|error| error.into_inner());
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let db_path = dir.path().join("memory.db");
+    let cache_root = dir.path().join("cache");
+    let _env = EnvGuard::set_all(&[("QUAID_MODEL_CACHE_DIR", cache_root.display().to_string())]);
+    let cache_dir = cache_dir_for_alias("test-pinned").expect("cache dir");
+    std::fs::create_dir_all(&cache_dir).expect("create cache dir");
+    for (path, file) in mock_files(false) {
+        std::fs::write(cache_dir.join(path), file.content).expect("write cached file");
+    }
+
+    let output = run_quaid_with_env(
+        &db_path,
+        &["model", "status", "test-pinned", "--verify"],
+        &[("QUAID_MODEL_CACHE_DIR", cache_root.display().to_string())],
+    );
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("extraction"));
+    assert!(stdout.contains("test-pinned"));
+    assert!(stdout.contains("complete"));
+}
+
+#[test]
+fn cli_model_clean_list_and_all_force_remove_only_cleanup_candidates() {
+    let _lock = env_lock().lock().unwrap_or_else(|error| error.into_inner());
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let db_path = dir.path().join("memory.db");
+    let cache_root = dir.path().join("cache");
+    std::fs::create_dir_all(&cache_root).expect("create cache root");
+    let _env = EnvGuard::set_all(&[("QUAID_MODEL_CACHE_DIR", cache_root.display().to_string())]);
+    let stale_dir = cache_root.join(".org-test-model-download-1-stale");
+    std::fs::create_dir_all(&stale_dir).expect("create stale dir");
+    std::fs::write(stale_dir.join("partial.bin"), b"stale").expect("write stale file");
+    mark_path_old(&stale_dir);
+
+    let cache_dir = cache_dir_for_alias("test-pinned").expect("cache dir");
+    std::fs::create_dir_all(&cache_dir).expect("create complete cache dir");
+    for (path, file) in mock_files(false) {
+        std::fs::write(cache_dir.join(path), file.content).expect("write cached file");
+    }
+    inspect_model_caches(Some("test-pinned"), true).expect("generate manifest");
+
+    let envs = [("QUAID_MODEL_CACHE_DIR", cache_root.display().to_string())];
+    let list_output = run_quaid_with_env(&db_path, &["model", "clean", "--list"], &envs);
+    assert!(
+        list_output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&list_output.stdout),
+        String::from_utf8_lossy(&list_output.stderr)
+    );
+    assert!(stale_dir.exists(), "--list must not delete stale dirs");
+    let list_stdout = String::from_utf8_lossy(&list_output.stdout);
+    assert!(list_stdout.contains("stale-temp"));
+    assert!(!list_stdout.contains("test-pinned"));
+
+    let clean_output = run_quaid_with_env(&db_path, &["model", "clean", "--all", "--force"], &envs);
+    assert!(
+        clean_output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&clean_output.stdout),
+        String::from_utf8_lossy(&clean_output.stderr)
+    );
+    assert!(
+        !stale_dir.exists(),
+        "--all --force should remove stale dirs"
+    );
+    assert!(
+        cache_dir.exists(),
+        "--all --force should preserve complete caches"
+    );
 }
 
 #[test]


### PR DESCRIPTION
This pull request introduces improvements to model caching and default collection setup in Quaid. It adds a unified model cache inspection and cleanup interface, enhances cache manifest compatibility and repair, and ensures a writable collection is provisioned by default for new databases. Documentation and migration guides have been updated to reflect these changes.

**Model cache improvements:**

* Introduced a versioned manifest format (`manifest_version = 1`) for model caches, with backward compatibility for legacy manifests. Manifests now include file size and modification time metadata, improving cache validation and repair. [[1]](diffhunk://#diff-9069ee5e76909ff15e297f35234e161ce30629f025cd9072dddba403cc875c31R33-R48) [[2]](diffhunk://#diff-813f8db22a8eb382dd79f854e444187506bf808510d6905dcb893c358ff09d72R1-R238)
* Added new CLI commands: `quaid model status` for cache health inspection (with optional hash verification), and `quaid model clean` for listing and removing incomplete or stale cache artifacts. [[1]](diffhunk://#diff-2a07d3a433aed65f279582bc009b0b43a8dbd983da3b4f19d91913e7e6dc152bR1-R62) [[2]](diffhunk://#diff-813f8db22a8eb382dd79f854e444187506bf808510d6905dcb893c358ff09d72R1-R238)
* Implemented robust cleanup guards for temporary download files/directories, ensuring partial or failed downloads are reliably removed.
* Updated documentation to describe new model cache operations, manifest upgrade behavior, and error recovery steps. [[1]](diffhunk://#diff-2a07d3a433aed65f279582bc009b0b43a8dbd983da3b4f19d91913e7e6dc152bR1-R62) [[2]](diffhunk://#diff-9069ee5e76909ff15e297f35234e161ce30629f025cd9072dddba403cc875c31R33-R48)

**Default collection provisioning:**

* On fresh `quaid init`, a writable default collection is now created at `~/.quaid/vault`, enabling immediate write operations (such as MCP conversation capture) without manual collection setup. Existing databases are preserved, and legacy unconfigured defaults are repaired on open. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR11-R15) [[2]](diffhunk://#diff-31bcba2ccafa41d46fbbd6d1219f7f1e3b1fb3cad9faa8e4dc521bbb579dd7b3R86) [[3]](diffhunk://#diff-da5e03c775a894c6a1b9a3c5620d74e086041f7d4f88d21a8f0996507bfcf752R125-R126)

**Migration and rollback:**

* No schema migration is required; legacy databases remain compatible. Only unconfigured write-target states are conditionally bootstrapped. Rollback instructions are provided for disabling default root bootstrap if needed. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL20-R26) [[2]](diffhunk://#diff-da5e03c775a894c6a1b9a3c5620d74e086041f7d4f88d21a8f0996507bfcf752R176-R184)

**Build and dependency updates:**

* Added new build targets to `Makefile` for cross-compilation and clarified build/benchmark flows.
* Updated `Cargo.toml` with a new version (`0.22.4`), added `filetime` as a dev dependency, and reformatted dependencies for clarity. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3-R3) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L36-R39) [[3]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R82-R90)

**Specification and documentation:**

* Added a design document and openspec metadata for the model cache improvements, detailing context, decisions, and migration steps. [[1]](diffhunk://#diff-813f8db22a8eb382dd79f854e444187506bf808510d6905dcb893c358ff09d72R1-R238) [[2]](diffhunk://#diff-9aec6feb1a0a5fc8fe457538c1ef144799af4c8efc9ca5eb14ade33af10d4b06R1-R2)