### PR TITLE
Fix issues #212 and #196

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2135,7 +2135,7 @@ dependencies = [
 
 [[package]]
 name = "quaid"
-version = "0.22.5"
+version = "0.22.6"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quaid"
-version = "0.22.5"
+version = "0.22.6"
 edition = "2021"
 description = "Local-first personal memory. SQLite + FTS5 + local vector embeddings. One static binary."
 license = "MIT"

--- a/src/core/fts.rs
+++ b/src/core/fts.rs
@@ -160,12 +160,18 @@ pub fn search_fts(conn: &Connection, q: FtsQuery<'_>) -> Result<Vec<SearchResult
 ///
 /// Single-token or empty inputs are returned unchanged.
 pub fn expand_fts_query_or(sanitized: &str) -> String {
-    let tokens: Vec<_> = sanitized.split_whitespace().collect();
-    if tokens.len() <= 1 {
-        sanitized.to_owned()
+    let token_queries = token_queries_with_numeric_aliases(sanitized);
+    if token_queries.len() <= 1 {
+        token_queries.into_iter().next().unwrap_or_default()
     } else {
-        tokens.join(" OR ")
+        token_queries.join(" OR ")
     }
+}
+
+/// Expand sanitized numeric tokens into equivalent FTS clauses while
+/// preserving implicit-AND semantics between top-level tokens.
+pub(crate) fn expand_numeric_fts_query(sanitized: &str) -> String {
+    token_queries_with_numeric_aliases(sanitized).join(" AND ")
 }
 
 /// Natural-language FTS5 search with tiered AND→OR fallback for compound-term
@@ -208,9 +214,10 @@ fn search_fts_tiered_internal(
     limit: usize,
     canonical_slug: bool,
 ) -> Result<Vec<SearchResult>, SearchError> {
+    let and_query = expand_numeric_fts_query(sanitized_query);
     // AND pass — highest precision; use this if it returns any results.
     let and_results = search_fts_internal(
-        sanitized_query,
+        &and_query,
         wing_filter,
         collection_filter,
         namespace_filter,
@@ -224,7 +231,7 @@ fn search_fts_tiered_internal(
     }
 
     let or_query = expand_fts_query_or(sanitized_query);
-    if or_query == sanitized_query {
+    if or_query == and_query {
         return Ok(Vec::new());
     }
 
@@ -238,6 +245,68 @@ fn search_fts_tiered_internal(
         limit,
         canonical_slug,
     )
+}
+
+fn token_queries_with_numeric_aliases(sanitized: &str) -> Vec<String> {
+    sanitized
+        .split_whitespace()
+        .map(expand_numeric_token_query)
+        .collect()
+}
+
+fn expand_numeric_token_query(token: &str) -> String {
+    let aliases = numeric_token_aliases(token);
+    if aliases.len() == 1 {
+        aliases.into_iter().next().unwrap_or_default()
+    } else {
+        format!("({})", aliases.join(" OR "))
+    }
+}
+
+fn numeric_token_aliases(token: &str) -> Vec<String> {
+    if !token.chars().all(|ch| ch.is_ascii_digit()) {
+        return vec![token.to_owned()];
+    }
+
+    let mut aliases = vec![token.to_owned()];
+    if let Some(grouped) = grouped_numeric_phrase(token) {
+        aliases.push(format!("\"{grouped}\""));
+    }
+    if let Some(abbreviated) = abbreviated_numeric_alias(token) {
+        aliases.push(abbreviated);
+    }
+    aliases
+}
+
+fn grouped_numeric_phrase(token: &str) -> Option<String> {
+    if token.len() <= 3 {
+        return None;
+    }
+
+    let split_at = token.len() % 3;
+    let mut groups = Vec::new();
+    if split_at != 0 {
+        groups.push(token[..split_at].to_owned());
+    }
+    for chunk in token.as_bytes()[split_at..].chunks(3) {
+        groups.push(String::from_utf8_lossy(chunk).into_owned());
+    }
+
+    Some(groups.join(" "))
+}
+
+fn abbreviated_numeric_alias(token: &str) -> Option<String> {
+    let value = token.parse::<u64>().ok()?;
+    for (divisor, suffix) in [
+        (1_000_000_000_u64, "b"),
+        (1_000_000_u64, "m"),
+        (1_000_u64, "k"),
+    ] {
+        if value >= divisor && value % divisor == 0 {
+            return Some(format!("{}{suffix}", value / divisor));
+        }
+    }
+    None
 }
 
 #[expect(

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -20,7 +20,10 @@ use serde::Deserialize;
 use crate::commands::{get, put};
 
 use crate::core::collections::{self, OpKind, SlugResolution};
-use crate::core::conversation::{extractor::SlmClient, slm::LazySlmRunner, turn_writer};
+use crate::core::conversation::{
+    extractor::SlmClient, format::MemoryLocation, slm::LazySlmRunner, turn_writer,
+};
+use crate::core::db;
 #[cfg(test)]
 use crate::core::graph::{GraphError, TemporalFilter};
 use crate::core::vault_sync;
@@ -82,6 +85,15 @@ pub(crate) fn resolve_memory_collection_filter_for_mcp(
         collections::get_single_active_collection(db).map_err(map_collection_error)?
     {
         return Ok(Some(collection));
+    }
+
+    let memory_location = db::read_config_value_or(db, "memory.location", "vault-subdir")
+        .map_err(map_config_error)?;
+    if matches!(
+        MemoryLocation::from_config(&memory_location).map_err(map_config_error)?,
+        MemoryLocation::VaultSubdir
+    ) {
+        return collections::resolve_read_collection_filter(db, None).map_err(map_collection_error);
     }
 
     let memory_root = turn_writer::resolve_memory_root(db).map_err(map_turn_write_error)?;

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -20,12 +20,13 @@ use serde::Deserialize;
 use crate::commands::{get, put};
 
 use crate::core::collections::{self, OpKind, SlugResolution};
-use crate::core::conversation::{extractor::SlmClient, slm::LazySlmRunner};
+use crate::core::conversation::{extractor::SlmClient, slm::LazySlmRunner, turn_writer};
 #[cfg(test)]
 use crate::core::graph::{GraphError, TemporalFilter};
 use crate::core::vault_sync;
 use crate::mcp::errors::{
-    ambiguous_slug_error, map_collection_error, map_config_error, map_db_error, page_not_found,
+    ambiguous_slug_error, map_collection_error, map_config_error, map_db_error,
+    map_turn_write_error, page_not_found,
 };
 #[cfg(test)]
 use crate::mcp::errors::{map_anyhow_error, map_graph_error, serialize_response};
@@ -68,11 +69,33 @@ pub(crate) fn resolve_slug_for_mcp(
     }
 }
 
-pub(crate) fn resolve_read_collection_filter_for_mcp(
+pub(crate) fn resolve_memory_collection_filter_for_mcp(
     db: &Connection,
     collection_name: Option<&str>,
 ) -> Result<Option<collections::Collection>, rmcp::Error> {
-    collections::resolve_read_collection_filter(db, collection_name).map_err(map_collection_error)
+    if collection_name.is_some() {
+        return collections::resolve_read_collection_filter(db, collection_name)
+            .map_err(map_collection_error);
+    }
+
+    if let Some(collection) =
+        collections::get_single_active_collection(db).map_err(map_collection_error)?
+    {
+        return Ok(Some(collection));
+    }
+
+    let memory_root = turn_writer::resolve_memory_root(db).map_err(map_turn_write_error)?;
+    collections::get_by_name(db, &memory_root.collection_name)
+        .map_err(map_collection_error)?
+        .ok_or_else(|| {
+            map_turn_write_error(turn_writer::TurnWriteError::Config {
+                message: format!(
+                    "memory root collection `{}` could not be resolved",
+                    memory_root.collection_name
+                ),
+            })
+        })
+        .map(Some)
 }
 
 pub(crate) fn page_id_for_resolved(

--- a/src/mcp/tools/pages.rs
+++ b/src/mcp/tools/pages.rs
@@ -21,8 +21,8 @@ use crate::mcp::errors::{
 };
 use crate::mcp::server::{
     canonical_slug, canonicalize_page_for_mcp, page_id_for_resolved,
-    resolve_read_collection_filter_for_mcp, resolve_slug_for_mcp, MemoryGetInput, MemoryListInput,
-    MemoryPutInput, MemoryRawInput, QuaidServer,
+    resolve_memory_collection_filter_for_mcp, resolve_slug_for_mcp, MemoryGetInput,
+    MemoryListInput, MemoryPutInput, MemoryRawInput, QuaidServer,
 };
 use crate::mcp::validation::{validate_content, validate_slug, MAX_LIMIT, MAX_RAW_DATA_LEN};
 
@@ -186,7 +186,7 @@ impl QuaidServer {
             .map_err(map_namespace_error)?;
         let namespace_filter = input.namespace.as_deref().or(Some(""));
         let collection_filter =
-            resolve_read_collection_filter_for_mcp(&db, input.collection.as_deref())?;
+            resolve_memory_collection_filter_for_mcp(&db, input.collection.as_deref())?;
 
         let limit = input.limit.unwrap_or(50).min(MAX_LIMIT);
         let mut sql = String::from(

--- a/src/mcp/tools/search.rs
+++ b/src/mcp/tools/search.rs
@@ -9,14 +9,14 @@
 use rmcp::model::{CallToolResult, Content};
 use rmcp::tool;
 
-use crate::core::fts::{sanitize_fts_query, search_fts, FtsQuery};
+use crate::core::fts::{expand_numeric_fts_query, sanitize_fts_query, search_fts, FtsQuery};
 use crate::core::gaps;
 use crate::core::namespace;
 use crate::core::progressive::progressive_retrieve_with_namespace;
 use crate::core::search::{hybrid_search, HybridSearch};
 use crate::mcp::errors::{map_namespace_error, map_search_error, map_serialize_error};
 use crate::mcp::server::{
-    resolve_read_collection_filter_for_mcp, MemoryQueryInput, MemorySearchInput, QuaidServer,
+    resolve_memory_collection_filter_for_mcp, MemoryQueryInput, MemorySearchInput, QuaidServer,
 };
 use crate::mcp::validation::MAX_LIMIT;
 
@@ -37,7 +37,7 @@ impl QuaidServer {
             .map_err(map_namespace_error)?;
         let namespace_filter = input.namespace.as_deref().or(Some(""));
         let collection_filter =
-            resolve_read_collection_filter_for_mcp(&db, input.collection.as_deref())?;
+            resolve_memory_collection_filter_for_mcp(&db, input.collection.as_deref())?;
         let include_superseded = input.include_superseded.unwrap_or(false);
 
         let limit = input.limit.unwrap_or(10).min(MAX_LIMIT) as usize;
@@ -113,11 +113,11 @@ impl QuaidServer {
             .map_err(map_namespace_error)?;
         let namespace_filter = input.namespace.as_deref().or(Some(""));
         let collection_filter =
-            resolve_read_collection_filter_for_mcp(&db, input.collection.as_deref())?;
+            resolve_memory_collection_filter_for_mcp(&db, input.collection.as_deref())?;
         let include_superseded = input.include_superseded.unwrap_or(false);
 
         let limit = input.limit.unwrap_or(50).min(MAX_LIMIT) as usize;
-        let safe_query = sanitize_fts_query(&input.query);
+        let safe_query = expand_numeric_fts_query(&sanitize_fts_query(&input.query));
         let results = search_fts(
             &db,
             FtsQuery {

--- a/tests/mcp_server_query_search_list.rs
+++ b/tests/mcp_server_query_search_list.rs
@@ -18,8 +18,10 @@ use harness::{
     create_page, create_page_in_collection, extract_text, insert_collection, open_test_db,
     set_collection_state,
 };
+use quaid::core::conversation::turn_writer;
 use quaid::mcp::server::{
-    MemoryLinkInput, MemoryListInput, MemoryQueryInput, MemorySearchInput, QuaidServer,
+    MemoryLinkInput, MemoryListInput, MemoryPutInput, MemoryQueryInput, MemorySearchInput,
+    QuaidServer,
 };
 use rmcp::model::ErrorCode;
 
@@ -185,6 +187,51 @@ fn memory_query_defaults_to_write_target_when_multiple_collections_are_active() 
 }
 
 #[test]
+fn memory_query_defaults_to_memory_collection_when_dedicated_memory_location_is_enabled() {
+    let (_dir, conn) = open_test_db();
+    conn.execute(
+        "UPDATE config SET value = 'dedicated-collection' WHERE key = 'memory.location'",
+        [],
+    )
+    .unwrap();
+    let memory_root = turn_writer::resolve_memory_root(&conn).unwrap();
+    conn.execute(
+        "UPDATE collections SET needs_full_sync = 0 WHERE id = ?1",
+        [memory_root.collection_id],
+    )
+    .unwrap();
+    let server = QuaidServer::new(conn);
+    server
+        .memory_put(MemoryPutInput {
+            slug: format!("{}::notes/memory-target", memory_root.collection_name),
+            content: "---\ntitle: Memory Target\ntype: note\n---\nshared semantic marker\n"
+                .to_string(),
+            expected_version: None,
+            namespace: Some("q0000".to_string()),
+        })
+        .unwrap();
+
+    let result = server
+        .memory_query(MemoryQueryInput {
+            query: "shared semantic marker".to_string(),
+            collection: None,
+            namespace: Some("q0000".to_string()),
+            wing: None,
+            limit: None,
+            depth: None,
+            include_superseded: None,
+        })
+        .unwrap();
+
+    let rows: Vec<serde_json::Value> = serde_json::from_str(&extract_text(&result)).unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0]["slug"],
+        format!("{}::notes/memory-target", memory_root.collection_name)
+    );
+}
+
+#[test]
 fn memory_search_returns_matching_pages() {
     let (_dir, conn) = open_test_db();
     let server = QuaidServer::new(conn);
@@ -207,6 +254,49 @@ fn memory_search_returns_matching_pages() {
 
     let rows: Vec<serde_json::Value> = serde_json::from_str(&extract_text(&result)).unwrap();
     assert_eq!(rows[0]["slug"], "default::companies/acme");
+}
+
+#[test]
+fn memory_search_defaults_to_memory_collection_when_dedicated_memory_location_is_enabled() {
+    let (_dir, conn) = open_test_db();
+    conn.execute(
+        "UPDATE config SET value = 'dedicated-collection' WHERE key = 'memory.location'",
+        [],
+    )
+    .unwrap();
+    let memory_root = turn_writer::resolve_memory_root(&conn).unwrap();
+    conn.execute(
+        "UPDATE collections SET needs_full_sync = 0 WHERE id = ?1",
+        [memory_root.collection_id],
+    )
+    .unwrap();
+    let server = QuaidServer::new(conn);
+    server
+        .memory_put(MemoryPutInput {
+            slug: format!("{}::notes/memory-hit", memory_root.collection_name),
+            content: "---\ntitle: Memory Hit\ntype: note\n---\nshared needle\n".to_string(),
+            expected_version: None,
+            namespace: Some("q0000".to_string()),
+        })
+        .unwrap();
+
+    let result = server
+        .memory_search(MemorySearchInput {
+            query: "shared".to_string(),
+            collection: None,
+            namespace: Some("q0000".to_string()),
+            wing: None,
+            limit: None,
+            include_superseded: None,
+        })
+        .unwrap();
+
+    let rows: Vec<serde_json::Value> = serde_json::from_str(&extract_text(&result)).unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0]["slug"],
+        format!("{}::notes/memory-hit", memory_root.collection_name)
+    );
 }
 
 #[test]
@@ -392,6 +482,49 @@ fn memory_list_defaults_to_write_target_when_multiple_collections_are_active() {
     let rows: Vec<serde_json::Value> = serde_json::from_str(&extract_text(&result)).unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0]["slug"], "default::notes/default-target");
+}
+
+#[test]
+fn memory_list_defaults_to_memory_collection_when_dedicated_memory_location_is_enabled() {
+    let (_dir, conn) = open_test_db();
+    conn.execute(
+        "UPDATE config SET value = 'dedicated-collection' WHERE key = 'memory.location'",
+        [],
+    )
+    .unwrap();
+    let memory_root = turn_writer::resolve_memory_root(&conn).unwrap();
+    conn.execute(
+        "UPDATE collections SET needs_full_sync = 0 WHERE id = ?1",
+        [memory_root.collection_id],
+    )
+    .unwrap();
+    let server = QuaidServer::new(conn);
+    server
+        .memory_put(MemoryPutInput {
+            slug: format!("{}::notes/memory-list", memory_root.collection_name),
+            content: "---\ntitle: Memory List\ntype: note\n---\nlisted from memory collection\n"
+                .to_string(),
+            expected_version: None,
+            namespace: Some("q0000".to_string()),
+        })
+        .unwrap();
+
+    let result = server
+        .memory_list(MemoryListInput {
+            collection: None,
+            namespace: Some("q0000".to_string()),
+            wing: Some("notes".to_string()),
+            page_type: Some("note".to_string()),
+            limit: None,
+        })
+        .unwrap();
+
+    let rows: Vec<serde_json::Value> = serde_json::from_str(&extract_text(&result)).unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0]["slug"],
+        format!("{}::notes/memory-list", memory_root.collection_name)
+    );
 }
 
 #[test]

--- a/tests/search_hardening.rs
+++ b/tests/search_hardening.rs
@@ -443,3 +443,74 @@ fn memory_search_compound_query_returns_valid_json_array() {
         "memory_search must always emit a JSON array (may be empty for compound-term AND miss)"
     );
 }
+
+#[test]
+fn search_numeric_query_matches_abbreviated_number_forms() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let db_path = test_db_path(&dir, "search-numeric-alias.db");
+    let conn = open_test_db(&db_path);
+
+    insert_page_with_namespace(
+        &conn,
+        "",
+        "journal/2026-04-15",
+        "journal",
+        "Journal 2026-04-15",
+        "BTC update",
+        "BTC clearing $75K in April.",
+    );
+    drop(conn);
+
+    let output = run_quaid(&db_path, &["--json", "search", "75000 April"]);
+
+    assert!(
+        output.status.success(),
+        "search should exit cleanly for numeric alias queries: {output:?}"
+    );
+
+    let parsed = parse_stdout_json(&output);
+    let results = parsed.as_array().expect("output must be a JSON array");
+    assert!(
+        result_slugs(results).contains("default::journal/2026-04-15"),
+        "numeric alias expansion should match $75K content: {results:?}"
+    );
+}
+
+#[test]
+fn memory_search_numeric_query_matches_abbreviated_number_forms() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let db_path = test_db_path(&dir, "memory-search-numeric-alias.db");
+    let conn = open_test_db(&db_path);
+
+    insert_page_with_namespace(
+        &conn,
+        "",
+        "journal/2026-04-15",
+        "journal",
+        "Journal 2026-04-15",
+        "BTC update",
+        "BTC clearing $75K in April.",
+    );
+    drop(conn);
+
+    let output = run_quaid(
+        &db_path,
+        &[
+            "call",
+            "memory_search",
+            r#"{"query":"75000 April","limit":10}"#,
+        ],
+    );
+
+    assert!(
+        output.status.success(),
+        "memory_search should exit cleanly for numeric alias queries: {output:?}"
+    );
+
+    let parsed = parse_stdout_json(&output);
+    let results = parsed.as_array().expect("output must be a JSON array");
+    assert!(
+        result_slugs(results).contains("default::journal/2026-04-15"),
+        "memory_search numeric alias expansion should match $75K content: {results:?}"
+    );
+}

--- a/tests/search_hardening.rs
+++ b/tests/search_hardening.rs
@@ -514,3 +514,74 @@ fn memory_search_numeric_query_matches_abbreviated_number_forms() {
         "memory_search numeric alias expansion should match $75K content: {results:?}"
     );
 }
+
+#[test]
+fn search_numeric_query_matches_grouped_number_forms() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let db_path = test_db_path(&dir, "search-numeric-grouped.db");
+    let conn = open_test_db(&db_path);
+
+    insert_page_with_namespace(
+        &conn,
+        "",
+        "journal/2026-04-16",
+        "journal",
+        "Journal 2026-04-16",
+        "Revenue update",
+        "Revenue reached 75,000 in April.",
+    );
+    drop(conn);
+
+    let output = run_quaid(&db_path, &["--json", "search", "75000 April"]);
+
+    assert!(
+        output.status.success(),
+        "search should exit cleanly for grouped numeric queries: {output:?}"
+    );
+
+    let parsed = parse_stdout_json(&output);
+    let results = parsed.as_array().expect("output must be a JSON array");
+    assert!(
+        result_slugs(results).contains("default::journal/2026-04-16"),
+        "numeric alias expansion should match 75,000 content: {results:?}"
+    );
+}
+
+#[test]
+fn memory_search_numeric_query_matches_grouped_number_forms() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let db_path = test_db_path(&dir, "memory-search-numeric-grouped.db");
+    let conn = open_test_db(&db_path);
+
+    insert_page_with_namespace(
+        &conn,
+        "",
+        "journal/2026-04-16",
+        "journal",
+        "Journal 2026-04-16",
+        "Revenue update",
+        "Revenue reached 75,000 in April.",
+    );
+    drop(conn);
+
+    let output = run_quaid(
+        &db_path,
+        &[
+            "call",
+            "memory_search",
+            r#"{"query":"75000 April","limit":10}"#,
+        ],
+    );
+
+    assert!(
+        output.status.success(),
+        "memory_search should exit cleanly for grouped numeric queries: {output:?}"
+    );
+
+    let parsed = parse_stdout_json(&output);
+    let results = parsed.as_array().expect("output must be a JSON array");
+    assert!(
+        result_slugs(results).contains("default::journal/2026-04-16"),
+        "memory_search numeric alias expansion should match 75,000 content: {results:?}"
+    );
+}


### PR DESCRIPTION
## Summary\n- route omitted MCP memory read filters through the conversation memory collection when dedicated memory storage is enabled\n- expand sanitized numeric FTS queries so 75000 can match aliases like 75K and 75 000 in both CLI search and memory_search\n- add regression coverage for dedicated memory collection reads and numeric alias search\n\n## Validation\n- cargo test --test mcp_server_query_search_list --test search_hardening --quiet\n- cargo build --quiet\n- cargo clippy --all-targets --locked -- -D warnings\n- cargo test --quiet -j 1 *(repo has unrelated existing failures in model_lifecycle and vault_sync)*\n\nFixes #212\nFixes #196