### PR TITLE
ci: wire the dormant quality gates (review area 9)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git -C /Users/macro/repos/quaid log --oneline -25)",
+      "Bash(gh issue *)",
+      "Bash(gh pr *)"
+    ]
+  }
+}

--- a/.github/workflows/beir-regression.yml
+++ b/.github/workflows/beir-regression.yml
@@ -20,10 +20,13 @@ jobs:
   beir:
     name: BEIR nDCG@10 Regression
     runs-on: ubuntu-latest
-    # Advisory only — failure/skip here must never block release-sync PRs.
-    # Dataset downloads from public.ukp.informatik.tu-darmstadt.de can stall;
-    # continue-on-error ensures a job failure surfaces as "neutral" not "failure".
-    continue-on-error: true
+    # Harness failures (compile errors, panics, regressions vs baseline) are
+    # blocking. Dataset downloads from public.ukp.informatik.tu-darmstadt.de can
+    # stall, so only the download step is resilient (bounded timeout +
+    # continue-on-error); evaluation is skipped when the download fails.
+    # NOTE: nq/fiqa baselines in benchmarks/baselines/beir.json are still
+    # pending recording (ndcg_at_10: null), so the eval tests early-return
+    # without asserting until real baselines are committed.
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,9 @@ jobs:
         run: |
           cargo test --test corpus_reality --test concurrency_stress --test embedding_migration --verbose
 
+      - name: Free debug artifacts before release latency build
+        run: rm -rf target/debug
+
       - name: Run latency gate (release build)
         env:
           # Hosted runners are slower and noisier than representative local

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,10 @@ on:
       - "Cargo.lock"
       - "Cross.toml"
       - "scripts/**"
+      - ".githooks/**"
       - ".github/workflows/ci.yml"
+      - ".github/workflows/release.yml"
+      - ".github/release-assets.txt"
   pull_request:
     branches: ["main"]
     paths:
@@ -24,7 +27,10 @@ on:
       - "Cargo.lock"
       - "Cross.toml"
       - "scripts/**"
+      - ".githooks/**"
       - ".github/workflows/ci.yml"
+      - ".github/workflows/release.yml"
+      - ".github/release-assets.txt"
 
 env:
   CARGO_TERM_COLOR: always
@@ -188,9 +194,43 @@ jobs:
           key: ${{ runner.os }}-cargo-bench-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
 
-      - name: Run offline benchmarks
+      - name: Run offline functional benchmarks
         run: |
           cargo test --test corpus_reality --test concurrency_stress --test embedding_migration --verbose
+
+      - name: Run latency gate (release build)
+        env:
+          # Hosted runners are slower and noisier than representative local
+          # hardware; relax the default 250ms p95 budget to a runner-safe bound.
+          QUAID_LATENCY_P95_MS: "500"
+        run: |
+          cargo test --release --test corpus_reality latency_100_queries_p95 -- --ignored --nocapture
+
+  mini-bench:
+    name: Mini-Bench Retrieval Gate
+    runs-on: ubuntu-latest
+    needs: check
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-minibench-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Build release binary
+        run: cargo build --release
+
+      - name: Run mini-bench retrieval gate (fails below 8/20)
+        run: ./scripts/mini-bench.sh --no-build
 
   coverage:
     name: Coverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,10 +32,87 @@ jobs:
           fi
           echo "Version check passed: $CARGO_VERSION"
 
+      - name: Verify CHANGELOG.md has an entry for this version
+        run: |
+          TAG_VERSION=${GITHUB_REF_NAME#v}
+          ESCAPED_VERSION=$(printf '%s' "$TAG_VERSION" | sed 's/\./\\./g')
+          if ! grep -Eq "^## v${ESCAPED_VERSION}( |$)" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md is missing a heading for v${TAG_VERSION} (expected a line starting with '## v${TAG_VERSION}')"
+            exit 1
+          fi
+          echo "CHANGELOG check passed: found heading for v${TAG_VERSION}"
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Run tests (default / airgapped channel)
+        run: cargo nextest run --locked
+
+      - name: Free target space before online channel tests
+        run: cargo clean
+
+      - name: Run tests (online channel)
+        run: cargo nextest run --locked -j 1 --no-default-features --features bundled,online-model,test-harness
+        env:
+          QUAID_FORCE_HASH_SHIM: "1"
+
+      - name: Run installer profile tests
+        run: sh tests/install_profile.sh
+
+      - name: Run release asset parity tests
+        run: sh tests/release_asset_parity.sh
+
+      - name: Run installer release seam tests
+        run: sh tests/install_release_seam.sh
+
+  mini-bench:
+    name: Mini-Bench Retrieval Gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-minibench-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Build release binary
+        run: cargo build --release
+
+      - name: Run mini-bench retrieval gate (fails below 8/20)
+        run: ./scripts/mini-bench.sh --no-build
+
   build:
     name: Build ${{ matrix.channel }} ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
-    needs: verify-version
+    needs: [verify-version, test, mini-bench]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    needs: verify-version
     steps:
       - uses: actions/checkout@v4
 
@@ -87,6 +88,7 @@ jobs:
   mini-bench:
     name: Mini-Bench Retrieval Gate
     runs-on: ubuntu-latest
+    needs: verify-version
     steps:
       - uses: actions/checkout@v4
 

--- a/tests/corpus_reality.rs
+++ b/tests/corpus_reality.rs
@@ -16,7 +16,8 @@
 //!   4. Duplicate ingest       — no duplicate pages after re-import
 //!   5. Conflicting ingest     — contradiction detected in check
 //!   6. Idempotent round-trip  — export → reimport → export → semantic diff = 0
-//!   7. Latency gate           — p95 < 250ms over 100 queries (release build, #[ignore])
+//!   7. Latency gate           — p95 < budget over 100 queries (release build, #[ignore];
+//!      budget defaults to 250ms, override via QUAID_LATENCY_P95_MS)
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -413,11 +414,27 @@ fn collect_recursive(root: &Path, dir: &Path, pages: &mut Vec<(String, String)>)
     }
 }
 
-// ── 7. Latency gate — p95 < 250ms (release build only) ───────────────────────
+// ── 7. Latency gate — p95 < budget (release build only) ──────────────────────
+//
+// The p95 budget defaults to 250ms (representative local hardware) and can be
+// relaxed for slower/noisier environments via QUAID_LATENCY_P95_MS (CI uses
+// 500ms on hosted runners).
+
+const DEFAULT_LATENCY_P95_BUDGET_MS: f64 = 250.0;
+
+fn latency_p95_budget_ms() -> f64 {
+    match std::env::var("QUAID_LATENCY_P95_MS") {
+        Ok(raw) => raw.trim().parse().unwrap_or_else(|_| {
+            panic!("QUAID_LATENCY_P95_MS must be a number of milliseconds, got {raw:?}")
+        }),
+        Err(_) => DEFAULT_LATENCY_P95_BUDGET_MS,
+    }
+}
 
 #[test]
 #[ignore = "latency gate requires release build — run: cargo test --release --test corpus_reality latency -- --ignored"]
-fn latency_100_queries_p95_under_250ms() {
+fn latency_100_queries_p95_under_budget() {
+    let budget_ms = latency_p95_budget_ms();
     let conn = open_test_db();
     ingest_markdown_tree(&conn, &fixtures_dir());
     embed::run(&conn, None, true, false).expect("embed pages");
@@ -464,8 +481,8 @@ fn latency_100_queries_p95_under_250ms() {
     eprintln!("  p99: {p99:.1}ms");
 
     assert!(
-        p95 < 250.0,
-        "p95 latency {p95:.1}ms exceeds 250ms gate — run on release build for accurate measurement"
+        p95 < budget_ms,
+        "p95 latency {p95:.1}ms exceeds {budget_ms:.0}ms gate — run on release build for accurate measurement"
     );
 }
 


### PR DESCRIPTION
Implements **Area 9 — CI, benchmark & release gating** from the full codebase review (`docs/fable-review.md` on branch `code-review-2`), plus the CHANGELOG gate from Area 22.

## Why
No quality or performance gate in this repo has ever fired: release.yml publishes binaries without running a test, the mini-bench harness that hard-fails below 8/20 is wired to no workflow, all latency gates are `#[ignore]`d with no caller, and BEIR baselines have been `null` since creation. This is how the #220 DAB regression shipped in v0.22.6.

## Changes
- **ci.yml**: new blocking `Mini-Bench Retrieval Gate` job (`cargo build --release` + `scripts/mini-bench.sh --no-build`); path filters widened with `.githooks/**`, `.github/workflows/release.yml`, `.github/release-assets.txt`; Offline Benchmarks job now actually runs the release-mode latency gate (`--ignored`, `QUAID_LATENCY_P95_MS=500`).
- **release.yml**: new `test` job mirroring ci.yml's nextest steps (both channels + installer/release-seam shell tests) and a `mini-bench` job; `build` now `needs: [verify-version, test, mini-bench]`; `verify-version` additionally requires a `## v<TAG_VERSION>` heading in CHANGELOG.md.
- **beir-regression.yml**: job-level `continue-on-error` removed so harness failures surface (download-step resilience kept; baselines still pending recording — the eval still early-returns until real `ndcg_at_10` values are committed).
- **tests/corpus_reality.rs**: p95 latency budget is now env-tunable via `QUAID_LATENCY_P95_MS` (default 250); test renamed `latency_100_queries_p95_under_budget`.

## Validation
- All three workflows strict-YAML-parsed; job graphs verified.
- `cargo check --tests`, `cargo fmt --check`, `cargo clippy --test corpus_reality -- -D warnings` all clean.
- CHANGELOG grep pattern negative/positive tested against real headings.
- The latency test could not be executed locally (pre-existing `gemm-f16` fullfp16 codegen failure on this aarch64 devcontainer) — its first real execution is this PR's CI run; watch the Offline Benchmarks job.

## Notes for reviewers
- The CHANGELOG tag gate means the next tag requires a `## v0.22.x` heading — the companion docs-truth PR backfills v0.22.4–v0.22.6.
- Mini-bench jobs build with default features, so build.rs downloads BGE-small on cache-cold runners — same network dependency as existing default-feature CI jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)