### PR TITLE
test: serialize env-mutating inline tests (fixes Coverage CI flake)

### DIFF
--- a/src/commands/model.rs
+++ b/src/commands/model.rs
@@ -444,6 +444,7 @@ mod tests {
         .expect("verified status should inspect local cache only");
     }
 
+    #[serial_test::serial]
     #[test]
     fn clean_force_removes_alias_cache_from_temp_root() {
         let cache_root = tempfile::TempDir::new().expect("cache root");

--- a/src/commands/put.rs
+++ b/src/commands/put.rs
@@ -2594,6 +2594,7 @@ mod tests {
     }
 
     #[cfg(all(unix, target_os = "linux"))]
+    #[serial_test::serial]
     #[test]
     fn cli_put_proxies_through_live_serve_socket() {
         let _env_lock = env_mutation_lock()
@@ -2659,6 +2660,7 @@ mod tests {
     }
 
     #[cfg(all(unix, target_os = "linux"))]
+    #[serial_test::serial]
     #[test]
     fn cli_put_refuses_same_uid_socket_spoof_with_pid_mismatch() {
         let _env_lock = env_mutation_lock()

--- a/src/core/conversation/model_lifecycle.rs
+++ b/src/core/conversation/model_lifecycle.rs
@@ -2739,6 +2739,7 @@ mod tests {
         assert_eq!(sanitize_cache_key("phi-3.5-mini"), "phi-3.5-mini");
     }
 
+    #[serial_test::serial]
     #[test]
     fn inspect_model_caches_reports_missing_alias_and_temporary_entries() {
         let cache_root = tempfile::TempDir::new().expect("cache root");
@@ -2760,6 +2761,7 @@ mod tests {
         }));
     }
 
+    #[serial_test::serial]
     #[test]
     fn trusted_source_pin_cache_loads_status_and_root_inspection() {
         let cache_root = tempfile::TempDir::new().expect("cache root");
@@ -2875,6 +2877,7 @@ mod tests {
         );
     }
 
+    #[serial_test::serial]
     #[test]
     fn utility_helpers_cover_edge_paths() {
         assert!(resolve_model_alias("   ").is_err());
@@ -2931,6 +2934,7 @@ mod tests {
         }
     }
 
+    #[serial_test::serial]
     #[test]
     fn lifecycle_edge_paths_cover_validation_and_cleanup_branches() {
         let alias = resolve_model_alias("org/model").expect("resolve raw alias");
@@ -3045,6 +3049,7 @@ mod tests {
         assert!(pin_error.to_string().contains("git blob"));
     }
 
+    #[serial_test::serial]
     #[test]
     fn remove_model_cache_entries_removes_only_allowed_paths() {
         let cache_root = tempfile::TempDir::new().expect("cache root");

--- a/src/core/conversation/slm.rs
+++ b/src/core/conversation/slm.rs
@@ -972,6 +972,7 @@ mod tests {
         assert!(matches!(error, SlmError::Parse { .. }));
     }
 
+    #[serial_test::serial]
     #[test]
     fn infer_returns_typed_panic_error() {
         let temp = tempfile::tempdir().unwrap();
@@ -987,6 +988,7 @@ mod tests {
         assert!(error.to_string().contains("boom"));
     }
 
+    #[serial_test::serial]
     #[test]
     fn lazy_runner_reuses_loaded_model_after_cache_is_removed() {
         let temp = tempfile::tempdir().unwrap();
@@ -1006,6 +1008,7 @@ mod tests {
         assert!(!runtime.is_runtime_disabled());
     }
 
+    #[serial_test::serial]
     #[test]
     fn lazy_runner_runtime_disables_after_cache_load_failure() {
         let temp = tempfile::tempdir().unwrap();

--- a/src/core/inference.rs
+++ b/src/core/inference.rs
@@ -1800,6 +1800,7 @@ mod tests {
         ));
     }
 
+    #[serial_test::serial]
     #[test]
     fn embed_returns_normalized_vector_of_expected_length() {
         // Force hash shim so this test never triggers a real HuggingFace
@@ -1828,6 +1829,7 @@ mod tests {
         assert_eq!(embedding.len(), 1024);
     }
 
+    #[serial_test::serial]
     #[test]
     fn embed_recovers_from_poisoned_model_runtime_mutex() {
         // Locks env_mutation_lock so we can safely toggle the hash-shim env
@@ -2265,6 +2267,7 @@ mod tests {
     }
 
     #[cfg(feature = "online-model")]
+    #[serial_test::serial]
     #[test]
     fn hydrate_model_config_can_use_mock_huggingface_downloads() {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");

--- a/src/core/raw_imports.rs
+++ b/src/core/raw_imports.rs
@@ -371,6 +371,7 @@ mod tests {
         assert_eq!(inactive_count, 1);
     }
 
+    #[serial_test::serial]
     #[test]
     fn inline_gc_keeps_only_ten_inactive_rows_by_default() {
         let _env_guard = env_mutation_lock().lock().unwrap();
@@ -404,6 +405,7 @@ mod tests {
         assert_eq!(active_raw_import_count(&conn, page_id).unwrap(), 1);
     }
 
+    #[serial_test::serial]
     #[test]
     fn inline_gc_prunes_ttl_expired_inactive_rows() {
         let _env_guard = env_mutation_lock().lock().unwrap();
@@ -438,6 +440,7 @@ mod tests {
         assert_eq!(inactive_count, 1);
     }
 
+    #[serial_test::serial]
     #[test]
     fn keep_all_disables_inline_gc() {
         let _env_guard = env_mutation_lock().lock().unwrap();
@@ -493,6 +496,7 @@ mod tests {
         assert!(error.contains("0 active raw_imports rows"));
     }
 
+    #[serial_test::serial]
     #[test]
     fn expired_inactive_rows_are_swept_even_when_page_is_idle() {
         let conn = open_test_db();
@@ -552,6 +556,7 @@ mod tests {
         assert_eq!(active_raw_import_count(&conn, page_id).unwrap(), 1);
     }
 
+    #[serial_test::serial]
     #[test]
     fn ttl_sweep_respects_keep_all_override() {
         let conn = open_test_db();

--- a/src/core/reconciler.rs
+++ b/src/core/reconciler.rs
@@ -6227,6 +6227,7 @@ mod tests {
         assert!(err.contains("load_frontmatter_map"));
     }
 
+    #[serial_test::serial]
     #[test]
     fn default_restore_stability_max_iters_uses_env_var_when_set() {
         let _guard = env_mutation_lock().lock().unwrap();
@@ -6235,6 +6236,7 @@ mod tests {
         assert_eq!(value, 12);
     }
 
+    #[serial_test::serial]
     #[test]
     fn default_restore_stability_max_iters_falls_back_to_default_when_var_is_zero() {
         let _guard = env_mutation_lock().lock().unwrap();
@@ -6243,6 +6245,7 @@ mod tests {
         assert_eq!(value, DEFAULT_RESTORE_STABILITY_MAX_ITERS);
     }
 
+    #[serial_test::serial]
     #[test]
     fn default_restore_stability_max_iters_guard_restores_previous_value() {
         let _guard = env_mutation_lock().lock().unwrap();

--- a/src/core/vault_sync/mod.rs
+++ b/src/core/vault_sync/mod.rs
@@ -3518,6 +3518,7 @@ mod tests {
     }
 
     #[cfg(all(unix, target_os = "linux"))]
+    #[serial_test::serial]
     #[test]
     fn publish_ipc_socket_unlinks_stale_socket_before_bind() {
         let _env_lock = env_mutation_lock().lock().unwrap();
@@ -3545,6 +3546,7 @@ mod tests {
     }
 
     #[cfg(all(unix, target_os = "linux"))]
+    #[serial_test::serial]
     #[test]
     fn audit_bound_ipc_socket_rejects_mode_regression() {
         let _env_lock = env_mutation_lock().lock().unwrap();
@@ -3611,6 +3613,7 @@ mod tests {
         assert!(error.to_string().contains("IpcPeerAuthFailedError"));
     }
 
+    #[serial_test::serial]
     #[test]
     fn configured_embedding_concurrency_uses_positive_env_override_when_present() {
         let _lock = env_mutation_lock().lock().unwrap();
@@ -3620,6 +3623,7 @@ mod tests {
         assert_eq!(configured_embedding_concurrency(), 3);
     }
 
+    #[serial_test::serial]
     #[test]
     fn configured_embedding_concurrency_falls_back_for_zero_or_invalid_values() {
         let _lock = env_mutation_lock().lock().unwrap();
@@ -5965,6 +5969,7 @@ mod tests {
         drop(runtime);
     }
 
+    #[serial_test::serial]
     #[test]
     fn full_hash_audit_helpers_respect_env_override_and_floor_at_zero() {
         let _guard = env_mutation_lock().lock().unwrap();
@@ -6007,6 +6012,7 @@ mod tests {
         }
     }
 
+    #[serial_test::serial]
     #[test]
     fn scheduled_full_hash_audit_budget_spreads_work_across_audit_days() {
         let _guard = env_mutation_lock().lock().unwrap();


### PR DESCRIPTION
The Coverage CI job fails on every current PR (including docs-only #222) with a panic in `model_lifecycle::tests::inspect_model_caches_reports_missing_alias_and_temporary_entries`. Root cause: ~28 inline tests mutate process-global env vars (e.g. `QUAID_MODEL_CACHE_DIR`) through `EnvVarGuard`/`EnvGuard`, and the Coverage job runs `cargo test --tests` under the **threaded** libtest harness where they race. The `Test` job uses nextest (process-per-test), which masks the race — which is why only Coverage reddens.

## Fix
Annotate every env-mutating inline test with keyless `#[serial_test::serial]`, following the existing convention already used by 21 tests in `vault_sync/mod.rs` (keyless = one shared global lock, so all env mutators serialize across modules). 28 tests across 8 files; coverage of the set was verified programmatically by mapping every `EnvVarGuard::set/unset/clear` call site to its enclosing test fn. No raw `set_var`/`remove_var` mutators exist outside guard impls; `tests/` integration files are process-isolated by nextest and untouched.

## Validation
- `cargo check --lib` clean; `cargo fmt --check` clean on touched files.
- `cargo test --lib -- --test-threads=16` ×3 post-fix: 928 passed / 0 failed each run.
- The race is scheduling-dependent (one pre-fix local attempt passed); the fix removes the interleaving by construction rather than relying on reproduction.

Part of the fable-review implementation (unblocks clean CI signal for the PR train; see `docs/fable-review-progress.md` on `code-review-2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)