### PR TITLE
fix(cli): close CLI/MCP surface gaps + honest schema-mismatch message (areas 19, 17.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,43 @@ All notable changes to Quaid are tracked here. Pre-1.0, schema and
 response-shape changes may break compatibility between minor versions —
 each entry below calls out the migration implications.
 
+## Unreleased
+
+### Fixed
+
+- **CLI ↔ MCP dispatch parity.** `quaid call` / `quaid pipe` now route
+  `memory_correct` and `memory_correct_continue`, matching the 24-tool MCP
+  registry. A parity test pins the dispatcher to the registry.
+- **Global `--json` flag.** `--json` is now honoured by `put`, `ingest`,
+  `export`, `extract`, `embed`, `link`, `link-close`, `unlink`, `tags`,
+  `timeline-add`, `compact`, and `config`; `quaid --json status` and
+  `quaid status --json` are equivalent.
+- **Dead flags implemented.** `quaid export --raw [--import-id <id>]` now
+  performs a byte-exact restore from `raw_imports`; `quaid embed --all`
+  forces a re-embed (bypassing the unchanged-hash skip) while `--stale`
+  keeps the skip.
+- **`quaid status` exit code 3.** A failed service-manager probe
+  (`launchctl`/`systemctl` error) now exits 3 as documented, instead of
+  being misreported as "not installed" (exit 2). JSON output gains a
+  `daemon.probe_failed` field.
+- **Schema-mismatch message accuracy.** Opening a database with an older
+  (e.g. v9, shipped with quaid v0.20.x-v0.21.x) or newer schema version
+  no longer claims the file predates the Quaid rename; the message now
+  distinguishes older/newer/legacy cases and instructs backing up the old
+  file before `quaid init` (the previous remediation dead-looped).
+
+### Changed
+
+- **Conflict message prefix.** All JSON-RPC `-32009` conflict messages now
+  carry the single canonical `ConflictError: ` prefix (previously a mix of
+  `conflict: `, `Conflict: `, and `ConflictError: `). The JSON-RPC error
+  code is unchanged; consumers pattern-matching the old spellings should
+  match `ConflictError` instead.
+
+### Migration
+
+- No schema migration. Existing v0.22.x databases remain compatible.
+
 ## v0.22.3 — post-release bug fixes
 
 ### Fixed

--- a/src/commands/call.rs
+++ b/src/commands/call.rs
@@ -43,6 +43,20 @@ pub fn dispatch_tool(server: &QuaidServer, tool: &str, params: Value) -> Result<
                 .memory_close_action(input)
                 .map_err(|e| e.message.to_string())
         }
+        "memory_correct" => {
+            let input: MemoryCorrectInput =
+                serde_json::from_value(params).map_err(|e| format!("invalid params: {e}"))?;
+            server
+                .memory_correct(input)
+                .map_err(|e| e.message.to_string())
+        }
+        "memory_correct_continue" => {
+            let input: MemoryCorrectContinueInput =
+                serde_json::from_value(params).map_err(|e| format!("invalid params: {e}"))?;
+            server
+                .memory_correct_continue(input)
+                .map_err(|e| e.message.to_string())
+        }
         "memory_query" => {
             let input: MemoryQueryInput =
                 serde_json::from_value(params).map_err(|e| format!("invalid params: {e}"))?;

--- a/src/commands/compact.rs
+++ b/src/commands/compact.rs
@@ -9,9 +9,13 @@ use rusqlite::Connection;
 use crate::core::db;
 
 /// Checkpoint the WAL and compact the database to a single file.
-pub fn run(conn: &Connection) -> Result<()> {
+pub fn run(conn: &Connection, json: bool) -> Result<()> {
     db::compact(conn)?;
-    println!("Compacted database (WAL checkpoint complete)");
+    if json {
+        println!("{}", serde_json::json!({ "status": "compacted" }));
+    } else {
+        println!("Compacted database (WAL checkpoint complete)");
+    }
     Ok(())
 }
 
@@ -41,14 +45,14 @@ mod tests {
         )
         .unwrap();
 
-        let result = run(&conn);
+        let result = run(&conn, false);
         assert!(result.is_ok());
     }
 
     #[test]
     fn compact_succeeds_on_empty_database() {
         let conn = open_test_db();
-        let result = run(&conn);
+        let result = run(&conn, false);
         assert!(result.is_ok());
     }
 }

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -14,7 +14,7 @@ pub enum ConfigAction {
     List,
 }
 
-pub fn run(db: &Connection, action: ConfigAction) -> Result<()> {
+pub fn run(db: &Connection, action: ConfigAction, json: bool) -> Result<()> {
     match action {
         ConfigAction::Get { key } => {
             let value: Result<String, _> =
@@ -22,8 +22,20 @@ pub fn run(db: &Connection, action: ConfigAction) -> Result<()> {
                     row.get(0)
                 });
             match value {
-                Ok(v) => println!("{v}"),
-                Err(rusqlite::Error::QueryReturnedNoRows) => println!("Not set"),
+                Ok(v) => {
+                    if json {
+                        println!("{}", serde_json::json!({ "key": key, "value": v }));
+                    } else {
+                        println!("{v}");
+                    }
+                }
+                Err(rusqlite::Error::QueryReturnedNoRows) => {
+                    if json {
+                        println!("{}", serde_json::json!({ "key": key, "value": null }));
+                    } else {
+                        println!("Not set");
+                    }
+                }
                 Err(e) => return Err(e.into()),
             }
         }
@@ -32,16 +44,29 @@ pub fn run(db: &Connection, action: ConfigAction) -> Result<()> {
                 "INSERT OR REPLACE INTO config (key, value) VALUES (?1, ?2)",
                 rusqlite::params![key, value],
             )?;
-            println!("Set {key} = {value}");
+            if json {
+                println!("{}", serde_json::json!({ "key": key, "value": value }));
+            } else {
+                println!("Set {key} = {value}");
+            }
         }
         ConfigAction::List => {
             let mut stmt = db.prepare("SELECT key, value FROM config ORDER BY key")?;
             let rows = stmt.query_map([], |row| {
                 Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
             })?;
-            for row in rows {
-                let (k, v) = row?;
-                println!("{k}={v}");
+            if json {
+                let mut map = serde_json::Map::new();
+                for row in rows {
+                    let (k, v) = row?;
+                    map.insert(k, serde_json::Value::String(v));
+                }
+                println!("{}", serde_json::to_string_pretty(&map)?);
+            } else {
+                for row in rows {
+                    let (k, v) = row?;
+                    println!("{k}={v}");
+                }
             }
         }
     }
@@ -71,6 +96,7 @@ mod tests {
                 key: "test_key".into(),
                 value: "test_value".into(),
             },
+            false,
         )
         .unwrap();
 
@@ -93,6 +119,7 @@ mod tests {
                 key: "version".into(),
                 value: "99".into(),
             },
+            false,
         )
         .unwrap();
 
@@ -115,6 +142,7 @@ mod tests {
             ConfigAction::Get {
                 key: "missing".into(),
             },
+            false,
         )
         .unwrap();
     }
@@ -133,6 +161,7 @@ mod tests {
             ConfigAction::Get {
                 key: "theme".into(),
             },
+            false,
         )
         .unwrap();
     }
@@ -146,6 +175,7 @@ mod tests {
             ConfigAction::Get {
                 key: "theme".into(),
             },
+            false,
         )
         .unwrap_err();
 
@@ -161,6 +191,7 @@ mod tests {
                 key: "alpha".into(),
                 value: "1".into(),
             },
+            false,
         )
         .unwrap();
         run(
@@ -169,9 +200,10 @@ mod tests {
                 key: "beta".into(),
                 value: "2".into(),
             },
+            false,
         )
         .unwrap();
 
-        run(&conn, ConfigAction::List).unwrap();
+        run(&conn, ConfigAction::List, false).unwrap();
     }
 }

--- a/src/commands/embed.rs
+++ b/src/commands/embed.rs
@@ -22,7 +22,7 @@ struct PageRef {
 }
 
 pub fn run(db: &Connection, slug: Option<String>, all: bool, stale: bool) -> Result<()> {
-    run_with_batch(db, slug, all, stale, None)
+    run_with_batch(db, slug, all, stale, None, false)
 }
 
 pub fn run_with_batch(
@@ -31,6 +31,7 @@ pub fn run_with_batch(
     all: bool,
     stale: bool,
     batch_size: Option<usize>,
+    json: bool,
 ) -> Result<()> {
     // Modes are mutually exclusive: exactly one of <SLUG>, --all, or --stale.
     if slug.is_some() && (all || stale) {
@@ -93,7 +94,10 @@ pub fn run_with_batch(
                     continue;
                 }
 
-                if !page_needs_refresh(db, page_ref.id, &model_name, &chunks)? {
+                // `--all` forces a re-embed of every page; only the default
+                // bulk path and `--stale` skip pages whose chunk metadata
+                // already matches the index.
+                if !all && !page_needs_refresh(db, page_ref.id, &model_name, &chunks)? {
                     continue;
                 }
 
@@ -118,7 +122,17 @@ pub fn run_with_batch(
         (embedded_pages, embedded_chunks)
     };
 
-    println!("Embedded {embedded_chunks} chunks across {embedded_pages} page(s).");
+    if json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "embedded_chunks": embedded_chunks,
+                "embedded_pages": embedded_pages,
+            })
+        );
+    } else {
+        println!("Embedded {embedded_chunks} chunks across {embedded_pages} page(s).");
+    }
     Ok(())
 }
 
@@ -442,7 +456,7 @@ mod tests {
     }
 
     #[test]
-    fn run_with_all_skips_unchanged_pages() {
+    fn run_with_all_force_re_embeds_unchanged_pages() {
         let conn = open_test_db();
         insert_test_page(
             &conn,
@@ -456,13 +470,29 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM page_embeddings", [], |row| row.get(0))
             .expect("initial metadata count");
 
-        // --all on unchanged content must skip (spec: skip if content_hash unchanged)
+        // Tamper with stored chunk text WITHOUT touching content_hash: the
+        // hash-based skip would leave this in place, but `--all` must force
+        // a full re-embed that rewrites the row from the page content.
+        conn.execute(
+            "UPDATE page_embeddings SET chunk_text = 'tampered' WHERE chunk_index = 0",
+            [],
+        )
+        .expect("tamper chunk text");
+
         run(&conn, None, true, false).expect("second all embed");
         let second_count: i64 = conn
             .query_row("SELECT COUNT(*) FROM page_embeddings", [], |row| row.get(0))
             .expect("second metadata count");
+        let tampered_left: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM page_embeddings WHERE chunk_text = 'tampered'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("tampered row count");
 
         assert_eq!(first_count, second_count);
+        assert_eq!(tampered_left, 0, "--all must force re-embed");
     }
 
     #[test]

--- a/src/commands/export.rs
+++ b/src/commands/export.rs
@@ -10,10 +10,34 @@ use rusqlite::Connection;
 
 use crate::core::migrate;
 
-pub fn run(db: &Connection, path: &str, _raw: bool, _import_id: Option<String>) -> Result<()> {
+pub fn run(
+    db: &Connection,
+    path: &str,
+    raw: bool,
+    import_id: Option<String>,
+    json: bool,
+) -> Result<()> {
+    anyhow::ensure!(
+        import_id.is_none() || raw,
+        "--import-id requires --raw (raw payloads are addressed by import id)"
+    );
     let output = Path::new(path);
-    let count = migrate::export_dir(db, output)?;
-    println!("Exported {count} page(s) to {path}");
+    let (count, mode) = if raw {
+        (
+            migrate::export_raw_dir(db, output, import_id.as_deref())?,
+            "raw",
+        )
+    } else {
+        (migrate::export_dir(db, output)?, "semantic")
+    };
+    if json {
+        println!(
+            "{}",
+            serde_json::json!({ "exported_pages": count, "path": path, "mode": mode })
+        );
+    } else {
+        println!("Exported {count} page(s) to {path}");
+    }
     Ok(())
 }
 
@@ -64,6 +88,7 @@ mod tests {
             export_dir.to_str().expect("export path"),
             false,
             None,
+            false,
         )
         .unwrap();
 

--- a/src/commands/extract.rs
+++ b/src/commands/extract.rs
@@ -34,7 +34,7 @@ pub struct ExtractArgs {
     force: bool,
 }
 
-pub fn run(db: &Connection, args: ExtractArgs) -> Result<()> {
+pub fn run(db: &Connection, args: ExtractArgs, json: bool) -> Result<()> {
     if !args.all && args.session_id.is_none() {
         bail!("provide <session-id> or --all");
     }
@@ -99,14 +99,21 @@ pub fn run(db: &Connection, args: ExtractArgs) -> Result<()> {
         enqueued.push(target.display_id.clone());
     }
 
-    println!(
-        "Enqueued manual extraction for {} session(s):",
-        enqueued.len()
-    );
-    for session_id in &enqueued {
-        println!("  - {session_id}");
+    if json {
+        println!(
+            "{}",
+            serde_json::json!({ "enqueued_sessions": enqueued, "count": enqueued.len() })
+        );
+    } else {
+        println!(
+            "Enqueued manual extraction for {} session(s):",
+            enqueued.len()
+        );
+        for session_id in &enqueued {
+            println!("  - {session_id}");
+        }
+        println!("Track progress with `quaid extraction status`.");
     }
-    println!("Track progress with `quaid extraction status`.");
     Ok(())
 }
 

--- a/src/commands/ingest.rs
+++ b/src/commands/ingest.rs
@@ -15,7 +15,19 @@ use crate::core::{
     entities, links, markdown, novelty, page_uuid, palace, raw_imports, supersede, vault_sync,
 };
 
+/// Outcome of a single-file ingest, used to keep human and `--json`
+/// output rendering in one place at the end of [`run_with_output`].
+enum IngestOutcome {
+    Ingested,
+    AlreadyIngested,
+    NotNovel,
+}
+
 pub fn run(db: &Connection, path: &str, force: bool) -> Result<()> {
+    run_with_output(db, path, force, false)
+}
+
+pub fn run_with_output(db: &Connection, path: &str, force: bool, json: bool) -> Result<()> {
     let file = Path::new(path);
     let raw_bytes = fs::read(file)?;
     let raw = String::from_utf8_lossy(&raw_bytes).into_owned();
@@ -38,11 +50,10 @@ pub fn run(db: &Connection, path: &str, force: bool) -> Result<()> {
         .map_err(|err| anyhow::anyhow!(err.to_string()))?;
 
     db.execute_batch("BEGIN IMMEDIATE TRANSACTION;")?;
-    let outcome = (|| -> Result<()> {
+    let outcome = (|| -> Result<IngestOutcome> {
         if !force && is_already_ingested(db, &raw_bytes)? {
             refresh_source_mapping_for_duplicate(db, &slug, path, &raw_bytes)?;
-            println!("Already ingested (exact bytes match), use --force to re-ingest");
-            return Ok(());
+            return Ok(IngestOutcome::AlreadyIngested);
         }
 
         // Novelty check: skip near-duplicate content unless --force
@@ -51,7 +62,7 @@ pub fn run(db: &Connection, path: &str, force: bool) -> Result<()> {
                 match novelty::check_novelty(&compiled_truth, &existing_page, db) {
                     Ok(false) => {
                         eprintln!("Skipping ingest: content not novel (slug: {slug})");
-                        return Ok(());
+                        return Ok(IngestOutcome::NotNovel);
                     }
                     Ok(true) => {} // novel content, proceed
                     Err(e) => {
@@ -126,14 +137,33 @@ pub fn run(db: &Connection, path: &str, force: bool) -> Result<()> {
             .map_err(|error| anyhow::anyhow!(error.to_string()))?;
         entities::try_run_for_page(db, page_id, 1, &slug, &compiled_truth, &entity_patterns);
         raw_imports::rotate_active_raw_import(db, page_id, path, &raw_bytes)?;
-        println!("Ingested {slug}");
 
-        Ok(())
+        Ok(IngestOutcome::Ingested)
     })();
 
     match outcome {
-        Ok(()) => {
+        Ok(outcome) => {
             db.execute_batch("COMMIT;")?;
+            if json {
+                let status = match outcome {
+                    IngestOutcome::Ingested => "ingested",
+                    IngestOutcome::AlreadyIngested => "already_ingested",
+                    IngestOutcome::NotNovel => "skipped_not_novel",
+                };
+                println!(
+                    "{}",
+                    serde_json::json!({ "status": status, "slug": slug, "path": path })
+                );
+            } else {
+                match outcome {
+                    IngestOutcome::Ingested => println!("Ingested {slug}"),
+                    IngestOutcome::AlreadyIngested => {
+                        println!("Already ingested (exact bytes match), use --force to re-ingest")
+                    }
+                    // The skip reason was already printed to stderr above.
+                    IngestOutcome::NotNovel => {}
+                }
+            }
             Ok(())
         }
         Err(err) => {

--- a/src/commands/link.rs
+++ b/src/commands/link.rs
@@ -53,6 +53,7 @@ pub fn run(
     relationship: &str,
     valid_from: Option<String>,
     valid_until: Option<String>,
+    json: bool,
 ) -> Result<()> {
     let from_page = resolve_page(db, from, OpKind::WriteUpdate)?;
     let to_page = resolve_page(db, to, OpKind::WriteUpdate)?;
@@ -66,7 +67,18 @@ pub fn run(
     )?;
     let from_slug = from_page.resolved.canonical_slug();
     let to_slug = to_page.resolved.canonical_slug();
-    if closed {
+    if json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "action": if closed { "closed" } else { "linked" },
+                "from": from_slug,
+                "to": to_slug,
+                "relationship": relationship,
+                "valid_until": valid_until,
+            })
+        );
+    } else if closed {
         println!(
             "Closed link {from} → {to} ({relationship}) valid_until={valid_until}",
             from = from_slug,
@@ -148,9 +160,20 @@ fn run_resolved(
 // ── quaid link-close ────────────────────────────────────────
 
 /// Close a temporal link interval by its database ID.
-pub fn close(db: &Connection, link_id: u64, valid_until: &str) -> Result<()> {
+pub fn close(db: &Connection, link_id: u64, valid_until: &str, json: bool) -> Result<()> {
     close_silent(db, link_id, valid_until)?;
-    println!("Closed link {link_id} valid_until={valid_until}");
+    if json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "action": "closed",
+                "link_id": link_id,
+                "valid_until": valid_until,
+            })
+        );
+    } else {
+        println!("Closed link {link_id} valid_until={valid_until}");
+    }
     Ok(())
 }
 
@@ -251,7 +274,13 @@ pub fn links(db: &Connection, slug: &str, _temporal: Option<String>, json: bool)
 // ── quaid unlink ────────────────────────────────────────────
 
 /// Remove a cross-reference entirely.
-pub fn unlink(db: &Connection, from: &str, to: &str, relationship: Option<String>) -> Result<()> {
+pub fn unlink(
+    db: &Connection,
+    from: &str,
+    to: &str,
+    relationship: Option<String>,
+    json: bool,
+) -> Result<()> {
     let from_page = resolve_page(db, from, OpKind::WriteUpdate)?;
     let to_page = resolve_page(db, to, OpKind::WriteUpdate)?;
     vault_sync::ensure_collection_write_allowed(db, from_page.resolved.collection_id)
@@ -279,11 +308,23 @@ pub fn unlink(db: &Connection, from: &str, to: &str, relationship: Option<String
         );
     }
 
-    println!(
-        "Removed {rows} link(s) {} → {}",
-        from_page.resolved.canonical_slug(),
-        to_page.resolved.canonical_slug()
-    );
+    if json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "action": "unlinked",
+                "removed": rows,
+                "from": from_page.resolved.canonical_slug(),
+                "to": to_page.resolved.canonical_slug(),
+            })
+        );
+    } else {
+        println!(
+            "Removed {rows} link(s) {} → {}",
+            from_page.resolved.canonical_slug(),
+            to_page.resolved.canonical_slug()
+        );
+    }
     Ok(())
 }
 
@@ -411,6 +452,7 @@ mod tests {
             "works_at",
             Some("2024-01".to_string()),
             None,
+            false,
         )
         .unwrap();
 
@@ -440,6 +482,7 @@ mod tests {
             "works_at",
             None,
             None,
+            false,
         )
         .unwrap();
 
@@ -468,6 +511,7 @@ mod tests {
             "works_at",
             Some("2024-01".to_string()),
             None,
+            false,
         )
         .unwrap();
 
@@ -479,6 +523,7 @@ mod tests {
             "works_at",
             None,
             Some("2025-06".to_string()),
+            false,
         )
         .unwrap();
 
@@ -500,9 +545,18 @@ mod tests {
         insert_page(&conn, "people/bob", "person");
         insert_page(&conn, "companies/beta", "company");
 
-        run(&conn, "people/bob", "companies/beta", "advises", None, None).unwrap();
+        run(
+            &conn,
+            "people/bob",
+            "companies/beta",
+            "advises",
+            None,
+            None,
+            false,
+        )
+        .unwrap();
 
-        close(&conn, 1, "2025-12").unwrap();
+        close(&conn, 1, "2025-12", false).unwrap();
 
         let link = get_link(&conn, 1).unwrap();
         assert_eq!(link.valid_until.as_deref(), Some("2025-12"));
@@ -511,7 +565,7 @@ mod tests {
     #[test]
     fn link_close_returns_error_for_nonexistent_id() {
         let conn = open_test_db();
-        let result = close(&conn, 999, "2025-01");
+        let result = close(&conn, 999, "2025-01", false);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("link not found"));
     }
@@ -530,6 +584,7 @@ mod tests {
             "works_at",
             None,
             None,
+            false,
         );
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("page not found"));
@@ -547,6 +602,7 @@ mod tests {
             "works_at",
             None,
             None,
+            false,
         );
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("page not found"));
@@ -570,6 +626,7 @@ mod tests {
             "works_at",
             None,
             None,
+            false,
         )
         .unwrap_err();
 
@@ -591,6 +648,7 @@ mod tests {
             "works_at",
             None,
             None,
+            false,
         )
         .unwrap();
         assert_eq!(
@@ -604,6 +662,7 @@ mod tests {
             "people/alice",
             "companies/acme",
             Some("works_at".to_string()),
+            false,
         )
         .unwrap();
         assert_eq!(
@@ -628,6 +687,7 @@ mod tests {
             "works_at",
             None,
             None,
+            false,
         )
         .unwrap();
 

--- a/src/commands/put.rs
+++ b/src/commands/put.rs
@@ -121,11 +121,17 @@ pub fn run(
     slug: &str,
     namespace: Option<&str>,
     expected_version: Option<i64>,
+    json: bool,
 ) -> anyhow::Result<()> {
     vault_sync::ensure_unix_platform("quaid put").map_err(anyhow::Error::new)?;
     let mut input = String::new();
     io::stdin().read_to_string(&mut input)?;
-    put_from_cli_string(db, slug, &input, namespace, expected_version)?;
+    let status = put_from_cli_string(db, slug, &input, namespace, expected_version)?;
+    if json {
+        println!("{}", serde_json::json!({ "result": status }));
+    } else {
+        println!("{status}");
+    }
     Ok(())
 }
 
@@ -136,7 +142,7 @@ fn put_from_cli_string(
     content: &str,
     namespace: Option<&str>,
     expected_version: Option<i64>,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<String> {
     crate::core::namespace::validate_optional_namespace(namespace)?;
     let op_kind = if expected_version.is_some() {
         crate::core::collections::OpKind::WriteUpdate
@@ -150,17 +156,14 @@ fn put_from_cli_string(
     let canonical_slug = format!("{}::{}", resolved.collection_name, resolved.slug);
     match vault_sync::live_serve_endpoint_for_root_path(db, &collection.root_path) {
         Ok(Some(endpoint)) => {
-            let status =
-                proxy_put_via_live_serve(&endpoint, &canonical_slug, content, expected_version)?;
-            println!("{status}");
-            return Ok(());
+            return proxy_put_via_live_serve(&endpoint, &canonical_slug, content, expected_version);
         }
         Ok(None) => {}
         Err(other) => return Err(anyhow::Error::new(other)),
     }
     let _lease = vault_sync::start_short_lived_owner_lease_for_root_path(db, &collection.root_path)
         .map_err(anyhow::Error::new)?;
-    put_from_string_with_namespace(db, &canonical_slug, content, namespace, expected_version)
+    put_from_string_status_with_namespace(db, &canonical_slug, content, namespace, expected_version)
 }
 
 #[cfg(not(unix))]
@@ -170,8 +173,8 @@ fn put_from_cli_string(
     content: &str,
     namespace: Option<&str>,
     expected_version: Option<i64>,
-) -> anyhow::Result<()> {
-    put_from_string_with_namespace(db, slug_input, content, namespace, expected_version)
+) -> anyhow::Result<String> {
+    put_from_string_status_with_namespace(db, slug_input, content, namespace, expected_version)
 }
 
 /// Apply page content supplied by the caller.
@@ -570,7 +573,7 @@ fn stage_page_record(
     tx: &rusqlite::Transaction<'_>,
     prepared: &PreparedPut,
     expected_version: Option<i64>,
-) -> Result<StagedPageRecord, rusqlite::Error> {
+) -> Result<StagedPageRecord, vault_sync::VaultSyncError> {
     let (created, version) = match prepared.current_version {
         None => {
             tx.execute(
@@ -652,9 +655,10 @@ fn stage_page_record(
             };
 
             if rows == 0 {
-                return Err(rusqlite::Error::InvalidParameterName(format!(
-                    "Conflict: page updated elsewhere (current version: {current})"
-                )));
+                return Err(crate::core::types::OccError::Conflict {
+                    current_version: current,
+                }
+                .into());
             }
 
             (false, current + 1)
@@ -750,10 +754,11 @@ fn persist_page_record(
     relative_path: &str,
     file_stat: Option<&file_state::FileStat>,
     expected_version: Option<i64>,
-) -> Result<PutOutcome, rusqlite::Error> {
+) -> Result<PutOutcome, vault_sync::VaultSyncError> {
     let tx = db.unchecked_transaction()?;
     let staged = stage_page_record(&tx, prepared, expected_version)?;
     commit_staged_page_record(tx, prepared, staged, raw_bytes, relative_path, file_stat)
+        .map_err(Into::into)
 }
 
 #[cfg(not(unix))]
@@ -772,7 +777,6 @@ fn persist_with_vault_write(
         None,
         expected_version,
     )
-    .map_err(Into::into)
 }
 
 #[cfg(unix)]
@@ -796,8 +800,7 @@ fn persist_with_vault_write(
             relative_path,
             None,
             expected_version,
-        )
-        .map_err(Into::into);
+        );
     }
 
     let collection = vault_sync::load_collection_by_id(db, prepared.collection_id)?;
@@ -845,7 +848,7 @@ fn persist_with_vault_write(
         Ok(staged) => staged,
         Err(error) => {
             let _ = tx.rollback();
-            return Err(error.into());
+            return Err(error);
         }
     };
     maybe_block_after_supersede_claim(db, prepared.supersedes.as_deref());
@@ -2615,7 +2618,7 @@ mod tests {
                 None,
                 None,
             ) {
-                Ok(()) => {
+                Ok(_) => {
                     proxied = true;
                     break;
                 }

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -35,6 +35,7 @@ pub fn run(db: &Connection, json_output: bool) -> Result<u8> {
         UnitState::Running => 0u8,
         UnitState::InstalledStopped => 1,
         UnitState::NotInstalled => 2,
+        UnitState::ProbeFailed => 3, // service-manager probe errored — unknown state
         UnitState::Unsupported => 0, // not an error: just no platform integration
     };
 
@@ -44,6 +45,7 @@ pub fn run(db: &Connection, json_output: bool) -> Result<u8> {
                 "installed": matches!(daemon_unit, UnitState::Running | UnitState::InstalledStopped),
                 "running": matches!(daemon_unit, UnitState::Running),
                 "platform_supported": !matches!(daemon_unit, UnitState::Unsupported),
+                "probe_failed": matches!(daemon_unit, UnitState::ProbeFailed),
             },
             "runtime_host": runtime_host.as_ref().map(|h| json!({
                 "session_type": h.session_type,
@@ -71,6 +73,9 @@ pub fn run(db: &Connection, json_output: bool) -> Result<u8> {
             UnitState::InstalledStopped => println!("  state: installed; stopped"),
             UnitState::NotInstalled => {
                 println!("  state: not installed (run `quaid daemon install` to set up)")
+            }
+            UnitState::ProbeFailed => {
+                println!("  state: unknown (service-manager status probe failed)")
             }
             UnitState::Unsupported => {
                 println!("  state: platform not supported (macOS and Linux only)")
@@ -112,12 +117,16 @@ pub fn run(db: &Connection, json_output: bool) -> Result<u8> {
 #[derive(Debug, Clone, Copy)]
 #[allow(
     dead_code,
-    reason = "Unsupported variant is only constructed on non-macOS/Linux targets; the cfg-gated daemon_unit_status uses the same enum across all targets so the variant is unreachable on macOS/Linux but still part of the type"
+    reason = "Unsupported and ProbeFailed variants are only constructed on a subset of targets; the cfg-gated daemon_unit_status uses the same enum across all targets so some variants are unreachable per-platform but still part of the type"
 )]
 enum UnitState {
     Running,
     InstalledStopped,
     NotInstalled,
+    /// The service-manager probe itself errored (e.g. `launchctl` /
+    /// `systemctl` could not be executed) — distinct from a clean
+    /// "not installed" answer.
+    ProbeFailed,
     Unsupported,
 }
 
@@ -127,7 +136,7 @@ fn daemon_unit_status() -> UnitState {
         Ok(crate::platform::UnitStatus::Running) => UnitState::Running,
         Ok(crate::platform::UnitStatus::InstalledStopped) => UnitState::InstalledStopped,
         Ok(crate::platform::UnitStatus::NotInstalled) => UnitState::NotInstalled,
-        Err(_) => UnitState::NotInstalled,
+        Err(_) => UnitState::ProbeFailed,
     }
 }
 
@@ -137,7 +146,7 @@ fn daemon_unit_status() -> UnitState {
         Ok(crate::platform::UnitStatus::Running) => UnitState::Running,
         Ok(crate::platform::UnitStatus::InstalledStopped) => UnitState::InstalledStopped,
         Ok(crate::platform::UnitStatus::NotInstalled) => UnitState::NotInstalled,
-        Err(_) => UnitState::NotInstalled,
+        Err(_) => UnitState::ProbeFailed,
     }
 }
 

--- a/src/commands/tags.rs
+++ b/src/commands/tags.rs
@@ -12,8 +12,16 @@ use crate::core::vault_sync;
 /// Manage tags on a page: list, add, or remove.
 ///
 /// Tags live in the `tags` table — no OCC, no page version bump.
-/// Without `--add` or `--remove`, prints current tags one per line.
-pub fn run(db: &Connection, slug: &str, add: &[String], remove: &[String]) -> Result<()> {
+/// Without `--add` or `--remove`, prints current tags one per line
+/// (or, with `--json`, the resulting tag list as a JSON array in
+/// every mode).
+pub fn run(
+    db: &Connection,
+    slug: &str,
+    add: &[String],
+    remove: &[String],
+    json: bool,
+) -> Result<()> {
     let resolved = vault_sync::resolve_slug_for_op(db, slug, OpKind::WriteUpdate)
         .map_err(|err| anyhow::anyhow!(err.to_string()))?;
     if !add.is_empty() || !remove.is_empty() {
@@ -36,7 +44,10 @@ pub fn run(db: &Connection, slug: &str, add: &[String], remove: &[String]) -> Re
         )?;
     }
 
-    if add.is_empty() && remove.is_empty() {
+    if json {
+        let tags = list_tags(db, page_id)?;
+        println!("{}", serde_json::to_string_pretty(&tags)?);
+    } else if add.is_empty() && remove.is_empty() {
         let tags = list_tags(db, page_id)?;
         for tag in &tags {
             println!("{tag}");
@@ -104,7 +115,7 @@ mod tests {
         let conn = open_test_db();
         insert_page(&conn, "people/alice");
 
-        run(&conn, "people/alice", &["investor".into()], &[]).unwrap();
+        run(&conn, "people/alice", &["investor".into()], &[], false).unwrap();
 
         let page_id = resolve_page_id(&conn, 1, "people/alice").unwrap();
         let tags = list_tags(&conn, page_id).unwrap();
@@ -116,8 +127,8 @@ mod tests {
         let conn = open_test_db();
         insert_page(&conn, "people/alice");
 
-        run(&conn, "people/alice", &["investor".into()], &[]).unwrap();
-        run(&conn, "people/alice", &["investor".into()], &[]).unwrap();
+        run(&conn, "people/alice", &["investor".into()], &[], false).unwrap();
+        run(&conn, "people/alice", &["investor".into()], &[], false).unwrap();
 
         let page_id = resolve_page_id(&conn, 1, "people/alice").unwrap();
         let tags = list_tags(&conn, page_id).unwrap();
@@ -134,9 +145,10 @@ mod tests {
             "people/alice",
             &["investor".into(), "founder".into()],
             &[],
+            false,
         )
         .unwrap();
-        run(&conn, "people/alice", &[], &["investor".into()]).unwrap();
+        run(&conn, "people/alice", &[], &["investor".into()], false).unwrap();
 
         let page_id = resolve_page_id(&conn, 1, "people/alice").unwrap();
         let tags = list_tags(&conn, page_id).unwrap();
@@ -148,7 +160,7 @@ mod tests {
         let conn = open_test_db();
         insert_page(&conn, "people/alice");
 
-        let result = run(&conn, "people/alice", &[], &["ghost".into()]);
+        let result = run(&conn, "people/alice", &[], &["ghost".into()], false);
         assert!(result.is_ok());
     }
 
@@ -156,7 +168,7 @@ mod tests {
     fn tags_on_nonexistent_page_returns_error() {
         let conn = open_test_db();
 
-        let result = run(&conn, "people/nobody", &["tag".into()], &[]);
+        let result = run(&conn, "people/nobody", &["tag".into()], &[], false);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("page not found"));
     }
@@ -174,7 +186,7 @@ mod tests {
             )
             .unwrap();
 
-        run(&conn, "people/alice", &["investor".into()], &[]).unwrap();
+        run(&conn, "people/alice", &["investor".into()], &[], false).unwrap();
 
         let version_after: i64 = conn
             .query_row(
@@ -197,6 +209,7 @@ mod tests {
             "people/alice",
             &["zebra".into(), "alpha".into(), "mid".into()],
             &[],
+            false,
         )
         .unwrap();
 
@@ -215,7 +228,7 @@ mod tests {
         )
         .unwrap();
 
-        let error = run(&conn, "people/alice", &["investor".into()], &[]).unwrap_err();
+        let error = run(&conn, "people/alice", &["investor".into()], &[], false).unwrap_err();
 
         assert!(error.to_string().contains("CollectionRestoringError"));
     }

--- a/src/commands/timeline.rs
+++ b/src/commands/timeline.rs
@@ -107,6 +107,7 @@ pub fn add(
     summary: &str,
     source: Option<String>,
     detail: Option<String>,
+    json: bool,
 ) -> Result<()> {
     let resolved = vault_sync::resolve_slug_for_op(db, slug, OpKind::WriteUpdate)
         .map_err(|err| anyhow::anyhow!(err.to_string()))?;
@@ -143,7 +144,18 @@ pub fn add(
         ],
     )?;
 
-    println!("Added timeline entry for {canonical_slug}");
+    if json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "status": "added",
+                "slug": canonical_slug,
+                "date": date,
+            })
+        );
+    } else {
+        println!("Added timeline entry for {canonical_slug}");
+    }
     Ok(())
 }
 
@@ -229,7 +241,16 @@ mod tests {
         )
         .unwrap();
 
-        let error = add(&conn, "notes/alice", "2026-04-22", "blocked", None, None).unwrap_err();
+        let error = add(
+            &conn,
+            "notes/alice",
+            "2026-04-22",
+            "blocked",
+            None,
+            None,
+            false,
+        )
+        .unwrap_err();
 
         assert!(error.to_string().contains("CollectionRestoringError"));
     }
@@ -262,6 +283,7 @@ mod tests {
             "something happened",
             None,
             None,
+            false,
         )
         .expect("add entry");
         run(&conn, "notes/structured", 10, false).expect("run with structured entry");
@@ -279,6 +301,7 @@ mod tests {
             "event text",
             Some("src".to_owned()),
             Some("some detail".to_owned()),
+            false,
         )
         .expect("add entry");
         run(&conn, "notes/structured-json", 10, true).expect("run json with structured entry");
@@ -310,6 +333,7 @@ mod tests {
             "something",
             Some("test-src".to_owned()),
             Some("some detail".to_owned()),
+            false,
         )
         .expect("add with source and detail");
         let count: i64 = conn

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -1043,10 +1043,34 @@ fn read_existing_schema_version(conn: &Connection) -> Result<Option<i64>, DbErro
 }
 
 fn format_schema_reinit_message(schema_version: i64, path: &str) -> String {
-    let default_path = default_db_path_string();
+    let header = format!(
+        "Error: database schema version mismatch.\n  Found version {schema_version}, expected {SCHEMA_VERSION}.\n  Database: {path}"
+    );
+
+    if schema_version > SCHEMA_VERSION {
+        // Newer-than-current: the data is fine, this binary is just too old.
+        return format!(
+            "{header}\n  This database was created by a NEWER quaid release than this binary supports.\n  Upgrade the quaid binary to a release that supports schema version {schema_version}.\n  Do NOT run `quaid init` against this database, and back up the file before any downgrade attempt."
+        );
+    }
+
+    let provenance = if schema_version == 0 {
+        // True legacy era: no readable schema version in either the
+        // `quaid_config` or the legacy `config` table.
+        "This file has no readable schema version: it was created by a legacy release predating versioned Quaid configs, or it is not a Quaid database.".to_owned()
+    } else {
+        let release_hint = if schema_version == 9 {
+            " (schema version 9 shipped with quaid v0.20.x-v0.21.x)"
+        } else {
+            ""
+        };
+        format!(
+            "This database was created by an older quaid release{release_hint}. This binary does not migrate older schemas automatically."
+        )
+    };
+
     format!(
-        "Error: database schema version mismatch.\n  Found version {}, expected {}.\n  Existing databases created before the Quaid rename are not supported.\n  To migrate: export your data with the pre-rename binary, then re-ingest the exported markdown with the current workflow.\n    quaid init {}\n    quaid collection add migrated <export-directory>\n    # or ingest files individually with `quaid ingest`\n  Original database: {}",
-        schema_version, SCHEMA_VERSION, default_path, path
+        "{header}\n  {provenance}\n  To migrate without losing data:\n    1. BACK UP / move the old database out of the way first:\n         mv {path} {path}.bak\n       (`quaid init` refuses to run while the old file sits at this path)\n    2. Re-create the store:        quaid init {path}\n    3. If you still have a matching older quaid release, `quaid export` your data\n       with it, then re-ingest the exported markdown:\n         quaid collection add migrated <export-directory>\n         # or ingest files individually with `quaid ingest`"
     )
 }
 

--- a/src/core/gaps.rs
+++ b/src/core/gaps.rs
@@ -1,7 +1,7 @@
 //! Knowledge-gap log: records queries the brain couldn't answer (keyed by
 //! SHA-256 for idempotent inserts), lists unresolved entries, and links them
-//! to pages that later answered them. Provides the data behind `quaid gap`,
-//! `quaid gaps`, and the matching MCP tools.
+//! to pages that later answered them. Provides the data behind `quaid gaps`
+//! and the `memory_gap` / `memory_gaps` MCP tools.
 //!
 //! See also: `types::KnowledgeGap` for the row shape, and `search` for the
 //! query path that detects low-confidence retrievals.

--- a/src/core/migrate.rs
+++ b/src/core/migrate.rs
@@ -25,6 +25,61 @@ pub fn export_dir(db: &Connection, output_path: &Path) -> Result<usize> {
     Ok(pages.len())
 }
 
+/// Export byte-exact raw source payloads from the `raw_imports` table.
+///
+/// With `import_id = None`, writes the **active** raw payload of every page
+/// that has one to `<output>/<slug>.md`; pages without a captured raw source
+/// are skipped (use the normalized [`export_dir`] for those). With
+/// `import_id = Some(_)`, restores exactly the one historical payload whose
+/// `raw_imports.import_id` matches, erroring when no such row exists.
+/// Returns the number of files written.
+pub fn export_raw_dir(
+    db: &Connection,
+    output_path: &Path,
+    import_id: Option<&str>,
+) -> Result<usize> {
+    let mut stmt = match import_id {
+        Some(_) => db.prepare(
+            "SELECT p.slug, r.raw_bytes \
+             FROM raw_imports r \
+             JOIN pages p ON p.id = r.page_id \
+             WHERE r.import_id = ?1 \
+             ORDER BY p.slug",
+        )?,
+        None => db.prepare(
+            "SELECT p.slug, r.raw_bytes \
+             FROM raw_imports r \
+             JOIN pages p ON p.id = r.page_id \
+             WHERE r.is_active = 1 \
+             ORDER BY p.slug",
+        )?,
+    };
+    let params: Vec<&dyn rusqlite::types::ToSql> = match &import_id {
+        Some(id) => vec![id],
+        None => Vec::new(),
+    };
+    let rows = stmt.query_map(params.as_slice(), |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, Vec<u8>>(1)?))
+    })?;
+
+    let mut written = 0_usize;
+    for row in rows {
+        let (slug, raw_bytes) = row?;
+        let file_path = output_path.join(format!("{slug}.md"));
+        if let Some(parent) = file_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(&file_path, &raw_bytes)?;
+        written += 1;
+    }
+
+    if let Some(id) = import_id {
+        anyhow::ensure!(written > 0, "raw import not found: {id}");
+    }
+
+    Ok(written)
+}
+
 /// Validate round-trip fidelity: export then re-parse and compare.
 /// Used only in tests.
 #[cfg(test)]

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -722,10 +722,13 @@ impl FromStr for ExtractionJobStatus {
 // ── Errors ────────────────────────────────────────────────────
 
 /// Optimistic concurrency control error.
+///
+/// The `ConflictError: ` prefix is the canonical spelling for every
+/// conflict surfaced over JSON-RPC (`-32009`); see `src/mcp/errors.rs`.
 #[derive(Debug, Error)]
 pub enum OccError {
     /// The page was updated by another writer since the caller last read it.
-    #[error("conflict: page updated elsewhere (current version: {current_version})")]
+    #[error("ConflictError: page updated elsewhere (current version: {current_version})")]
     Conflict {
         /// Version currently persisted in the database.
         current_version: i64,

--- a/src/core/vault_sync/error.rs
+++ b/src/core/vault_sync/error.rs
@@ -132,6 +132,12 @@ pub enum VaultSyncError {
     #[error(transparent)]
     Conflict(#[from] ConflictError),
 
+    /// Surfaces an optimistic-concurrency conflict from the page write
+    /// path itself (the compare-and-swap UPDATE matched zero rows).
+    /// Cross-platform, unlike the unix-only vault [`ConflictError`].
+    #[error(transparent)]
+    Occ(#[from] crate::core::types::OccError),
+
     /// Surfaces a watcher-thread failure (initialisation, crash,
     /// channel exhaustion).
     #[cfg(unix)]

--- a/src/core/vault_sync/restore.rs
+++ b/src/core/vault_sync/restore.rs
@@ -430,7 +430,7 @@ pub enum ConflictError {
     /// incremented the version between the caller's read and the
     /// commit attempt.
     #[error(
-        "Conflict: ConflictError StaleExpectedVersion collection_id={collection_id} relative_path={relative_path} expected_version={expected_version} current version: {current_version}"
+        "ConflictError: collection_id={collection_id} relative_path={relative_path} reason=StaleExpectedVersion expected_version={expected_version} current version: {current_version}"
     )]
     StaleExpectedVersion {
         /// Collection id the conflicting row belongs to.

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,9 +119,13 @@ enum Commands {
     /// Export memory to markdown directory
     Export {
         path: String,
+        /// Export byte-exact raw source payloads (from `raw_imports`)
+        /// instead of normalized rendered markdown
         #[arg(long)]
         raw: bool,
-        #[arg(long)]
+        /// Restore a single raw payload by its `raw_imports` import id
+        /// (requires --raw)
+        #[arg(long, requires = "raw")]
         import_id: Option<String>,
     },
     /// Control conversation extraction runtime state
@@ -140,8 +144,10 @@ enum Commands {
     Embed {
         /// Embed a single page by slug
         slug: Option<String>,
+        /// Force re-embed every page, even when chunk hashes are unchanged
         #[arg(long)]
         all: bool,
+        /// Re-embed only pages whose chunk hashes drifted from the index
         #[arg(long)]
         stale: bool,
         /// Maximum number of pages to scan per batch for bulk embedding
@@ -277,8 +283,9 @@ enum Commands {
         /// Non-loopback binds are refused in v1; requires `--http`.
         #[arg(long, requires = "http")]
         bind: Option<std::net::IpAddr>,
-        /// Path to a bearer-token file. Parsed and validated but not
-        /// enforced in v1 (see HTTP transport docs); requires `--http`.
+        /// Path to a bearer-token file. Bearer auth is not yet enforced,
+        /// so supplying this flag is refused (fail-closed) rather than
+        /// silently ignored; requires `--http`.
         #[arg(long, requires = "http")]
         token_file: Option<std::path::PathBuf>,
         /// Treat the loopback interface as trusted and allow unauthenticated
@@ -382,7 +389,7 @@ async fn main() -> Result<()> {
             slug,
             namespace,
             expected_version,
-        } => commands::put::run(&db, &slug, namespace.as_deref(), expected_version),
+        } => commands::put::run(&db, &slug, namespace.as_deref(), expected_version, cli.json),
         Commands::List {
             wing,
             r#type,
@@ -439,41 +446,53 @@ async fn main() -> Result<()> {
             )
             .await
         }
-        Commands::Ingest { path, force } => commands::ingest::run(&db, &path, force),
+        Commands::Ingest { path, force } => {
+            commands::ingest::run_with_output(&db, &path, force, cli.json)
+        }
         Commands::Export {
             path,
             raw,
             import_id,
-        } => commands::export::run(&db, &path, raw, import_id),
+        } => commands::export::run(&db, &path, raw, import_id, cli.json),
         Commands::Extraction { action } => commands::extraction::run(&db, action),
-        Commands::Extract(args) => commands::extract::run(&db, args),
+        Commands::Extract(args) => commands::extract::run(&db, args, cli.json),
         Commands::Embed {
             slug,
             all,
             stale,
             batch_size,
-        } => commands::embed::run_with_batch(&db, slug, all, stale, batch_size),
+        } => commands::embed::run_with_batch(&db, slug, all, stale, batch_size, cli.json),
         Commands::Link {
             from,
             to,
             relationship,
             valid_from,
             valid_until,
-        } => commands::link::run(&db, &from, &to, &relationship, valid_from, valid_until),
+        } => commands::link::run(
+            &db,
+            &from,
+            &to,
+            &relationship,
+            valid_from,
+            valid_until,
+            cli.json,
+        ),
         Commands::LinkClose {
             link_id,
             valid_until,
-        } => commands::link::close(&db, link_id, &valid_until),
+        } => commands::link::close(&db, link_id, &valid_until, cli.json),
         Commands::Links { slug, temporal } => commands::link::links(&db, &slug, temporal, cli.json),
         Commands::Unlink {
             from,
             to,
             relationship,
-        } => commands::link::unlink(&db, &from, &to, relationship),
+        } => commands::link::unlink(&db, &from, &to, relationship, cli.json),
         Commands::Backlinks { slug, temporal } => {
             commands::link::backlinks(&db, &slug, temporal, cli.json)
         }
-        Commands::Tags { slug, add, remove } => commands::tags::run(&db, &slug, &add, &remove),
+        Commands::Tags { slug, add, remove } => {
+            commands::tags::run(&db, &slug, &add, &remove, cli.json)
+        }
         Commands::Timeline { slug, limit } => commands::timeline::run(&db, &slug, limit, cli.json),
         Commands::TimelineAdd {
             slug,
@@ -481,16 +500,16 @@ async fn main() -> Result<()> {
             summary,
             source,
             detail,
-        } => commands::timeline::add(&db, &slug, &date, &summary, source, detail),
+        } => commands::timeline::add(&db, &slug, &date, &summary, source, detail, cli.json),
         Commands::Graph(args) => commands::graph::run_cli(&db, args, cli.json),
         Commands::Check { slug, all, r#type } => {
             commands::check::run(&db, slug, all, r#type, cli.json)
         }
         Commands::Gaps { limit, resolved } => commands::gaps::run(&db, limit, resolved, cli.json),
-        Commands::Compact => commands::compact::run(&db),
+        Commands::Compact => commands::compact::run(&db, cli.json),
         Commands::Collection { action } => commands::collection::run(&db, action, cli.json),
         Commands::Namespace { action } => commands::namespace::run(&db, action, cli.json),
-        Commands::Config { action } => commands::config::run(&db, action),
+        Commands::Config { action } => commands::config::run(&db, action, cli.json),
         Commands::Validate {
             all,
             links,
@@ -527,7 +546,8 @@ async fn main() -> Result<()> {
             Ok(())
         }
         Commands::Status { json } => {
-            let code = commands::status::run(&db, json)?;
+            // Honour both spellings: `quaid --json status` and `quaid status --json`.
+            let code = commands::status::run(&db, json || cli.json)?;
             if code != 0 {
                 std::process::exit(i32::from(code));
             }

--- a/src/mcp/errors.rs
+++ b/src/mcp/errors.rs
@@ -94,7 +94,7 @@ pub fn map_db_error(e: SqliteError) -> rmcp::Error {
             return rmcp::Error::new(
                 ErrorCode(-32009),
                 format!(
-                    "conflict: {}",
+                    "ConflictError: {}",
                     msg.as_deref().unwrap_or("unique constraint violation")
                 ),
                 None,
@@ -237,6 +237,7 @@ pub fn map_vault_sync_error(e: vault_sync::VaultSyncError) -> rmcp::Error {
         | vault_sync::VaultSyncError::Conflict(vault_sync::ConflictError::ConcurrentRename {
             ..
         }) => ErrorCode(-32009),
+        vault_sync::VaultSyncError::Occ(_) => ErrorCode(-32009),
         _ => ErrorCode(-32003),
     };
     rmcp::Error::new(code, e.to_string(), None)

--- a/src/mcp/http.rs
+++ b/src/mcp/http.rs
@@ -63,8 +63,9 @@ pub struct HttpConfig {
     /// Bind address. Loopback (`127.0.0.1`/`::1`) is the default; any
     /// other value is refused in v1 (see module docs).
     pub bind: IpAddr,
-    /// Optional path to a bearer token file. Currently parsed and
-    /// validated but not enforced — see v1 known limitations.
+    /// Optional path to a bearer token file. Bearer-auth enforcement is
+    /// not implemented in v1, so [`bind_with_token_guard`] refuses any
+    /// config that sets this (fail-closed; never a silent no-op).
     pub token_file: Option<PathBuf>,
     /// When `true`, loopback binds are unauthenticated (stdio-equivalent
     /// security profile). When `false`, loopback requires a token —

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -526,6 +526,20 @@ impl QuaidServer {
         memory_namespace_create,
         memory_namespace_destroy,
     } tool_box);
+
+    /// Names of every tool exposed by the MCP `tool_box!` registry above.
+    ///
+    /// The macro-generated `tool_box()` accessor is private, so this is the
+    /// public introspection point for consumers that must stay in lockstep
+    /// with the wire surface (e.g. the `quaid call`/`quaid pipe` dispatcher
+    /// parity check in `tests/cli_call_dispatch_parity.rs`).
+    pub fn registered_tool_names() -> Vec<String> {
+        Self::tool_box()
+            .list()
+            .into_iter()
+            .map(|tool| tool.name.to_string())
+            .collect()
+    }
 }
 
 #[tool(tool_box)]

--- a/src/mcp/tools/pages.rs
+++ b/src/mcp/tools/pages.rs
@@ -118,14 +118,14 @@ impl QuaidServer {
         match (existing_version, input.expected_version) {
             (None, Some(expected)) => {
                 return Err(conflict_error(
-                    format!("conflict: page does not exist at version {expected}"),
+                    format!("ConflictError: page does not exist at version {expected}"),
                     Some(serde_json::json!({ "current_version": null })),
                 ));
             }
             (Some(current), None) => {
                 return Err(conflict_error(
                     format!(
-                        "conflict: page already exists (current version: {current}). Provide expected_version to update."
+                        "ConflictError: page already exists (current version: {current}). Provide expected_version to update."
                     ),
                     Some(serde_json::json!({ "current_version": current })),
                 ));
@@ -141,9 +141,12 @@ impl QuaidServer {
         )
         .map_err(|err| {
             let message = err.to_string();
-            if message.contains("Conflict:") {
+            // Normalise the canonical (`ConflictError: `) and legacy
+            // (`Conflict: `) spellings onto the single `ConflictError: `
+            // prefix used for every -32009 response.
+            if message.contains("ConflictError") || message.contains("Conflict:") {
                 conflict_error(
-                    message.replace("Conflict: ", "conflict: "),
+                    message.replace("Conflict: ", "ConflictError: "),
                     Some(serde_json::json!({ "current_version": existing_version })),
                 )
             } else {

--- a/tests/cli_call_dispatch_parity.rs
+++ b/tests/cli_call_dispatch_parity.rs
@@ -1,0 +1,82 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    reason = "test fixtures legitimately panic on setup failure; per-site #[expect] would add noise"
+)]
+
+//! CLI ↔ MCP surface parity: `quaid call` / `quaid pipe` route through
+//! `commands::call::dispatch_tool`, which keeps its own match over tool
+//! names. This test guarantees the dispatcher accepts every tool that the
+//! MCP `tool_box!` registry exposes, so the CLI can never silently lag the
+//! wire surface again (issue: `memory_correct` / `memory_correct_continue`
+//! hit the "unknown tool" fallthrough while being listed by `tools/list`).
+
+use quaid::commands::call::dispatch_tool;
+use quaid::core::{db, inference::default_model};
+use quaid::mcp::server::QuaidServer;
+use serde_json::json;
+
+#[test]
+fn dispatch_tool_accepts_every_registered_mcp_tool() {
+    let names = QuaidServer::registered_tool_names();
+    assert!(
+        names.len() >= 24,
+        "expected at least the 24 known tools, got {}: {names:?}",
+        names.len()
+    );
+
+    let conn = db::init(":memory:", &default_model()).expect("init in-memory db");
+    let server = QuaidServer::new(conn);
+
+    for name in &names {
+        // Probe with empty params: tools either succeed or fail on params /
+        // domain validation. The only unacceptable outcome is the dispatcher
+        // not knowing the tool at all.
+        match dispatch_tool(&server, name, json!({})) {
+            Ok(_) => {}
+            Err(message) => {
+                assert!(
+                    !message.contains("unknown tool"),
+                    "tool `{name}` is exposed by the MCP registry but is not \
+                     dispatchable via `quaid call`/`quaid pipe`: {message}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn dispatch_tool_routes_correction_tools_past_unknown_tool_fallthrough() {
+    let conn = db::init(":memory:", &default_model()).expect("init in-memory db");
+    let server = QuaidServer::new(conn);
+
+    // Minimal valid-shaped params; both calls fail in the domain layer
+    // (page / correction session does not exist), proving the arm routed
+    // into the handler instead of the "unknown tool" fallthrough.
+    let correct = dispatch_tool(
+        &server,
+        "memory_correct",
+        json!({"fact_slug": "facts/none", "correction": "value is wrong"}),
+    )
+    .expect_err("nonexistent fact page must error in the handler");
+    assert!(!correct.contains("unknown tool"), "got: {correct}");
+
+    let cont = dispatch_tool(
+        &server,
+        "memory_correct_continue",
+        json!({"correction_id": "no-such-correction"}),
+    )
+    .expect_err("nonexistent correction session must error in the handler");
+    assert!(!cont.contains("unknown tool"), "got: {cont}");
+}
+
+#[test]
+fn dispatch_tool_still_rejects_truly_unknown_tools() {
+    let conn = db::init(":memory:", &default_model()).expect("init in-memory db");
+    let server = QuaidServer::new(conn);
+
+    let err = dispatch_tool(&server, "memory_does_not_exist", json!({}))
+        .expect_err("unknown tool must return Err");
+    assert!(err.contains("unknown tool"));
+}

--- a/tests/cli_embed_batching.rs
+++ b/tests/cli_embed_batching.rs
@@ -35,7 +35,7 @@ fn insert_page(conn: &Connection, slug: &str) {
 #[test]
 fn run_with_batch_rejects_zero_batch_size_before_embedding() {
     let conn = open_test_db();
-    let error = run_with_batch(&conn, None, true, false, Some(0)).unwrap_err();
+    let error = run_with_batch(&conn, None, true, false, Some(0), false).unwrap_err();
     assert!(error.to_string().contains("batch-size"));
 }
 
@@ -46,15 +46,53 @@ fn run_with_batch_embeds_all_pages_and_rerun_is_idempotent() {
         insert_page(&conn, &format!("notes/page-{index:02}"));
     }
 
-    run_with_batch(&conn, None, true, false, Some(5)).unwrap();
+    run_with_batch(&conn, None, true, false, Some(5), false).unwrap();
     let first_count: i64 = conn
         .query_row("SELECT COUNT(*) FROM page_embeddings", [], |row| row.get(0))
         .unwrap();
     assert_eq!(first_count, 12);
 
-    run_with_batch(&conn, None, true, false, Some(5)).unwrap();
+    run_with_batch(&conn, None, true, false, Some(5), false).unwrap();
     let second_count: i64 = conn
         .query_row("SELECT COUNT(*) FROM page_embeddings", [], |row| row.get(0))
         .unwrap();
     assert_eq!(second_count, first_count);
+}
+
+/// `--stale` keeps the hash-based skip; `--all` bypasses it. Tampering with
+/// stored `chunk_text` while leaving `content_hash` intact is invisible to
+/// the stale check, so only a forced `--all` run repairs the row.
+#[test]
+fn run_with_batch_all_forces_re_embed_while_stale_skips() {
+    let conn = open_test_db();
+    insert_page(&conn, "notes/force-target");
+
+    run_with_batch(&conn, None, true, false, Some(5), false).unwrap();
+    conn.execute("UPDATE page_embeddings SET chunk_text = 'tampered'", [])
+        .unwrap();
+
+    // --stale: hashes match, page is skipped, the tampered row survives.
+    run_with_batch(&conn, None, false, true, Some(5), false).unwrap();
+    let after_stale: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM page_embeddings WHERE chunk_text = 'tampered'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(after_stale, 1, "--stale must skip hash-unchanged pages");
+
+    // --all: force re-embed rewrites the chunk row from the page content.
+    run_with_batch(&conn, None, true, false, Some(5), false).unwrap();
+    let after_all: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM page_embeddings WHERE chunk_text = 'tampered'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        after_all, 0,
+        "--all must bypass the page_needs_refresh skip"
+    );
 }

--- a/tests/cli_json_flag.rs
+++ b/tests/cli_json_flag.rs
@@ -1,0 +1,183 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::print_stdout,
+    reason = "test fixtures legitimately panic on setup failure and inspect subprocess output"
+)]
+
+//! Subprocess tests asserting the global `--json` flag is honoured by
+//! dispatch arms that historically ignored it (`put`, `tags`) and that
+//! `quaid --json status` matches `quaid status --json` (the global and
+//! local flags are OR-ed).
+
+mod common;
+#[path = "common/subprocess.rs"]
+mod common_subprocess;
+
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Output, Stdio};
+
+use quaid::core::db;
+use serde_json::Value;
+
+struct Fixture {
+    _dir: tempfile::TempDir,
+    home_dir: PathBuf,
+    db_path: PathBuf,
+}
+
+fn fixture_with_writable_vault() -> Fixture {
+    let dir = tempfile::TempDir::new().unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o700)).unwrap();
+    }
+    let home_dir = dir.path().join("home");
+    fs::create_dir_all(&home_dir).unwrap();
+    let db_path = fs::canonicalize(dir.path()).unwrap().join("memory.db");
+    let conn = db::open(db_path.to_str().unwrap()).unwrap();
+    let vault_root = dir.path().join("vault");
+    fs::create_dir_all(&vault_root).unwrap();
+    conn.execute(
+        "UPDATE collections
+         SET root_path = ?1,
+             writable = 1,
+             is_write_target = 1,
+             state = 'active',
+             needs_full_sync = 0
+         WHERE id = 1",
+        [fs::canonicalize(&vault_root).unwrap().display().to_string()],
+    )
+    .unwrap();
+    drop(conn);
+    Fixture {
+        _dir: dir,
+        home_dir,
+        db_path,
+    }
+}
+
+fn quaid_command(fixture: &Fixture) -> Command {
+    let mut command = Command::new(common::quaid_bin());
+    common_subprocess::configure_test_command(&mut command);
+    command
+        .env("HOME", &fixture.home_dir)
+        .env("USERPROFILE", &fixture.home_dir)
+        .arg("--db")
+        .arg(&fixture.db_path);
+    command
+}
+
+fn run_quaid(fixture: &Fixture, args: &[&str]) -> Output {
+    quaid_command(fixture)
+        .args(args)
+        .output()
+        .expect("run quaid")
+}
+
+fn run_quaid_with_stdin(fixture: &Fixture, args: &[&str], stdin: &str) -> Output {
+    let mut child = quaid_command(fixture)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn quaid");
+    child
+        .stdin
+        .as_mut()
+        .expect("piped stdin")
+        .write_all(stdin.as_bytes())
+        .expect("write stdin");
+    child.wait_with_output().expect("wait for quaid")
+}
+
+fn stdout_json(output: &Output) -> Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(stdout.trim()).unwrap_or_else(|error| {
+        panic!(
+            "stdout must be valid JSON, got error {error}\nstdout: {stdout}\nstderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    })
+}
+
+fn seed_page(fixture: &Fixture, slug: &str) {
+    let output = run_quaid_with_stdin(
+        fixture,
+        &["put", slug],
+        "---\ntitle: Json Flag\ntype: concept\n---\nContent.\n",
+    );
+    assert!(
+        output.status.success(),
+        "seed put failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn global_json_flag_makes_put_emit_json() {
+    let fixture = fixture_with_writable_vault();
+
+    let output = run_quaid_with_stdin(
+        &fixture,
+        &["--json", "put", "notes/json-put"],
+        "---\ntitle: Json Put\ntype: concept\n---\nBody.\n",
+    );
+
+    assert!(
+        output.status.success(),
+        "put failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let payload = stdout_json(&output);
+    let result = payload["result"].as_str().expect("result string");
+    assert!(result.contains("notes/json-put"), "got: {result}");
+    assert!(result.contains("version 1"), "got: {result}");
+}
+
+#[cfg(unix)]
+#[test]
+fn global_json_flag_makes_tags_emit_json_array() {
+    let fixture = fixture_with_writable_vault();
+    seed_page(&fixture, "notes/json-tags");
+
+    let mutate = run_quaid(
+        &fixture,
+        &["--json", "tags", "notes/json-tags", "--add", "alpha"],
+    );
+    assert!(
+        mutate.status.success(),
+        "tags --add failed: {}",
+        String::from_utf8_lossy(&mutate.stderr)
+    );
+    let mutated = stdout_json(&mutate);
+    assert_eq!(mutated, serde_json::json!(["alpha"]));
+
+    let list = run_quaid(&fixture, &["--json", "tags", "notes/json-tags"]);
+    assert!(list.status.success());
+    assert_eq!(stdout_json(&list), serde_json::json!(["alpha"]));
+}
+
+#[test]
+fn global_json_flag_matches_local_status_json_flag() {
+    let fixture = fixture_with_writable_vault();
+
+    let global = run_quaid(&fixture, &["--json", "status"]);
+    let local = run_quaid(&fixture, &["status", "--json"]);
+
+    assert_eq!(global.status.code(), local.status.code());
+    let global_payload = stdout_json(&global);
+    let local_payload = stdout_json(&local);
+    assert!(global_payload["daemon"].is_object());
+    assert_eq!(
+        global_payload["daemon"]["installed"],
+        local_payload["daemon"]["installed"]
+    );
+    assert_eq!(global_payload["database"], local_payload["database"]);
+}

--- a/tests/cli_put_source_invariants.rs
+++ b/tests/cli_put_source_invariants.rs
@@ -59,14 +59,13 @@ fn cli_put_source_routes_live_owner_through_ipc_without_direct_fallback() {
     );
     assert!(
         cli_source.contains(
-            "proxy_put_via_live_serve(&endpoint, &canonical_slug, content, expected_version)?;"
+            "proxy_put_via_live_serve(&endpoint, &canonical_slug, content, expected_version)"
         ),
         "live owner branch must proxy through IPC"
     );
-    let return_idx = cli_source[proxy_idx..]
-        .find("return Ok(());")
-        .map(|offset| proxy_idx + offset)
-        .expect("live owner branch returns immediately after proxy");
+    let return_idx = cli_source
+        .find("return proxy_put_via_live_serve(")
+        .expect("live owner branch returns immediately via the proxy call");
     assert!(
         return_idx < direct_idx,
         "live owner branch must return after IPC proxy instead of falling back to direct write"

--- a/tests/conflict_error_prefix.rs
+++ b/tests/conflict_error_prefix.rs
@@ -1,0 +1,136 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    reason = "test fixtures legitimately panic on setup failure; per-site #[expect] would add noise"
+)]
+
+//! Conflict-message unification: every `-32009` conflict surfaced by the
+//! MCP layer and every optimistic-concurrency failure raised by the write
+//! path must carry the single canonical `ConflictError: ` prefix (the
+//! legacy spellings were `conflict: `, `Conflict: `, and a smuggled
+//! `rusqlite::Error::InvalidParameterName`).
+
+#[path = "common/mcp_harness.rs"]
+mod harness;
+
+use harness::{create_page, open_test_db};
+use quaid::commands::put::put_from_string;
+use quaid::core::{db, inference::default_model};
+use quaid::mcp::server::{MemoryPutInput, QuaidServer};
+use rmcp::model::ErrorCode;
+
+const CONTENT: &str = "---\ntitle: Conflict Fixture\ntype: concept\n---\nBody.\n";
+
+#[test]
+fn memory_put_existing_page_without_expected_version_uses_canonical_prefix() {
+    let (_dir, conn) = open_test_db();
+    let server = QuaidServer::new(conn);
+    create_page(&server, "notes/conflict-a", CONTENT);
+
+    let error = server
+        .memory_put(MemoryPutInput {
+            slug: "notes/conflict-a".to_string(),
+            content: CONTENT.to_string(),
+            expected_version: None,
+            namespace: None,
+        })
+        .unwrap_err();
+
+    assert_eq!(error.code, ErrorCode(-32009));
+    assert!(
+        error.message.starts_with("ConflictError: "),
+        "got: {}",
+        error.message
+    );
+}
+
+#[test]
+fn memory_put_ghost_expected_version_uses_canonical_prefix() {
+    let (_dir, conn) = open_test_db();
+    let server = QuaidServer::new(conn);
+
+    let error = server
+        .memory_put(MemoryPutInput {
+            slug: "notes/conflict-ghost".to_string(),
+            content: CONTENT.to_string(),
+            expected_version: Some(3),
+            namespace: None,
+        })
+        .unwrap_err();
+
+    assert_eq!(error.code, ErrorCode(-32009));
+    assert!(
+        error.message.starts_with("ConflictError: "),
+        "got: {}",
+        error.message
+    );
+}
+
+#[test]
+fn memory_put_stale_expected_version_uses_canonical_prefix() {
+    let (_dir, conn) = open_test_db();
+    let server = QuaidServer::new(conn);
+    create_page(&server, "notes/conflict-stale", CONTENT);
+
+    let error = server
+        .memory_put(MemoryPutInput {
+            slug: "notes/conflict-stale".to_string(),
+            content: CONTENT.to_string(),
+            expected_version: Some(7),
+            namespace: None,
+        })
+        .unwrap_err();
+
+    assert_eq!(error.code, ErrorCode(-32009));
+    assert!(
+        error.message.starts_with("ConflictError: "),
+        "got: {}",
+        error.message
+    );
+}
+
+/// The CLI write path (file-backed vault) raises its OCC failure through
+/// `vault_sync` — the message must carry the canonical prefix and still
+/// name the current version for caller re-fetch.
+#[test]
+fn cli_put_stale_expected_version_uses_canonical_prefix() {
+    let (_dir, conn) = open_test_db();
+    put_from_string(&conn, "notes/occ", CONTENT, None).unwrap();
+    conn.execute("UPDATE pages SET version = 2 WHERE slug = 'notes/occ'", [])
+        .unwrap();
+
+    let error = put_from_string(&conn, "notes/occ", CONTENT, Some(1)).unwrap_err();
+    let message = error.to_string();
+
+    assert!(message.starts_with("ConflictError: "), "got: {message}");
+    assert!(message.contains("current version: 2"), "got: {message}");
+    assert!(
+        !message.contains("Invalid parameter name"),
+        "rusqlite smuggling resurfaced: {message}"
+    );
+}
+
+/// The in-memory write path skips the vault precondition check and loses
+/// the compare-and-swap inside `stage_page_record` — formerly the
+/// `InvalidParameterName` smuggling site. It must now surface the typed
+/// `OccError` with the canonical prefix.
+#[test]
+fn in_memory_put_cas_failure_uses_typed_occ_error() {
+    let conn = db::init(":memory:", &default_model()).unwrap();
+    put_from_string(&conn, "notes/occ-mem", CONTENT, None).unwrap();
+    conn.execute(
+        "UPDATE pages SET version = 2 WHERE slug = 'notes/occ-mem'",
+        [],
+    )
+    .unwrap();
+
+    let error = put_from_string(&conn, "notes/occ-mem", CONTENT, Some(1)).unwrap_err();
+    let message = error.to_string();
+
+    assert!(
+        message.starts_with("ConflictError: page updated elsewhere"),
+        "got: {message}"
+    );
+    assert!(message.contains("current version: 2"), "got: {message}");
+}

--- a/tests/db_schema_reinit_message.rs
+++ b/tests/db_schema_reinit_message.rs
@@ -1,0 +1,149 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    reason = "test fixtures legitimately panic on setup failure; per-site #[expect] would add noise"
+)]
+
+//! Accuracy tests for the schema-version-mismatch refusal message.
+//!
+//! The previous message claimed every mismatched database was "created
+//! before the Quaid rename" and pointed users at a `quaid init` invocation
+//! that re-fails on the same preflight — a remediation dead-loop. These
+//! tests pin the rewritten message: older-than-current names the v9
+//! release range, newer-than-current says to upgrade the binary, and both
+//! downgrade paths instruct the user to back up / move the old file first.
+
+use quaid::core::db::{open_with_model, QuaidConfig};
+use quaid::core::inference::default_model;
+use rusqlite::Connection;
+use std::path::Path;
+
+/// Seed a database carrying only config tables with the given schema
+/// version — the same fixture shape `quaid` v0.20.x-v0.21.x (v9) or a
+/// future release would leave on disk.
+fn seed_versioned_db(path: &Path, schema_version: i64) {
+    let conn = Connection::open(path).unwrap();
+    conn.execute_batch(
+        "CREATE TABLE quaid_config (
+             key   TEXT PRIMARY KEY NOT NULL,
+             value TEXT NOT NULL
+         ) STRICT;
+         CREATE TABLE config (
+             key   TEXT PRIMARY KEY NOT NULL,
+             value TEXT NOT NULL
+         ) STRICT;",
+    )
+    .unwrap();
+    let model = default_model();
+    quaid::core::db::write_quaid_config(
+        &conn,
+        &QuaidConfig {
+            model_id: model.model_id.clone(),
+            model_alias: model.alias.clone(),
+            embedding_dim: model.embedding_dim,
+            schema_version,
+        },
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO config (key, value) VALUES ('version', ?1)",
+        [schema_version.to_string()],
+    )
+    .unwrap();
+}
+
+#[test]
+fn v9_database_message_names_release_range_and_backup_step() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("legacy-v9.db");
+    seed_versioned_db(&db_path, 9);
+
+    let error = open_with_model(db_path.to_str().unwrap(), &default_model())
+        .expect_err("v9 database must be refused");
+    let message = error.to_string();
+
+    assert!(
+        message.contains("Found version 9, expected 10"),
+        "got: {message}"
+    );
+    // The rename claim was factually wrong for v9 databases — it must be gone.
+    assert!(!message.contains("rename"), "got: {message}");
+    assert!(!message.contains("pre-rename"), "got: {message}");
+    // Older-than-current names the likely release range for v9.
+    assert!(message.contains("v0.20.x-v0.21.x"), "got: {message}");
+    assert!(message.contains("older quaid release"), "got: {message}");
+    // Remediation must start with backing up / moving the old file, since
+    // `quaid init` re-fails on the same preflight at the old path.
+    assert!(message.contains("BACK UP"), "got: {message}");
+    assert!(
+        message.contains(&format!(
+            "mv {} {}.bak",
+            db_path.display(),
+            db_path.display()
+        )),
+        "got: {message}"
+    );
+}
+
+#[test]
+fn newer_schema_database_message_says_upgrade_binary() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("future.db");
+    seed_versioned_db(&db_path, 11);
+
+    let error = open_with_model(db_path.to_str().unwrap(), &default_model())
+        .expect_err("future-schema database must be refused");
+    let message = error.to_string();
+
+    assert!(
+        message.contains("Found version 11, expected 10"),
+        "got: {message}"
+    );
+    assert!(message.contains("NEWER quaid release"), "got: {message}");
+    assert!(
+        message.contains("Upgrade the quaid binary"),
+        "got: {message}"
+    );
+    // The newer-DB path must NOT suggest re-initialising over good data.
+    assert!(
+        message.contains("Do NOT run `quaid init` against this database"),
+        "got: {message}"
+    );
+    assert!(!message.contains("rename"), "got: {message}");
+}
+
+#[test]
+fn versionless_legacy_database_message_describes_legacy_era() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("legacy-versionless.db");
+    // A database holding page content but no readable schema version in
+    // either config table: the true legacy (pre-versioned-config) case.
+    // Built from the current DDL, then stripped of every version marker.
+    let conn = quaid::core::db::open(db_path.to_str().unwrap()).unwrap();
+    conn.execute(
+        "INSERT INTO pages (slug, uuid, type, title)
+         VALUES ('notes/legacy', ?1, 'concept', 'Legacy')",
+        [uuid::Uuid::now_v7().to_string()],
+    )
+    .unwrap();
+    conn.execute("DELETE FROM quaid_config", []).unwrap();
+    conn.execute("DELETE FROM config WHERE key = 'version'", [])
+        .unwrap();
+    drop(conn);
+
+    let error = open_with_model(db_path.to_str().unwrap(), &default_model())
+        .expect_err("versionless database with content must be refused");
+    let message = error.to_string();
+
+    assert!(
+        message.contains("Found version 0, expected 10"),
+        "got: {message}"
+    );
+    assert!(
+        message.contains("no readable schema version"),
+        "got: {message}"
+    );
+    assert!(message.contains("legacy release"), "got: {message}");
+    assert!(message.contains("BACK UP"), "got: {message}");
+}

--- a/tests/entity_extraction.rs
+++ b/tests/entity_extraction.rs
@@ -75,6 +75,32 @@ fn count_entity_pattern_links(conn: &Connection) -> i64 {
     .unwrap()
 }
 
+/// `entities::run_for_page` with a generous extraction deadline.
+///
+/// The production 5 ms budget is load-sensitive: on a saturated CI runner the
+/// first pattern can already blow it, skipping extraction and flaking any
+/// assertion-count expectation. Routing tests pin a deterministic deadline via
+/// the explicit seam; budget behaviour itself is covered by the
+/// `extract_entities` over-budget test.
+fn run_for_page_generous(
+    conn: &Connection,
+    page_id: i64,
+    collection_id: i64,
+    page_slug: &str,
+    compiled_truth: &str,
+    patterns: &[EntityPattern],
+) -> Result<entities::RoutingSummary, entities::EntityError> {
+    entities::run_for_page_with_deadline(
+        conn,
+        page_id,
+        collection_id,
+        page_slug,
+        compiled_truth,
+        patterns,
+        Duration::from_secs(30),
+    )
+}
+
 // ── 6.x: pattern config and validation ────────────────────────
 
 #[test]
@@ -305,7 +331,7 @@ fn budget_overrun_logs_knowledge_gap() {
     assert!(outcome.over_budget);
 
     // Force the wired gap-logging via the helper for budget overrun.
-    let summary = entities::run_for_page(&conn, page_id, 1, "people/alice", "", &[]).unwrap();
+    let summary = run_for_page_generous(&conn, page_id, 1, "people/alice", "", &[]).unwrap();
     assert_eq!(summary.matches_seen, 0);
     let gap_count: i64 = conn
         .query_row("SELECT COUNT(*) FROM knowledge_gaps", [], |row| row.get(0))
@@ -323,7 +349,7 @@ fn match_with_both_resolved_inserts_assertion_no_link() {
     insert_page(&conn, "companies/brex", "Brex", "body");
 
     let patterns = entities::load_patterns_from(None, &conn).unwrap();
-    let summary = entities::run_for_page(
+    let summary = run_for_page_generous(
         &conn,
         source,
         1,
@@ -360,7 +386,7 @@ fn unresolved_match_still_inserts_assertion_no_link() {
     insert_page(&conn, "people/alice", "Alice", "body");
 
     let patterns = entities::load_patterns_from(None, &conn).unwrap();
-    let summary = entities::run_for_page(
+    let summary = run_for_page_generous(
         &conn,
         source,
         1,
@@ -387,7 +413,7 @@ fn unresolved_evidence_does_not_include_raw_capture_text() {
     insert_page(&conn, "people/alice", "Alice", "body");
 
     let patterns = entities::load_patterns_from(None, &conn).unwrap();
-    entities::run_for_page(
+    run_for_page_generous(
         &conn,
         source,
         1,
@@ -450,7 +476,7 @@ fn idempotent_reingest_does_not_duplicate_assertions() {
     let patterns = entities::load_patterns_from(None, &conn).unwrap();
 
     for _ in 0..3 {
-        entities::run_for_page(
+        run_for_page_generous(
             &conn,
             source,
             1,
@@ -475,7 +501,7 @@ fn reingest_removes_entity_assertions_no_longer_in_page_text() {
     insert_page(&conn, "companies/stripe", "Stripe", "body");
     let patterns = entities::load_patterns_from(None, &conn).unwrap();
 
-    entities::run_for_page(
+    run_for_page_generous(
         &conn,
         source,
         1,
@@ -484,7 +510,7 @@ fn reingest_removes_entity_assertions_no_longer_in_page_text() {
         &patterns,
     )
     .unwrap();
-    entities::run_for_page(
+    run_for_page_generous(
         &conn,
         source,
         1,
@@ -574,7 +600,7 @@ fn over_budget_run_for_page_logs_gap_and_preserves_existing_entity_assertions() 
     insert_page(&conn, "companies/brex", "Brex", "body");
     let patterns = entities::load_patterns_from(None, &conn).unwrap();
 
-    entities::run_for_page(
+    run_for_page_generous(
         &conn,
         source,
         1,

--- a/tests/roundtrip_raw.rs
+++ b/tests/roundtrip_raw.rs
@@ -50,3 +50,115 @@ fn export_reproduces_canonical_markdown_fixture_byte_for_byte() {
     let exported = fs::read(export_root.path().join("notes/canonical-person.md")).unwrap();
     assert_eq!(exported, canonical.as_bytes());
 }
+
+/// `quaid export --raw` restores the byte-exact active raw payload even when
+/// the source bytes are NOT in canonical form (so the rendered export would
+/// differ from them).
+#[test]
+fn export_raw_reproduces_non_canonical_source_bytes_exactly() {
+    // Trailing whitespace, CRLF, and unsorted frontmatter keys — content the
+    // normalized renderer would rewrite.
+    let messy = "---\ntype: person\ntitle: Messy Person\nslug: notes/messy-person\n---\r\nBody with trailing spaces   \r\n\r\n";
+
+    let fixture_root = tempfile::TempDir::new().unwrap();
+    let fixture_path = fixture_root.path().join("messy.md");
+    fs::write(&fixture_path, messy).unwrap();
+
+    let db_root = tempfile::TempDir::new().unwrap();
+    let db_path = db_root.path().join("memory.db");
+    let conn = db::open(db_path.to_str().unwrap()).unwrap();
+    ingest::run(&conn, fixture_path.to_str().unwrap(), false).unwrap();
+
+    let export_root = tempfile::TempDir::new().unwrap();
+    let count = quaid::core::migrate::export_raw_dir(&conn, export_root.path(), None).unwrap();
+    assert_eq!(count, 1);
+
+    let exported = fs::read(export_root.path().join("notes/messy-person.md")).unwrap();
+    assert_eq!(exported, messy.as_bytes());
+}
+
+/// `--import-id` restores exactly one historical payload by its
+/// `raw_imports.import_id`, and unknown ids error instead of silently
+/// writing nothing.
+#[test]
+fn export_raw_with_import_id_restores_single_historical_payload() {
+    let first = "---\ntitle: Note\ntype: concept\nslug: notes/history\n---\nFirst revision.\n";
+    let second = "---\ntitle: Note\ntype: concept\nslug: notes/history\n---\nSecond revision.\n";
+
+    let fixture_root = tempfile::TempDir::new().unwrap();
+    let db_root = tempfile::TempDir::new().unwrap();
+    let db_path = db_root.path().join("memory.db");
+    let conn = db::open(db_path.to_str().unwrap()).unwrap();
+
+    let first_path = fixture_root.path().join("a.md");
+    fs::write(&first_path, first).unwrap();
+    ingest::run(&conn, first_path.to_str().unwrap(), false).unwrap();
+    let second_path = fixture_root.path().join("b.md");
+    fs::write(&second_path, second).unwrap();
+    ingest::run(&conn, second_path.to_str().unwrap(), true).unwrap();
+
+    // The first revision rotated to inactive; grab its import id.
+    let historic_import_id: String = conn
+        .query_row(
+            "SELECT import_id FROM raw_imports WHERE is_active = 0 LIMIT 1",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+
+    let export_root = tempfile::TempDir::new().unwrap();
+    let count =
+        quaid::core::migrate::export_raw_dir(&conn, export_root.path(), Some(&historic_import_id))
+            .unwrap();
+    assert_eq!(count, 1);
+    let exported = fs::read(export_root.path().join("notes/history.md")).unwrap();
+    assert_eq!(exported, first.as_bytes());
+
+    let missing = quaid::core::migrate::export_raw_dir(
+        &conn,
+        export_root.path(),
+        Some("00000000-0000-0000-0000-000000000000"),
+    );
+    assert!(missing.is_err(), "unknown import id must error");
+    assert!(missing
+        .unwrap_err()
+        .to_string()
+        .contains("raw import not found"));
+}
+
+/// The CLI command surface: `--raw` flows through `commands::export::run`
+/// (formerly bound as `_raw`/`_import_id` no-ops), and `--import-id`
+/// without `--raw` is rejected.
+#[test]
+fn export_command_honours_raw_flag_and_guards_import_id() {
+    let canonical = "---\ntitle: Cli Raw\ntype: concept\nslug: notes/cli-raw\n---\nBody.   \n";
+    let fixture_root = tempfile::TempDir::new().unwrap();
+    let fixture_path = fixture_root.path().join("cli-raw.md");
+    fs::write(&fixture_path, canonical).unwrap();
+
+    let db_root = tempfile::TempDir::new().unwrap();
+    let db_path = db_root.path().join("memory.db");
+    let conn = db::open(db_path.to_str().unwrap()).unwrap();
+    ingest::run(&conn, fixture_path.to_str().unwrap(), false).unwrap();
+
+    let export_root = tempfile::TempDir::new().unwrap();
+    quaid::commands::export::run(
+        &conn,
+        export_root.path().to_str().unwrap(),
+        true,
+        None,
+        false,
+    )
+    .unwrap();
+    let exported = fs::read(export_root.path().join("notes/cli-raw.md")).unwrap();
+    assert_eq!(exported, canonical.as_bytes());
+
+    let guard = quaid::commands::export::run(
+        &conn,
+        export_root.path().to_str().unwrap(),
+        false,
+        Some("some-id".to_owned()),
+        false,
+    );
+    assert!(guard.is_err(), "--import-id without --raw must error");
+}

--- a/tests/status_command.rs
+++ b/tests/status_command.rs
@@ -94,3 +94,45 @@ fn status_human_output_reports_no_runtime_host_for_empty_database() {
     assert!(stdout.contains("none (no live daemon or serve_host)"));
     assert!(stdout.contains("transports:"));
 }
+
+/// Exit code 3 ("unexpected error") is reachable: when the daemon unit file
+/// exists but the service-manager probe itself fails (here: `systemctl`
+/// missing from PATH), `quaid status` must report the probe failure instead
+/// of misclassifying the daemon as not installed (exit 2).
+#[cfg(target_os = "linux")]
+#[test]
+fn status_exits_3_when_service_manager_probe_fails() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let home_dir = dir.path().join("home");
+    let unit_dir = home_dir.join(".config").join("systemd").join("user");
+    fs::create_dir_all(&unit_dir).unwrap();
+    fs::write(unit_dir.join("quaid-daemon.service"), "[Unit]\n").unwrap();
+    // Empty PATH: spawning `systemctl` fails, so the probe returns Err(_).
+    let empty_bin = dir.path().join("empty-bin");
+    fs::create_dir_all(&empty_bin).unwrap();
+    let (conn, db_path) = open_test_db_file(&dir);
+    drop(conn);
+
+    let mut command = Command::new(common::quaid_bin());
+    common_subprocess::configure_test_command(&mut command);
+    let output = command
+        .env("HOME", &home_dir)
+        .env("USERPROFILE", &home_dir)
+        .env("PATH", &empty_bin)
+        .arg("--db")
+        .arg(&db_path)
+        .args(["status", "--json"])
+        .output()
+        .expect("run quaid status");
+
+    assert_eq!(
+        output.status.code(),
+        Some(3),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let payload: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(payload["daemon"]["probe_failed"], true);
+    assert_eq!(payload["daemon"]["installed"], false);
+}


### PR DESCRIPTION
Implements **Area 19 (steps 1–4, 6)** and **Area 17 step 1** of the codebase review (`docs/fable-review.md` on `code-review-2`).

## Changes
- **Tool dispatch parity**: `quaid call`/`pipe` gain `memory_correct` + `memory_correct_continue` arms; a new parity test asserts `dispatch_tool` accepts every registered MCP tool name (introspected via a new public `QuaidServer::registered_tool_names()`).
- **`--json` honesty**: the global flag is threaded through all previously-missing dispatch arms (put, ingest, export, extract, embed, link family, tags, timeline-add, compact, config); `quaid --json status` now equals `quaid status --json`.
- **Dead flags implemented**: `export --raw --import-id` now performs byte-exact raw export via the `raw_imports` helpers (pages without raw payloads are skipped, documented); `embed --all` force-bypasses `page_needs_refresh` (a true re-embed now exists); `serve --token-file` help text corrected (it already hard-errored at bind time — the docs claimed otherwise).
- **One conflict error**: typed `ConflictError` (thiserror) replaces the `InvalidParameterName` smuggling in put.rs; all -32009 surfaces normalized to a single `ConflictError: ` prefix (including the `StaleExpectedVersion` display in vault_sync/restore.rs which also reaches -32009). JSON-RPC code unchanged.
- **`quaid status` exit 3**: service-manager probe failure now returns the documented exit 3, distinct from NotInstalled.
- **Schema-mismatch message rewrite** (`db.rs`): drops the false "created before the Quaid rename" claim; distinguishes older-schema (names the v0.20.x–v0.21.x range for v9), newer-schema ("upgrade the binary"), and true legacy config-table era; instructs backing up/moving the DB before `quaid init` (the old remediation dead-looped on its own preflight).

## Validation
`cargo check`, `cargo clippy --all-targets -- -D warnings` (CI's exact gate), `cargo fmt --check` all pass. Targeted suites green: cli_call_dispatch_parity 3, conflict_error_prefix 5, db_schema_reinit_message 3, roundtrip_raw 4 (3 new), cli_embed_batching 3, cli_json_flag 3, status_command 3, cli_put_update_occ 5, mcp_server_get_put 11, command_surface_coverage 12, mcp_http_transport 5, memory_correct 7; lib: commands 276, core::db 22, mcp 59.

## Notes
- MCP tool *description* strings deliberately untouched (Wave 4 docs/skills pass).
- launchd exit-3 path implemented symmetrically with systemd but only the systemd variant is test-exercised (Linux container).
- Touches `vault_sync/restore.rs` (one display impl) — textually disjoint from the security-hardening PR's changes to the same file; merge either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)