### PR TITLE
feat(search): hybrid fusion + lexical recall fixes (review areas 1.1-1.3, 3)

### DIFF
--- a/src/core/fts.rs
+++ b/src/core/fts.rs
@@ -2,11 +2,19 @@
 //! query-sanitization and tiered-fallback helpers callers need to drive it
 //! safely from natural-language input. Quoted phrases, boolean operators,
 //! and prefix wildcards in expert (`--raw`) queries pass through unchanged;
-//! everyday callers sanitize first and let the tiered helper widen
-//! precision-first AND queries into OR-fallback for compound terms.
+//! everyday callers (CLI `quaid search`, MCP `memory_search`, and
+//! `hybrid_search`) sanitize first and use the tiered helper, which runs a
+//! precision-first AND pass and blends OR-recall hits below the AND hits to
+//! fill any spare `limit` slots. Numeric tokens are aliased symmetrically in
+//! both passes: `75000` ↔ `75k`/`"75 000"`, `1500000` ↔ `"1 5m"` (the
+//! tokenized form of `$1.5M`), and formatted multi-token numerals
+//! (`75` + `000`, the tokenized form of `$75,000`) fuse back into the
+//! single-token numeral.
 //!
 //! See also: `inference` for the semantic counterpart, and `search` for the
 //! hybrid composer that fuses these results with vector hits.
+
+use std::collections::HashSet;
 
 use rusqlite::Connection;
 
@@ -139,8 +147,10 @@ pub struct FtsQuery<'a> {
 /// function as its precision-first AND pass before widening to OR fallback.
 ///
 /// Default callers are sanitized upstream:
-/// - `src/commands/search.rs` applies `sanitize_fts_query` unless `--raw` is set.
-/// - `src/mcp/server.rs` (`memory_search`) always sanitizes.
+/// - `src/commands/search.rs` applies `sanitize_fts_query` unless `--raw` is
+///   set, then calls [`search_fts_tiered`].
+/// - `src/mcp/tools/search.rs` (`memory_search`) always sanitizes and calls
+///   [`search_fts_tiered`].
 /// - `hybrid_search` in `src/core/search.rs` sanitizes before calling
 ///   [`search_fts_tiered`].
 pub fn search_fts(conn: &Connection, q: FtsQuery<'_>) -> Result<Vec<SearchResult>, SearchError> {
@@ -174,15 +184,19 @@ pub(crate) fn expand_numeric_fts_query(sanitized: &str) -> String {
     token_queries_with_numeric_aliases(sanitized).join(" AND ")
 }
 
-/// Natural-language FTS5 search with tiered AND→OR fallback for compound-term
+/// Natural-language FTS5 search with tiered AND→OR blending for compound-term
 /// recall.
 ///
-/// Tries an AND query first (highest precision). If AND returns no results and
-/// the sanitized query has more than one token, retries with an explicit OR
-/// chain so documents matching any individual term are surfaced.
+/// Tries an AND query first (highest precision). When the AND pass leaves
+/// spare `limit` slots and the sanitized query has more than one token, an
+/// explicit OR chain runs as a recall pass: its hits are appended below the
+/// AND hits (deduplicated by slug, scored strictly below the weakest AND hit)
+/// until `limit` results are accumulated. When the AND pass is empty, the OR
+/// results are returned as-is with their own BM25 ranking.
 ///
 /// Callers must pass a **sanitized** `q.query` from `sanitize_fts_query`
-/// (crate-internal; CLI consumers route through `src/commands/search.rs`).
+/// (crate-internal; CLI consumers route through `src/commands/search.rs`,
+/// MCP consumers through `memory_search` in `src/mcp/tools/search.rs`).
 /// See [`FtsQuery`] for per-field documentation.
 pub fn search_fts_tiered(
     conn: &Connection,
@@ -215,8 +229,8 @@ fn search_fts_tiered_internal(
     canonical_slug: bool,
 ) -> Result<Vec<SearchResult>, SearchError> {
     let and_query = expand_numeric_fts_query(sanitized_query);
-    // AND pass — highest precision; use this if it returns any results.
-    let and_results = search_fts_internal(
+    // AND pass — highest precision; these hits always rank first.
+    let mut results = search_fts_internal(
         &and_query,
         wing_filter,
         collection_filter,
@@ -226,16 +240,16 @@ fn search_fts_tiered_internal(
         limit,
         canonical_slug,
     )?;
-    if !and_results.is_empty() {
-        return Ok(and_results);
+    if results.len() >= limit {
+        return Ok(results);
     }
 
     let or_query = expand_fts_query_or(sanitized_query);
     if or_query == and_query {
-        return Ok(Vec::new());
+        return Ok(results);
     }
 
-    search_fts_internal(
+    let or_results = search_fts_internal(
         &or_query,
         wing_filter,
         collection_filter,
@@ -244,14 +258,126 @@ fn search_fts_tiered_internal(
         conn,
         limit,
         canonical_slug,
-    )
+    )?;
+    if results.is_empty() {
+        // Pure OR fallback — keep the OR pass's own BM25 ranking and scores.
+        return Ok(or_results);
+    }
+    blend_or_hits_below_and(&mut results, or_results, limit);
+    Ok(results)
+}
+
+/// Append OR-pass hits below the AND-pass hits, deduplicated by slug, until
+/// `limit` results are accumulated.
+///
+/// OR-hit scores are demoted strictly below the weakest AND score while
+/// preserving the OR pass's relative ranking, so score-sorted consumers
+/// (e.g. the hybrid merge in `core::search`) never rank a recall-only OR hit
+/// above a precision AND hit.
+fn blend_or_hits_below_and(
+    and_results: &mut Vec<SearchResult>,
+    or_results: Vec<SearchResult>,
+    limit: usize,
+) {
+    let seen: HashSet<String> = and_results
+        .iter()
+        .map(|result| result.slug.clone())
+        .collect();
+    let and_floor = and_results.last().map_or(0.0, |result| result.score);
+    let step = and_floor.abs().max(1.0) * 1e-6;
+    let mut demoted = and_floor;
+    for mut hit in or_results {
+        if and_results.len() >= limit {
+            break;
+        }
+        if seen.contains(&hit.slug) {
+            continue;
+        }
+        demoted -= step;
+        hit.score = demoted;
+        and_results.push(hit);
+    }
 }
 
 fn token_queries_with_numeric_aliases(sanitized: &str) -> Vec<String> {
-    sanitized
-        .split_whitespace()
-        .map(expand_numeric_token_query)
-        .collect()
+    let tokens: Vec<&str> = sanitized.split_whitespace().collect();
+    let mut queries = Vec::with_capacity(tokens.len());
+    let mut index = 0;
+    while index < tokens.len() {
+        if let Some((fused, consumed)) = fuse_numeric_token_run(&tokens[index..]) {
+            queries.push(expand_numeric_token_query(&fused));
+            index += consumed;
+        } else {
+            queries.push(expand_numeric_token_query(tokens[index]));
+            index += 1;
+        }
+    }
+    queries
+}
+
+/// Detect a run of adjacent tokens that together form one numeral and return
+/// the fused single-token numeral plus the number of tokens consumed.
+///
+/// Two shapes are recognised, both produced by sanitizing formatted numerals:
+/// - grouped numerals: a 1-3 digit lead group followed by one or more 3-digit
+///   groups (`75` + `000` → `75000`, the sanitized form of `$75,000`);
+/// - one-decimal abbreviations: an all-digit integer part followed by a
+///   single digit plus magnitude suffix (`1` + `5M` → `1500000`, the
+///   sanitized form of `$1.5M`).
+///
+/// The fused numeral's aliases (see [`numeric_token_aliases`]) always include
+/// the phrase form of the original run, so fusing never loses the
+/// adjacent-token match the unfused query would have had.
+fn fuse_numeric_token_run(tokens: &[&str]) -> Option<(String, usize)> {
+    let first = *tokens.first()?;
+    if !first.chars().all(|ch| ch.is_ascii_digit()) {
+        return None;
+    }
+
+    // Grouped numeral: 1-3 digit lead group plus 3-digit groups.
+    if (1..=3).contains(&first.len()) {
+        let mut fused = first.to_owned();
+        let mut consumed = 1;
+        for token in &tokens[1..] {
+            if token.len() == 3 && token.chars().all(|ch| ch.is_ascii_digit()) {
+                fused.push_str(token);
+                consumed += 1;
+            } else {
+                break;
+            }
+        }
+        if consumed > 1 {
+            return Some((fused, consumed));
+        }
+    }
+
+    // One-decimal abbreviation: integer part plus a `<digit><suffix>` token.
+    let second = *tokens.get(1)?;
+    let mut chars = second.chars();
+    let frac = chars.next()?;
+    let suffix = chars.next()?;
+    if chars.next().is_some() || !frac.is_ascii_digit() {
+        return None;
+    }
+    let divisor = magnitude_divisor(suffix)?;
+    let int_part = first.parse::<u64>().ok()?;
+    if int_part == 0 {
+        return None;
+    }
+    let frac_part = u64::from(frac as u8 - b'0');
+    let value = int_part
+        .checked_mul(divisor)?
+        .checked_add(frac_part * (divisor / 10))?;
+    Some((value.to_string(), 2))
+}
+
+fn magnitude_divisor(suffix: char) -> Option<u64> {
+    match suffix.to_ascii_lowercase() {
+        'k' => Some(1_000),
+        'm' => Some(1_000_000),
+        'b' => Some(1_000_000_000),
+        _ => None,
+    }
 }
 
 fn expand_numeric_token_query(token: &str) -> String {
@@ -264,6 +390,16 @@ fn expand_numeric_token_query(token: &str) -> String {
 }
 
 fn numeric_token_aliases(token: &str) -> Vec<String> {
+    if let Some(numeral) = abbreviated_token_numeral(token) {
+        // `75k` → add the full numeral and its grouped phrase so the
+        // abbreviated query also matches `75000` and `75,000` content.
+        let mut aliases = vec![token.to_owned(), numeral.clone()];
+        if let Some(grouped) = grouped_numeric_phrase(&numeral) {
+            aliases.push(format!("\"{grouped}\""));
+        }
+        return aliases;
+    }
+
     if !token.chars().all(|ch| ch.is_ascii_digit()) {
         return vec![token.to_owned()];
     }
@@ -272,10 +408,29 @@ fn numeric_token_aliases(token: &str) -> Vec<String> {
     if let Some(grouped) = grouped_numeric_phrase(token) {
         aliases.push(format!("\"{grouped}\""));
     }
-    if let Some(abbreviated) = abbreviated_numeric_alias(token) {
-        aliases.push(abbreviated);
+    for abbreviated in abbreviated_numeric_aliases(token) {
+        // One-decimal forms are two-token phrases ("1 5m") and need quoting.
+        if abbreviated.contains(' ') {
+            aliases.push(format!("\"{abbreviated}\""));
+        } else {
+            aliases.push(abbreviated);
+        }
     }
     aliases
+}
+
+/// Parse an abbreviated-magnitude token (`\d+[kKmMbB]`) into its full
+/// numeral string: `75k`/`75K` → `75000`, `1M` → `1000000`. Returns `None`
+/// for any other shape or on overflow.
+fn abbreviated_token_numeral(token: &str) -> Option<String> {
+    let suffix = token.chars().next_back()?;
+    let divisor = magnitude_divisor(suffix)?;
+    let digits = &token[..token.len() - suffix.len_utf8()];
+    if digits.is_empty() || !digits.chars().all(|ch| ch.is_ascii_digit()) {
+        return None;
+    }
+    let value = digits.parse::<u64>().ok()?.checked_mul(divisor)?;
+    Some(value.to_string())
 }
 
 fn grouped_numeric_phrase(token: &str) -> Option<String> {
@@ -295,18 +450,37 @@ fn grouped_numeric_phrase(token: &str) -> Option<String> {
     Some(groups.join(" "))
 }
 
-fn abbreviated_numeric_alias(token: &str) -> Option<String> {
-    let value = token.parse::<u64>().ok()?;
+/// Abbreviated-magnitude aliases for an all-digit token. Exact multiples
+/// yield single-token forms (`75000` → `75k`); one-decimal values yield the
+/// two-token phrase that formatted content tokenizes to (`1500000` → `1 5m`,
+/// matching `$1.5M`; `75500` → `75 5k`, matching `$75.5K`).
+fn abbreviated_numeric_aliases(token: &str) -> Vec<String> {
+    let Ok(value) = token.parse::<u64>() else {
+        return Vec::new();
+    };
+    let Some(times_ten) = value.checked_mul(10) else {
+        return Vec::new();
+    };
+    let mut aliases = Vec::new();
     for (divisor, suffix) in [
         (1_000_000_000_u64, "b"),
         (1_000_000_u64, "m"),
         (1_000_u64, "k"),
     ] {
-        if value >= divisor && value % divisor == 0 {
-            return Some(format!("{}{suffix}", value / divisor));
+        if value < divisor {
+            continue;
+        }
+        if value % divisor == 0 {
+            aliases.push(format!("{}{suffix}", value / divisor));
+        } else if times_ten % divisor == 0 {
+            aliases.push(format!(
+                "{} {}{suffix}",
+                value / divisor,
+                (value % divisor) / (divisor / 10)
+            ));
         }
     }
-    None
+    aliases
 }
 
 #[expect(
@@ -946,9 +1120,10 @@ mod tests {
         assert_eq!(results[0].slug, "concepts/inference-engine");
     }
 
-    /// Precision-first: when AND finds results, OR fallback must NOT be triggered.
+    /// Precision-first blending: AND hits rank first and OR-recall hits fill
+    /// the remaining limit slots below them, deduplicated by slug.
     #[test]
-    fn search_tiered_returns_and_results_without_or_fallback() {
+    fn search_tiered_blends_or_hits_below_and_results() {
         let conn = open_test_db();
         insert_page(
             &conn,
@@ -975,15 +1150,6 @@ mod tests {
             "Inference in formal logic.",
         );
 
-        let and_results = search_fts(
-            &conn,
-            FtsQuery {
-                query: "neural network inference",
-                limit: 1000,
-                ..Default::default()
-            },
-        )
-        .unwrap();
         let tiered_results = search_fts_tiered(
             &conn,
             FtsQuery {
@@ -994,8 +1160,34 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(tiered_results.len(), and_results.len());
-        assert_eq!(tiered_results[0].slug, "concepts/combined");
+        assert_eq!(
+            tiered_results.len(),
+            3,
+            "OR-recall hits must blend in below the AND hit"
+        );
+        assert_eq!(
+            tiered_results[0].slug, "concepts/combined",
+            "the AND hit must rank first"
+        );
+        assert!(
+            tiered_results[1..]
+                .iter()
+                .all(|result| result.score < tiered_results[0].score),
+            "every blended OR hit must score strictly below the AND hit"
+        );
+
+        // The blend respects the remaining-slot budget.
+        let limited = search_fts_tiered(
+            &conn,
+            FtsQuery {
+                query: "neural network inference",
+                limit: 2,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(limited.len(), 2);
+        assert_eq!(limited[0].slug, "concepts/combined");
     }
 
     /// Single-token query: no OR fallback attempted; empty returns empty.

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -121,10 +121,14 @@ pub fn hybrid_search(
             limit: q.limit,
         },
     )?;
-    let vec_results = if q.canonical {
+    // The vector arm receives the caller's depth like FTS does, floored at
+    // the historical k=10 and capped at 200 to bound the brute-force cosine
+    // scan at high limits.
+    let vec_k = q.limit.clamp(10, 200);
+    let mut vec_results = if q.canonical {
         search_vec_canonical_with_namespace_filtered(
             trimmed,
-            10,
+            vec_k,
             q.wing,
             q.collection,
             q.namespace,
@@ -134,7 +138,7 @@ pub fn hybrid_search(
     } else {
         search_vec_with_namespace_filtered(
             trimmed,
-            10,
+            vec_k,
             q.wing,
             q.collection,
             q.namespace,
@@ -142,6 +146,14 @@ pub fn hybrid_search(
             conn,
         )?
     };
+
+    // Absolute cosine floor on the vector arm, applied to the raw cosine
+    // scores before the per-arm normalization in the merge step. The seeded
+    // default `0.0` is identity behaviour: no hit is dropped.
+    let relevance_floor = read_config_f64(conn, "search.relevance_floor", 0.0)?;
+    if relevance_floor > 0.0 {
+        vec_results.retain(|result| result.score >= relevance_floor);
+    }
 
     let mut merged = match read_merge_strategy(conn)? {
         SearchMergeStrategy::SetUnion => merge_set_union(&fts_results, &vec_results),

--- a/src/mcp/tools/search.rs
+++ b/src/mcp/tools/search.rs
@@ -1,6 +1,7 @@
 //! Read-side query tool bodies: `memory_query` (the hybrid semantic +
 //! FTS5 retrieval that drives most agent reads, with optional progressive
-//! depth expansion) and `memory_search` (raw FTS5 search). Both honour
+//! depth expansion) and `memory_search` (tiered FTS5 search — the same
+//! sanitize + AND→OR-blended path as CLI `quaid search`). Both honour
 //! collection, namespace, wing, and superseded filters. The call sites
 //! into `crate::core::search::*` and `crate::core::fts::*` are kept
 //! minimal to make a future API rename in the search layer (see the
@@ -9,7 +10,7 @@
 use rmcp::model::{CallToolResult, Content};
 use rmcp::tool;
 
-use crate::core::fts::{expand_numeric_fts_query, sanitize_fts_query, search_fts, FtsQuery};
+use crate::core::fts::{sanitize_fts_query, search_fts_tiered, FtsQuery};
 use crate::core::gaps;
 use crate::core::namespace;
 use crate::core::progressive::progressive_retrieve_with_namespace;
@@ -97,12 +98,16 @@ impl QuaidServer {
         Ok(CallToolResult::success(vec![Content::text(json)]))
     }
 
-    /// `memory_search` MCP tool: run an FTS5 full-text search over the
-    /// sanitised query, honouring collection, namespace, wing, and
+    /// `memory_search` MCP tool: run a tiered FTS5 full-text search over the
+    /// sanitised query — a precision-first implicit-AND pass with OR-recall
+    /// hits blended in below the AND hits, the same path as CLI
+    /// `quaid search` — honouring collection, namespace, wing, and
     /// superseded filters and clamping the result count to `MAX_LIMIT`.
     #[tool(description = "FTS5 full-text search")]
-    /// `memory_search` MCP tool: run an FTS5 full-text search over the
-    /// sanitised query, honouring collection, namespace, wing, and
+    /// `memory_search` MCP tool: run a tiered FTS5 full-text search over the
+    /// sanitised query — a precision-first implicit-AND pass with OR-recall
+    /// hits blended in below the AND hits, the same path as CLI
+    /// `quaid search` — honouring collection, namespace, wing, and
     /// superseded filters and clamping the result count to `MAX_LIMIT`.
     pub fn memory_search(
         &self,
@@ -117,8 +122,10 @@ impl QuaidServer {
         let include_superseded = input.include_superseded.unwrap_or(false);
 
         let limit = input.limit.unwrap_or(50).min(MAX_LIMIT) as usize;
-        let safe_query = expand_numeric_fts_query(&sanitize_fts_query(&input.query));
-        let results = search_fts(
+        // `search_fts_tiered` applies numeric-alias expansion in its AND
+        // pass, so sanitization is the only preprocessing needed here.
+        let safe_query = sanitize_fts_query(&input.query);
+        let results = search_fts_tiered(
             &db,
             FtsQuery {
                 query: &safe_query,

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -441,6 +441,7 @@ INSERT OR IGNORE INTO config (key, value) VALUES
     ('embedding_dimensions',  '384'),
     ('chunk_strategy',        'section'),
     ('search_merge_strategy', 'set-union'),
+    ('search.relevance_floor', '0.0'),
     ('default_token_budget',  '4000'),
     ('memory.location',       'vault-subdir'),
     ('corrections.history_on_disk', 'false'),

--- a/tests/search_fusion.rs
+++ b/tests/search_fusion.rs
@@ -1,0 +1,208 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::print_stdout,
+    reason = "test fixtures legitimately panic on setup failure and print diagnostics; per-site #[expect] would generate noise across thousands of test sites"
+)]
+
+//! Hybrid-search fusion integration tests.
+//!
+//! Scenarios tested:
+//!   1. Vector-arm depth — `limit > 10` propagates into the vector arm's k
+//!      instead of the historical hardcoded k=10
+//!   2. Relevance floor — `search.relevance_floor` drops low-cosine vector
+//!      hits before the merge; the seeded `0.0` default keeps identity
+//!      behaviour
+
+use std::collections::BTreeSet;
+
+use quaid::commands::embed;
+use quaid::core::db;
+use quaid::core::search::{hybrid_search, HybridSearch};
+
+fn open_test_db() -> rusqlite::Connection {
+    db::open(":memory:").expect("open in-memory DB")
+}
+
+/// Deterministic RFC-4122-shaped uuid derived from the slug, mirroring the
+/// fixture style used by the search unit tests.
+fn test_uuid(seed: &str) -> String {
+    let mut hex = String::new();
+    for byte in seed.as_bytes() {
+        hex.push_str(&format!("{byte:02x}"));
+        if hex.len() >= 32 {
+            break;
+        }
+    }
+    while hex.len() < 32 {
+        hex.push('0');
+    }
+    format!(
+        "{}-{}-{}-{}-{}",
+        &hex[0..8],
+        &hex[8..12],
+        &hex[12..16],
+        &hex[16..20],
+        &hex[20..32]
+    )
+}
+
+fn insert_page(conn: &rusqlite::Connection, slug: &str, title: &str, truth: &str) {
+    conn.execute(
+        "INSERT INTO pages (slug, uuid, type, title, summary, compiled_truth, timeline, \
+                            frontmatter, wing, room, version) \
+         VALUES (?1, ?2, 'concept', ?3, '', ?4, '', '{}', 'notes', '', 1)",
+        rusqlite::params![slug, test_uuid(slug), title, truth],
+    )
+    .expect("insert page");
+}
+
+fn result_slugs(results: &[quaid::core::types::SearchResult]) -> BTreeSet<String> {
+    results.iter().map(|result| result.slug.clone()).collect()
+}
+
+// ── 1. Vector-arm k propagation ───────────────────────────────────────────────
+
+/// `limit > 10` must reach the vector arm: with 15 embedded pages, none of
+/// which match the query lexically, the merged output is vector-arm-only and
+/// must exceed the historical hardcoded k=10.
+#[test]
+fn hybrid_search_vector_arm_honours_limit_above_ten() {
+    let conn = open_test_db();
+    for index in 0..15 {
+        insert_page(
+            &conn,
+            &format!("notes/entry-{index:02}"),
+            &format!("Entry {index:02}"),
+            &format!("Entry {index:02} covers granite ledger and willow maintenance routines."),
+        );
+    }
+    embed::run(&conn, None, true, false).expect("embed pages");
+
+    // No page contains any query token, so the FTS arm (AND and OR passes)
+    // stays empty and every merged result comes from the vector arm.
+    let results = hybrid_search(
+        &conn,
+        HybridSearch {
+            query: "cosmic jellyfish parade",
+            limit: 25,
+            ..Default::default()
+        },
+    )
+    .expect("hybrid search");
+
+    assert!(
+        results.len() > 10,
+        "limit=25 must propagate into the vector arm instead of capping at k=10, got {} results",
+        results.len()
+    );
+    assert_eq!(
+        results.len(),
+        15,
+        "all embedded pages should surface through the vector arm at limit=25"
+    );
+}
+
+// ── 2. Relevance floor on the vector arm ──────────────────────────────────────
+
+fn seed_floor_corpus(conn: &rusqlite::Connection) {
+    // The target page's truth is byte-identical to the query, so its chunk
+    // embedding matches the query embedding at cosine ~1.0 under any
+    // deterministic backend.
+    insert_page(
+        conn,
+        "notes/target",
+        "Target",
+        "violet umbrella daydream symposium",
+    );
+    insert_page(
+        conn,
+        "notes/junk-1",
+        "Junk One",
+        "Quarterly ledger review for the harbor warehouse.",
+    );
+    insert_page(
+        conn,
+        "notes/junk-2",
+        "Junk Two",
+        "Granite trail erosion report from the northern ridge.",
+    );
+    insert_page(
+        conn,
+        "notes/junk-3",
+        "Junk Three",
+        "Recipe rotation notes for the winter pantry.",
+    );
+    embed::run(conn, None, true, false).expect("embed pages");
+}
+
+const FLOOR_QUERY: &str = "violet umbrella daydream symposium";
+
+/// With the seeded default floor (`0.0`) the behaviour is identity: the
+/// vector arm surfaces every page, junk included.
+#[test]
+fn relevance_floor_seeded_zero_keeps_low_cosine_vector_hits() {
+    let conn = open_test_db();
+    seed_floor_corpus(&conn);
+
+    let seeded: String = conn
+        .query_row(
+            "SELECT value FROM config WHERE key = 'search.relevance_floor'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("relevance floor must be seeded");
+    assert_eq!(seeded, "0.0", "schema must seed the identity floor");
+
+    let results = hybrid_search(
+        &conn,
+        HybridSearch {
+            query: FLOOR_QUERY,
+            limit: 10,
+            ..Default::default()
+        },
+    )
+    .expect("hybrid search");
+
+    let slugs = result_slugs(&results);
+    assert!(
+        slugs.contains("notes/target"),
+        "the exact-match page must always surface: {slugs:?}"
+    );
+    assert_eq!(
+        results.len(),
+        4,
+        "identity floor must keep every vector-arm hit, junk included: {slugs:?}"
+    );
+}
+
+/// A high floor drops the junk vector hits while the exact match (cosine
+/// ~1.0, plus its FTS hit) survives.
+#[test]
+fn relevance_floor_drops_low_cosine_vector_hits() {
+    let conn = open_test_db();
+    seed_floor_corpus(&conn);
+
+    conn.execute(
+        "UPDATE config SET value = '0.995' WHERE key = 'search.relevance_floor'",
+        [],
+    )
+    .expect("raise relevance floor");
+
+    let results = hybrid_search(
+        &conn,
+        HybridSearch {
+            query: FLOOR_QUERY,
+            limit: 10,
+            ..Default::default()
+        },
+    )
+    .expect("hybrid search");
+
+    assert_eq!(
+        result_slugs(&results),
+        BTreeSet::from(["notes/target".to_owned()]),
+        "a high floor must drop junk vector hits and keep the exact match"
+    );
+}

--- a/tests/search_hardening.rs
+++ b/tests/search_hardening.rs
@@ -311,7 +311,8 @@ fn search_compound_terms_finds_docs_when_any_token_matches() {
     );
 }
 
-/// When at least one page matches ALL tokens (AND path), results must include it.
+/// When at least one page matches ALL tokens (AND path), it must rank first;
+/// partial-match pages blend in below it instead of being suppressed.
 #[test]
 fn search_compound_terms_and_path_takes_precedence() {
     let dir = tempfile::TempDir::new().expect("temp dir");
@@ -344,10 +345,73 @@ fn search_compound_terms_and_path_takes_precedence() {
     let parsed = parse_stdout_json(&output);
     let results = parsed.as_array().expect("output must be a JSON array");
     assert_eq!(
+        results[0].get("slug").and_then(Value::as_str),
+        Some("default::concepts/combined"),
+        "the AND hit must rank first"
+    );
+    assert_eq!(
         result_slugs(results),
-        BTreeSet::from(["default::concepts/combined".to_owned()]),
-        "non-raw CLI search must keep canonical slugs and stop at the AND hit instead of \
-         widening to OR results"
+        BTreeSet::from([
+            "default::concepts/combined".to_owned(),
+            "default::concepts/neural-only".to_owned(),
+        ]),
+        "non-raw CLI search must blend OR-recall hits below the AND hit"
+    );
+}
+
+/// Tiered blending: a page matching all four query terms ranks first, and a
+/// page matching only three of four still surfaces below it instead of being
+/// suppressed by the AND pass.
+#[test]
+fn search_blends_three_of_four_term_match_below_full_match() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let db_path = test_db_path(&dir, "compound-blend.db");
+    let conn = open_test_db(&db_path);
+
+    insert_page_with_namespace(
+        &conn,
+        "",
+        "notes/marginal",
+        "concept",
+        "Marginal",
+        "Marginal note",
+        "A glancing aside on quasar harmonics, tideflow, and basalt drift.",
+    );
+    insert_page_with_namespace(
+        &conn,
+        "",
+        "notes/relevant",
+        "concept",
+        "Relevant",
+        "Relevant note",
+        "Quasar harmonics and tideflow interact strongly. Harmonics dominate \
+         tideflow measurements when quasar emissions spike.",
+    );
+    drop(conn);
+
+    let output = run_quaid(
+        &db_path,
+        &["--json", "search", "quasar harmonics tideflow basalt"],
+    );
+    assert!(
+        output.status.success(),
+        "search should exit cleanly: {output:?}"
+    );
+
+    let parsed = parse_stdout_json(&output);
+    let results = parsed.as_array().expect("output must be a JSON array");
+    assert_eq!(
+        results[0].get("slug").and_then(Value::as_str),
+        Some("default::notes/marginal"),
+        "the 4-of-4 AND hit must rank first: {results:?}"
+    );
+    assert_eq!(
+        result_slugs(results),
+        BTreeSet::from([
+            "default::notes/marginal".to_owned(),
+            "default::notes/relevant".to_owned(),
+        ]),
+        "the 3-of-4 match must blend in below the AND hit instead of being suppressed: {results:?}"
     );
 }
 
@@ -393,9 +457,8 @@ fn search_raw_mode_bypasses_or_fallback() {
 }
 
 /// MCP memory_search returns a valid JSON array (safety contract — no crash).
-/// NOTE: compound-term OR fallback is NOT applied to memory_search per the
-/// compound-term-recall design decision (MCP agents needing compound recall
-/// should use memory_query which includes the hybrid/vector arm).
+/// memory_search now routes through the tiered AND→OR path (surface parity
+/// with CLI `quaid search`), so the compound query also yields results here.
 #[test]
 fn memory_search_compound_query_returns_valid_json_array() {
     let dir = tempfile::TempDir::new().expect("temp dir");
@@ -438,9 +501,14 @@ fn memory_search_compound_query_returns_valid_json_array() {
     );
 
     let parsed = parse_stdout_json(&output);
-    assert!(
-        parsed.is_array(),
-        "memory_search must always emit a JSON array (may be empty for compound-term AND miss)"
+    let results = parsed.as_array().expect("output must be a JSON array");
+    assert_eq!(
+        result_slugs(results),
+        BTreeSet::from([
+            "default::concepts/neural".to_owned(),
+            "default::concepts/inference".to_owned(),
+        ]),
+        "memory_search must widen to OR recall when the AND pass misses"
     );
 }
 
@@ -583,5 +651,210 @@ fn memory_search_numeric_query_matches_grouped_number_forms() {
     assert!(
         result_slugs(results).contains("default::journal/2026-04-16"),
         "memory_search numeric alias expansion should match 75,000 content: {results:?}"
+    );
+}
+
+// ── Regression: reverse-direction numeric aliases (issue #196 symmetry) ──────
+
+/// Seed one page with grouped content (`75,000`) and one with the plain
+/// numeral (`75000`); both must be reachable from abbreviated queries.
+fn seed_reverse_numeric_corpus(conn: &Connection) {
+    insert_page_with_namespace(
+        conn,
+        "",
+        "journal/grouped",
+        "journal",
+        "Journal grouped",
+        "Revenue update",
+        "Revenue reached 75,000 in April.",
+    );
+    insert_page_with_namespace(
+        conn,
+        "",
+        "journal/plain",
+        "journal",
+        "Journal plain",
+        "Salary update",
+        "Salary set to 75000 in April.",
+    );
+}
+
+#[test]
+fn search_abbreviated_numeric_query_matches_full_and_grouped_content() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let db_path = test_db_path(&dir, "search-numeric-reverse.db");
+    let conn = open_test_db(&db_path);
+    seed_reverse_numeric_corpus(&conn);
+    drop(conn);
+
+    for query in ["75k April", "$75K April"] {
+        let output = run_quaid(&db_path, &["--json", "search", query]);
+        assert!(
+            output.status.success(),
+            "search should exit cleanly for abbreviated numeric query {query:?}: {output:?}"
+        );
+
+        let parsed = parse_stdout_json(&output);
+        let results = parsed.as_array().expect("output must be a JSON array");
+        let slugs = result_slugs(results);
+        assert!(
+            slugs.contains("default::journal/grouped") && slugs.contains("default::journal/plain"),
+            "query {query:?} must match both 75,000 and 75000 content: {results:?}"
+        );
+    }
+}
+
+#[test]
+fn memory_search_abbreviated_numeric_query_matches_full_and_grouped_content() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let db_path = test_db_path(&dir, "memory-search-numeric-reverse.db");
+    let conn = open_test_db(&db_path);
+    seed_reverse_numeric_corpus(&conn);
+    drop(conn);
+
+    for payload in [
+        r#"{"query":"75k April","limit":10}"#,
+        r#"{"query":"$75K April","limit":10}"#,
+    ] {
+        let output = run_quaid(&db_path, &["call", "memory_search", payload]);
+        assert!(
+            output.status.success(),
+            "memory_search should exit cleanly for abbreviated numeric payload {payload}: {output:?}"
+        );
+
+        let parsed = parse_stdout_json(&output);
+        let results = parsed.as_array().expect("output must be a JSON array");
+        let slugs = result_slugs(results);
+        assert!(
+            slugs.contains("default::journal/grouped") && slugs.contains("default::journal/plain"),
+            "memory_search payload {payload} must match both 75,000 and 75000 content: {results:?}"
+        );
+    }
+}
+
+/// Formatted query `$75,000` sanitizes to the two tokens `75 000`; the fused
+/// single-token alias must reach content holding the plain numeral `75000`.
+#[test]
+fn search_formatted_numeric_query_matches_single_token_content() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let db_path = test_db_path(&dir, "search-numeric-formatted.db");
+    let conn = open_test_db(&db_path);
+
+    insert_page_with_namespace(
+        &conn,
+        "",
+        "journal/plain",
+        "journal",
+        "Journal plain",
+        "Salary update",
+        "Salary set to 75000 in April.",
+    );
+    drop(conn);
+
+    let output = run_quaid(&db_path, &["--json", "search", "$75,000"]);
+    assert!(
+        output.status.success(),
+        "search should exit cleanly for formatted numeric query: {output:?}"
+    );
+
+    let parsed = parse_stdout_json(&output);
+    let results = parsed.as_array().expect("output must be a JSON array");
+    assert!(
+        result_slugs(results).contains("default::journal/plain"),
+        "formatted query $75,000 must match single-token 75000 content: {results:?}"
+    );
+}
+
+/// One-decimal abbreviations must alias in both directions: plain-numeral
+/// query ↔ `$1.5M` content and `$1.5M` query ↔ plain-numeral content.
+#[test]
+fn search_decimal_abbreviated_numeric_aliases_work_in_both_directions() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let db_path = test_db_path(&dir, "search-numeric-decimal.db");
+    let conn = open_test_db(&db_path);
+
+    insert_page_with_namespace(
+        &conn,
+        "",
+        "journal/decimal",
+        "journal",
+        "Journal decimal",
+        "Raise update",
+        "Raise closed at $1.5M in May.",
+    );
+    insert_page_with_namespace(
+        &conn,
+        "",
+        "journal/numeral",
+        "journal",
+        "Journal numeral",
+        "Round update",
+        "Round closed at 1500000 in May.",
+    );
+    drop(conn);
+
+    let output = run_quaid(&db_path, &["--json", "search", "1500000"]);
+    assert!(
+        output.status.success(),
+        "search should exit cleanly for plain-numeral query: {output:?}"
+    );
+    let parsed = parse_stdout_json(&output);
+    let results = parsed.as_array().expect("output must be a JSON array");
+    assert!(
+        result_slugs(results).contains("default::journal/decimal"),
+        "query 1500000 must match $1.5M content: {results:?}"
+    );
+
+    let output = run_quaid(&db_path, &["--json", "search", "$1.5M"]);
+    assert!(
+        output.status.success(),
+        "search should exit cleanly for decimal-abbreviated query: {output:?}"
+    );
+    let parsed = parse_stdout_json(&output);
+    let results = parsed.as_array().expect("output must be a JSON array");
+    assert!(
+        result_slugs(results).contains("default::journal/numeral"),
+        "query $1.5M must match 1500000 content: {results:?}"
+    );
+}
+
+// ── memory_search tiered fallback (surface parity with CLI search) ───────────
+
+/// A two-term memory_search query where only one term exists in the corpus
+/// must return results via the tiered OR fallback instead of an empty array.
+#[test]
+fn memory_search_two_term_query_falls_back_to_or_when_and_misses() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let db_path = test_db_path(&dir, "memory-search-or-fallback.db");
+    let conn = open_test_db(&db_path);
+
+    insert_page(
+        &conn,
+        "concepts/quantum",
+        "concept",
+        "Quantum Computing",
+        "Quantum computing uses qubits for parallel computation.",
+    );
+    drop(conn);
+
+    let output = run_quaid(
+        &db_path,
+        &[
+            "call",
+            "memory_search",
+            r#"{"query":"quantum jellyfish","limit":10}"#,
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "memory_search should exit cleanly: {output:?}"
+    );
+
+    let parsed = parse_stdout_json(&output);
+    let results = parsed.as_array().expect("output must be a JSON array");
+    assert_eq!(
+        result_slugs(results),
+        BTreeSet::from(["default::concepts/quantum".to_owned()]),
+        "memory_search must widen to OR when only one of two terms matches: {results:?}"
     );
 }


### PR DESCRIPTION
Implements the mechanical retrieval fixes from **Area 1 (steps 1–3)** and all of **Area 3** of the codebase review (`docs/fable-review.md` on `code-review-2`). These target the DAB §4 regression signatures in #219/#220 and the one-directional #196 fix.

## Changes
- **Vector arm k** (`search.rs`): `q.limit.clamp(10, 200)` instead of hardcoded `10` in both vector branches — semantic recall no longer capped at 10 regardless of requested depth.
- **Tiered FTS blending** (`fts.rs`): a non-empty AND pass no longer suppresses OR recall. AND hits keep BM25 order first; OR hits (deduped by slug, score-demoted below the weakest AND hit) fill remaining slots. Fixes the 4-term/3-of-4-term suppression (DAB S06 signature).
- **Relevance floor**: new config `search.relevance_floor` (seeded `0.0` = exact identity; applied only when > 0.0 since cosine can be negative) — an absolute raw-cosine floor on the vector arm pre-merge, so junk semantic hits can be cut before max-normalization inflates them.
- **Numeric-alias symmetry** (`fts.rs`): `75k`/`$75K` → `75000` + `"75 000"`; one-decimal forms (`1500000` ↔ `$1.5M`, `75500` → `"75 5k"`); adjacent digit-run fusion (`75` + `000` → `75000`); every matching magnitude emitted, not first-divisor-only.
- **memory_search parity** (`mcp/tools/search.rs`): now routes through `sanitize_fts_query` + `search_fts_tiered` — agents get the same tiered recall as the CLI (the #212 "empty results" shape).

## Validation
`cargo check`/clippy clean. Targeted suites green: search_hardening 18/18 (4 numeric regression tests unchanged), new search_fusion 3/3, lib fts 37 + search 31. Blast radius: mcp_server_query_search_list 15, supersede_chain, file_edit_supersede, namespace_isolation, graph_retrieval 16, corpus_reality 8 — all pass.

## Notes
- Behavioral change by design: OR-blending affects CLI search, hybrid_search, and memory_search; two tests codifying the old AND-verbatim contract were updated.
- OR-blended hit scores are synthetic (weakest-AND minus epsilon) to preserve AND-first ordering through score-sorted consumers; raw BM25 kept in the pure OR-fallback path.
- `search.relevance_floor` vs the unprefixed `relevance_floor` in openspec `retrieval-quality-rerank` tasks.md — naming to reconcile when that change executes (next PR in this train).

🤖 Generated with [Claude Code](https://claude.com/claude-code)