### PR TITLE
feat(embeddings): CLS pooling, BGE query instruction, chunk caps, versioned re-embed (area 2)

### DIFF
--- a/src/commands/embed.rs
+++ b/src/commands/embed.rs
@@ -9,10 +9,14 @@ use rusqlite::Connection;
 use crate::commands::get::get_page_by_key;
 use crate::core::chunking::chunk_page;
 use crate::core::collections::OpKind;
-use crate::core::inference::{embed, embedding_to_blob};
+use crate::core::inference::{embed, embedding_to_blob, EMBEDDER_VERSION};
 use crate::core::vault_sync;
 
 const DEFAULT_BATCH_SIZE: usize = 32;
+
+/// `quaid_config` key recording the [`EMBEDDER_VERSION`] the store was last
+/// fully re-embedded under. A missing key marks a legacy store (version 1).
+const EMBEDDER_VERSION_KEY: &str = "embedder_version";
 
 #[derive(Debug, Clone)]
 struct PageRef {
@@ -61,8 +65,10 @@ pub fn run_with_batch(
             (1, chunks.len())
         }
     } else {
+        let embedder_version_mismatch = stored_embedder_version(db)? != Some(EMBEDDER_VERSION);
         let mut embedded_pages = 0_usize;
         let mut embedded_chunks = 0_usize;
+        let mut failed_pages = 0_usize;
         let mut last_page_id = 0_i64;
 
         loop {
@@ -84,6 +90,7 @@ pub fn run_with_batch(
                                 &e
                             )
                         );
+                        failed_pages += 1;
                         continue;
                     }
                 };
@@ -93,7 +100,13 @@ pub fn run_with_batch(
                     continue;
                 }
 
-                if !page_needs_refresh(db, page_ref.id, &model_name, &chunks)? {
+                if !page_needs_refresh(
+                    db,
+                    page_ref.id,
+                    &model_name,
+                    &chunks,
+                    embedder_version_mismatch,
+                )? {
                     continue;
                 }
 
@@ -108,11 +121,19 @@ pub fn run_with_batch(
                             &e
                         )
                     );
+                    failed_pages += 1;
                     continue;
                 }
                 embedded_pages += 1;
                 embedded_chunks += chunks.len();
             }
+        }
+
+        // A clean full pass means every page's embeddings are now current, so
+        // record the pipeline version; any failure keeps the old version so
+        // the next pass retries the skipped pages.
+        if failed_pages == 0 {
+            record_embedder_version(db)?;
         }
 
         (embedded_pages, embedded_chunks)
@@ -170,12 +191,52 @@ fn page_id_by_key(db: &Connection, collection_id: i64, slug: &str) -> Result<i64
     })
 }
 
+/// Reads the embedder version recorded by the last clean full embed pass.
+/// `None` marks a legacy store last embedded before version tracking.
+fn stored_embedder_version(db: &Connection) -> Result<Option<i64>> {
+    let value: Option<String> = db
+        .query_row(
+            "SELECT value FROM quaid_config WHERE key = ?1",
+            [EMBEDDER_VERSION_KEY],
+            |row| row.get(0),
+        )
+        .map(Some)
+        .or_else(|error| match error {
+            rusqlite::Error::QueryReturnedNoRows => Ok(None),
+            other => Err(other),
+        })?;
+
+    match value {
+        Some(raw) => {
+            let parsed = raw.parse::<i64>().map_err(|_| {
+                anyhow::anyhow!("quaid_config.{EMBEDDER_VERSION_KEY} must be an integer: {raw}")
+            })?;
+            Ok(Some(parsed))
+        }
+        None => Ok(None),
+    }
+}
+
+fn record_embedder_version(db: &Connection) -> Result<()> {
+    db.execute(
+        "INSERT INTO quaid_config (key, value) VALUES (?1, ?2) \
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        rusqlite::params![EMBEDDER_VERSION_KEY, EMBEDDER_VERSION.to_string()],
+    )?;
+    Ok(())
+}
+
 fn page_needs_refresh(
     db: &Connection,
     page_id: i64,
     model_name: &str,
     chunks: &[crate::core::types::Chunk],
+    embedder_version_mismatch: bool,
 ) -> Result<bool> {
+    if embedder_version_mismatch {
+        return Ok(true);
+    }
+
     let mut stmt = db.prepare(
         "SELECT chunk_type, content_hash, heading_path \
          FROM page_embeddings \

--- a/src/core/chunking.rs
+++ b/src/core/chunking.rs
@@ -2,6 +2,24 @@ use sha2::{Digest, Sha256};
 
 use super::types::{Chunk, Page};
 
+/// Approximate bytes per token used by the `len / 4` token estimate.
+const APPROX_BYTES_PER_TOKEN: usize = 4;
+
+/// Chunks whose estimated token count exceeds this cap are sub-split so the
+/// whole chunk fits the encoder's 512-token window, with margin for special
+/// tokens and tokenizer variance. Without the cap, a heading-less page becomes
+/// one whole-page chunk silently truncated at 512 tokens — everything past
+/// roughly the first ~2,000 characters never reaches the vector index.
+const MAX_CHUNK_TOKENS: usize = 480;
+
+/// Target window size (estimated tokens) for sub-split chunk parts.
+const SPLIT_WINDOW_TOKENS: usize = 440;
+
+/// Approximate context overlap (estimated tokens) carried between consecutive
+/// sub-split parts so facts near a window boundary stay intact in at least
+/// one window.
+const SPLIT_OVERLAP_TOKENS: usize = 60;
+
 /// Split a page into truth-section and timeline-entry chunks.
 pub fn chunk_page(page: &Page) -> Vec<Chunk> {
     let mut chunks = truth_chunks(page);
@@ -24,12 +42,13 @@ fn truth_chunks(page: &Page) -> Vec<Chunk> {
         if let Some(heading) = line.strip_prefix("## ") {
             saw_heading = true;
             if !current_lines.is_empty() {
-                chunks.push(build_chunk(
+                push_capped_chunks(
+                    &mut chunks,
                     &page.slug,
                     &current_heading,
                     &current_lines.join("\n"),
                     "truth_section",
-                ));
+                );
                 current_lines.clear();
             }
             current_heading = heading.trim().to_owned();
@@ -44,12 +63,13 @@ fn truth_chunks(page: &Page) -> Vec<Chunk> {
         } else {
             ""
         };
-        chunks.push(build_chunk(
+        push_capped_chunks(
+            &mut chunks,
             &page.slug,
             heading,
             &current_lines.join("\n"),
             "truth_section",
-        ));
+        );
     }
 
     chunks
@@ -61,24 +81,29 @@ fn timeline_chunks(page: &Page) -> Vec<Chunk> {
         return Vec::new();
     }
 
-    split_timeline_entries(&page.timeline)
-        .into_iter()
-        .map(|entry| {
-            let heading_path = entry
-                .lines()
-                .find_map(|line| {
-                    let trimmed = line.trim();
-                    if trimmed.is_empty() {
-                        None
-                    } else {
-                        Some(trimmed.to_owned())
-                    }
-                })
-                .unwrap_or_default();
+    let mut chunks = Vec::new();
+    for entry in split_timeline_entries(&page.timeline) {
+        let heading_path = entry
+            .lines()
+            .find_map(|line| {
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(trimmed.to_owned())
+                }
+            })
+            .unwrap_or_default();
 
-            build_chunk(&page.slug, &heading_path, &entry, "timeline_entry")
-        })
-        .collect()
+        push_capped_chunks(
+            &mut chunks,
+            &page.slug,
+            &heading_path,
+            &entry,
+            "timeline_entry",
+        );
+    }
+    chunks
 }
 
 fn split_timeline_entries(timeline: &str) -> Vec<String> {
@@ -105,6 +130,174 @@ fn split_timeline_entries(timeline: &str) -> Vec<String> {
         .into_iter()
         .filter(|entry| !entry.trim().is_empty())
         .collect()
+}
+
+/// Push `content` as one chunk when it fits [`MAX_CHUNK_TOKENS`], otherwise
+/// sub-split it into overlapping windows of roughly [`SPLIT_WINDOW_TOKENS`],
+/// suffixing each part's heading path with its part index (e.g. `" [2/3]"`).
+fn push_capped_chunks(
+    chunks: &mut Vec<Chunk>,
+    page_slug: &str,
+    heading_path: &str,
+    content: &str,
+    chunk_type: &str,
+) {
+    let windows = split_oversized(content);
+    if windows.len() <= 1 {
+        chunks.push(build_chunk(page_slug, heading_path, content, chunk_type));
+        return;
+    }
+
+    let total = windows.len();
+    for (index, window) in windows.iter().enumerate() {
+        let part_heading = part_heading_path(heading_path, index + 1, total);
+        chunks.push(build_chunk(page_slug, &part_heading, window, chunk_type));
+    }
+}
+
+fn part_heading_path(heading_path: &str, part: usize, total: usize) -> String {
+    if heading_path.is_empty() {
+        format!("[{part}/{total}]")
+    } else {
+        format!("{heading_path} [{part}/{total}]")
+    }
+}
+
+/// Split `content` into overlapping windows whose `len / 4` token estimate
+/// stays under [`MAX_CHUNK_TOKENS`], breaking at paragraph boundaries first,
+/// then line boundaries, then (as a last resort) character boundaries.
+/// Content already under the cap is returned as a single window.
+fn split_oversized(content: &str) -> Vec<&str> {
+    if content.len() <= MAX_CHUNK_TOKENS * APPROX_BYTES_PER_TOKEN {
+        return vec![content];
+    }
+
+    let window_bytes = SPLIT_WINDOW_TOKENS * APPROX_BYTES_PER_TOKEN;
+    let overlap_bytes = SPLIT_OVERLAP_TOKENS * APPROX_BYTES_PER_TOKEN;
+    let atoms = split_atoms(content, window_bytes);
+    if atoms.is_empty() {
+        return vec![content];
+    }
+
+    let mut windows = Vec::new();
+    let mut window_start_atom = 0;
+    loop {
+        let window_byte_start = atoms[window_start_atom].0;
+        let mut end_atom = window_start_atom;
+        while end_atom + 1 < atoms.len()
+            && atoms[end_atom + 1].1 - window_byte_start <= window_bytes
+        {
+            end_atom += 1;
+        }
+        let window_byte_end = atoms[end_atom].1;
+        windows.push(&content[window_byte_start..window_byte_end]);
+        if end_atom + 1 >= atoms.len() {
+            return windows;
+        }
+
+        // Start the next window inside this one's tail so consecutive parts
+        // share roughly SPLIT_OVERLAP_TOKENS of context: walk back over atoms
+        // that begin inside the overlap region, falling back to carrying the
+        // final atom when it is small enough.
+        let desired_overlap_start = window_byte_end.saturating_sub(overlap_bytes);
+        let mut next_start = end_atom + 1;
+        while next_start > window_start_atom + 1 && atoms[next_start - 1].0 >= desired_overlap_start
+        {
+            next_start -= 1;
+        }
+        if next_start > end_atom
+            && end_atom > window_start_atom
+            && window_byte_end - atoms[end_atom].0 <= 2 * overlap_bytes
+        {
+            next_start = end_atom;
+        }
+        window_start_atom = next_start;
+    }
+}
+
+/// Split `content` into byte ranges of at most `max_atom_bytes`, preferring
+/// whole paragraphs, then single lines, then hard character splits. Blank
+/// lines and trailing whitespace are excluded from the ranges.
+fn split_atoms(content: &str, max_atom_bytes: usize) -> Vec<(usize, usize)> {
+    let mut atoms = Vec::new();
+    for (start, end) in paragraph_ranges(content) {
+        if end - start <= max_atom_bytes {
+            atoms.push((start, end));
+            continue;
+        }
+        for (line_start, line_end) in line_ranges(&content[start..end], start) {
+            if line_end - line_start <= max_atom_bytes {
+                atoms.push((line_start, line_end));
+            } else {
+                hard_split(content, line_start, line_end, max_atom_bytes, &mut atoms);
+            }
+        }
+    }
+    atoms
+}
+
+/// Byte ranges of paragraphs (runs of non-blank lines), with trailing
+/// whitespace trimmed from each range.
+fn paragraph_ranges(content: &str) -> Vec<(usize, usize)> {
+    let mut ranges = Vec::new();
+    let mut start: Option<usize> = None;
+    let mut end = 0;
+    let mut offset = 0;
+    for line in content.split_inclusive('\n') {
+        let line_start = offset;
+        offset += line.len();
+        if line.trim().is_empty() {
+            if let Some(paragraph_start) = start.take() {
+                ranges.push((paragraph_start, end));
+            }
+        } else {
+            if start.is_none() {
+                start = Some(line_start);
+            }
+            end = line_start + line.trim_end().len();
+        }
+    }
+    if let Some(paragraph_start) = start {
+        ranges.push((paragraph_start, end));
+    }
+    ranges
+}
+
+/// Byte ranges (relative to the whole content via `base`) of the non-blank
+/// lines of `paragraph`, with trailing whitespace trimmed.
+fn line_ranges(paragraph: &str, base: usize) -> Vec<(usize, usize)> {
+    let mut ranges = Vec::new();
+    let mut offset = 0;
+    for line in paragraph.split_inclusive('\n') {
+        let line_start = offset;
+        offset += line.len();
+        let trimmed = line.trim_end();
+        if !trimmed.is_empty() {
+            ranges.push((base + line_start, base + line_start + trimmed.len()));
+        }
+    }
+    ranges
+}
+
+/// Last-resort split of an unbreakable span into ranges of at most
+/// `max_atom_bytes`, cutting only at UTF-8 character boundaries.
+fn hard_split(
+    content: &str,
+    start: usize,
+    end: usize,
+    max_atom_bytes: usize,
+    atoms: &mut Vec<(usize, usize)>,
+) {
+    let mut piece_start = start;
+    while end - piece_start > max_atom_bytes {
+        let mut cut = piece_start + max_atom_bytes;
+        while !content.is_char_boundary(cut) {
+            cut -= 1;
+        }
+        atoms.push((piece_start, cut));
+        piece_start = cut;
+    }
+    atoms.push((piece_start, end));
 }
 
 fn build_chunk(page_slug: &str, heading_path: &str, content: &str, chunk_type: &str) -> Chunk {

--- a/src/core/inference.rs
+++ b/src/core/inference.rs
@@ -74,6 +74,23 @@ impl Drop for TempFileCleanupGuard {
 const DEFAULT_MODEL_ALIAS: &str = "small";
 const DEFAULT_EMBEDDING_DIMENSIONS: usize = 384;
 
+/// Version of the embedding pipeline: pooling strategy, query instruction,
+/// and chunk shaping. Bump whenever embeddings produced by older binaries are
+/// no longer comparable with freshly computed ones, so `quaid embed --all` /
+/// `--stale` re-embeds existing pages exactly once.
+///
+/// History:
+/// - 1: masked mean pooling, no query instruction, unbounded chunk size.
+/// - 2: CLS pooling, "Represent this sentence for searching relevant
+///   passages: " prefix on BGE en-v1.5 retrieval queries, ~480-token chunk
+///   cap with overlapping sub-splits.
+pub const EMBEDDER_VERSION: i64 = 2;
+
+/// Instruction prefix the BGE en-v1.5 family was trained to expect on
+/// retrieval *queries*. Passages — and symmetric comparisons such as novelty
+/// and supersede checks — are embedded without it.
+const BGE_QUERY_INSTRUCTION: &str = "Represent this sentence for searching relevant passages: ";
+
 /// Pinned SHA-256 fingerprints for the three files that make up a downloadable
 /// embedding model, used for integrity verification after download.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -147,6 +164,13 @@ impl ModelConfig {
     /// of the model's `config.json` (only possible for custom models).
     pub fn needs_dimension_hydration(&self) -> bool {
         self.embedding_dim == 0
+    }
+
+    /// Returns `true` for the BGE en-v1.5 family (`small`/`base`/`large`),
+    /// which is trained with [`BGE_QUERY_INSTRUCTION`] prepended to retrieval
+    /// queries. BGE-m3 and unknown custom models take no query prefix.
+    fn uses_query_instruction(&self) -> bool {
+        matches!(self.alias.as_str(), "small" | "base" | "large")
     }
 }
 
@@ -489,6 +513,18 @@ impl EmbeddingModel {
         }
     }
 
+    /// Embeds a retrieval query, prepending [`BGE_QUERY_INSTRUCTION`] for the
+    /// BGE en-v1.5 family on a real semantic backend. The hash shim stays
+    /// prefix-free so its query and passage embeddings remain comparable.
+    fn embed_query(&self, text: &str) -> Result<Vec<f32>, InferenceError> {
+        let semantic = !matches!(self.backend, EmbeddingBackend::HashShim);
+        if semantic && self.config.uses_query_instruction() {
+            self.embed(&format!("{BGE_QUERY_INSTRUCTION}{text}"))
+        } else {
+            self.embed(text)
+        }
+    }
+
     fn evidence_kind(&self) -> EmbeddingEvidenceKind {
         match self.backend {
             EmbeddingBackend::HashShim => EmbeddingEvidenceKind::HashShim,
@@ -608,6 +644,7 @@ fn embed_candle(
         })?;
 
     let max_len = 512;
+    warn_on_truncation(encoding.get_ids().len(), max_len);
     let ids: &[u32] = &encoding.get_ids()[..encoding.get_ids().len().min(max_len)];
     let mask: &[u32] =
         &encoding.get_attention_mask()[..encoding.get_attention_mask().len().min(max_len)];
@@ -636,7 +673,18 @@ fn embed_candle(
             message: format!("BERT forward: {e}"),
         })?;
 
-    mean_pool_and_normalize(output, attention_mask)
+    cls_pool_and_normalize(output)
+}
+
+/// Warns when tokenized input exceeds the encoder window and must be sliced.
+/// Chunking caps chunk sizes well below the window, so this firing usually
+/// means a pathological chunk (e.g. a single enormous unbreakable line).
+fn warn_on_truncation(token_len: usize, max_len: usize) {
+    if token_len > max_len {
+        eprintln!(
+            "Warning: embedding input is {token_len} tokens but the model window is {max_len}; truncating. Text beyond the window will not contribute to this vector."
+        );
+    }
 }
 
 #[cfg(feature = "online-model")]
@@ -653,6 +701,7 @@ fn embed_candle_xlm_roberta(
             message: format!("tokenizer: {e}"),
         })?;
 
+    warn_on_truncation(encoding.get_ids().len(), max_len);
     let ids: &[u32] = &encoding.get_ids()[..encoding.get_ids().len().min(max_len)];
     let mask: &[u32] =
         &encoding.get_attention_mask()[..encoding.get_attention_mask().len().min(max_len)];
@@ -688,55 +737,22 @@ fn embed_candle_xlm_roberta(
             message: format!("XLM-R forward: {e}"),
         })?;
 
-    mean_pool_and_normalize(output, attention_mask)
+    cls_pool_and_normalize(output)
 }
 
-fn mean_pool_and_normalize(
-    output: Tensor,
-    attention_mask: Tensor,
-) -> Result<Vec<f32>, InferenceError> {
-    let mask_f32 = attention_mask
-        .unsqueeze(2)
-        .and_then(|t| t.to_dtype(DType::F32))
+/// Pools a transformer forward pass to the hidden state of the first token
+/// ([CLS] for BERT, `<s>` for XLM-R) and L2-normalizes it. The BGE en-v1.5
+/// family and bge-m3 dense retrieval are trained for CLS pooling; mean
+/// pooling produces embeddings off the models' calibrated similarity scale.
+fn cls_pool_and_normalize(output: Tensor) -> Result<Vec<f32>, InferenceError> {
+    let cls = output
+        .narrow(1, 0, 1)
+        .and_then(|t| t.squeeze(1))
         .map_err(|e| InferenceError::Internal {
-            message: format!("mask expand: {e}"),
+            message: format!("cls pool: {e}"),
         })?;
 
-    let mask_broadcast =
-        mask_f32
-            .broadcast_as(output.shape())
-            .map_err(|e| InferenceError::Internal {
-                message: format!("mask broadcast: {e}"),
-            })?;
-
-    let masked = output
-        .mul(&mask_broadcast)
-        .map_err(|e| InferenceError::Internal {
-            message: format!("mask mul: {e}"),
-        })?;
-
-    let sum = masked.sum(1).map_err(|e| InferenceError::Internal {
-        message: format!("sum: {e}"),
-    })?;
-
-    let count = mask_f32.sum(1).map_err(|e| InferenceError::Internal {
-        message: format!("count: {e}"),
-    })?;
-
-    let count_broadcast =
-        count
-            .broadcast_as(sum.shape())
-            .map_err(|e| InferenceError::Internal {
-                message: format!("count broadcast: {e}"),
-            })?;
-
-    let mean = sum
-        .div(&count_broadcast)
-        .map_err(|e| InferenceError::Internal {
-            message: format!("mean: {e}"),
-        })?;
-
-    let norm = mean
+    let norm = cls
         .sqr()
         .and_then(|t| t.sum_keepdim(1))
         .and_then(|t| t.sqrt())
@@ -745,12 +761,12 @@ fn mean_pool_and_normalize(
         })?;
 
     let norm_broadcast = norm
-        .broadcast_as(mean.shape())
+        .broadcast_as(cls.shape())
         .map_err(|e| InferenceError::Internal {
             message: format!("norm broadcast: {e}"),
         })?;
 
-    let normalized = mean
+    let normalized = cls
         .div(&norm_broadcast)
         .map_err(|e| InferenceError::Internal {
             message: format!("normalize: {e}"),
@@ -1259,6 +1275,30 @@ pub fn embed(text: &str) -> Result<Vec<f32>, InferenceError> {
         .embed(trimmed)
 }
 
+/// Embeds a retrieval *query* with the currently configured model. The BGE
+/// en-v1.5 family is trained for asymmetric retrieval: queries carry an
+/// instruction prefix while passages do not, so this must only be used for
+/// query-to-passage search (e.g. [`search_vec`]). Symmetric comparisons
+/// (novelty, supersede, doc-doc similarity) should call [`embed`] instead.
+/// BGE-m3, custom models, and the hash-shim fallback embed queries exactly
+/// like passages.
+pub fn embed_query(text: &str) -> Result<Vec<f32>, InferenceError> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return Err(InferenceError::EmptyInput);
+    }
+
+    ensure_model();
+    let runtime = model_runtime().lock().unwrap_or_else(|e| e.into_inner());
+    runtime
+        .loaded
+        .as_ref()
+        .ok_or_else(|| InferenceError::Internal {
+            message: "embedding model is not loaded; call configure_runtime_model first".to_owned(),
+        })?
+        .embed_query(trimmed)
+}
+
 /// Reports whether the currently loaded model is the real semantic backend or
 /// the deterministic hash-based shim. Used by callers that want to label or
 /// downrank evidence produced by the fallback.
@@ -1419,7 +1459,7 @@ fn search_vec_internal(
         });
     }
 
-    let query_embedding = embed(query).map_err(|err| SearchError::Internal {
+    let query_embedding = embed_query(query).map_err(|err| SearchError::Internal {
         message: err.to_string(),
     })?;
     let query_blob = embedding_to_blob(&query_embedding);
@@ -1983,8 +2023,11 @@ mod tests {
 
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].slug, "people/alice");
+        // Retrieval is asymmetric since EMBEDDER_VERSION 2: the query carries
+        // the BGE instruction prefix while the stored passage does not, so an
+        // identical-text match scores high (~0.92 measured) but no longer 1.0.
         assert!(
-            results[0].score > 0.99,
+            results[0].score > 0.85,
             "unexpected score: {}",
             results[0].score
         );

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -8,6 +8,13 @@ PRAGMA foreign_keys = ON;
 -- ============================================================
 -- quaid_config: persisted embedding model metadata
 -- ============================================================
+-- Init writes: model_id, model_alias, embedding_dim, schema_version.
+-- Runtime keys:
+--   embedder_version — embedding pipeline version (pooling / query
+--   instruction / chunking semantics; see EMBEDDER_VERSION in
+--   src/core/inference.rs) recorded after a clean `quaid embed --all` or
+--   `--stale` pass; a missing or mismatched value makes the next full embed
+--   pass refresh every page once.
 CREATE TABLE IF NOT EXISTS quaid_config (
     key   TEXT PRIMARY KEY NOT NULL,
     value TEXT NOT NULL

--- a/tests/embedding_quality.rs
+++ b/tests/embedding_quality.rs
@@ -1,0 +1,434 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::print_stdout,
+    reason = "test fixtures legitimately panic on setup failure and print diagnostics; per-site #[expect] would generate noise across thousands of test sites"
+)]
+
+//! Embedding semantic-quality tests.
+//!
+//! Covers the BGE-usage fixes: chunk-size capping with overlapping sub-splits,
+//! asymmetric query embedding for the BGE en-v1.5 family, embedder-version
+//! driven re-embeds, and — the acceptance test — semantic recall of a fact
+//! planted mid-page in a heading-less document, which a single truncated
+//! whole-page chunk can never surface.
+//!
+//! The semantic tests run against the real embedded BGE-small model (default
+//! `embedded-model` build channel, fully offline) and skip themselves when
+//! only the hash-shim fallback is available.
+
+use quaid::commands::embed;
+use quaid::core::chunking::chunk_page;
+use quaid::core::db;
+use quaid::core::inference::{
+    embed as embed_passage, embed_query, embedding_evidence_kind, search_vec,
+    EmbeddingEvidenceKind, EMBEDDER_VERSION,
+};
+use quaid::core::types::{Frontmatter, Page};
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+fn open_test_db() -> rusqlite::Connection {
+    let dir = tempfile::TempDir::new().expect("create temp dir");
+    let db_path = dir.path().join("memory.db");
+    let conn = db::open(db_path.to_str().unwrap()).expect("open DB");
+    // Leak TempDir to keep the database file alive for the test's duration.
+    std::mem::forget(dir);
+    conn
+}
+
+fn insert_page(conn: &rusqlite::Connection, slug: &str, title: &str, truth: &str) {
+    conn.execute(
+        "INSERT INTO pages (slug, uuid, type, title, summary, compiled_truth, timeline, \
+                            frontmatter, wing, room, version) \
+         VALUES (?1, ?2, 'note', ?3, '', ?4, '', '{}', 'notes', '', 1)",
+        rusqlite::params![
+            slug,
+            quaid::core::page_uuid::generate_uuid_v7(),
+            title,
+            truth
+        ],
+    )
+    .expect("insert page");
+}
+
+fn test_page(compiled_truth: &str, timeline: &str) -> Page {
+    Page {
+        slug: "journal/2026-06-01".to_owned(),
+        uuid: "01969f11-9448-7d79-8d3f-c68f54761234".to_owned(),
+        page_type: "note".to_owned(),
+        superseded_by: None,
+        title: "Journal".to_owned(),
+        summary: String::new(),
+        compiled_truth: compiled_truth.to_owned(),
+        timeline: timeline.to_owned(),
+        frontmatter: Frontmatter::new(),
+        wing: "notes".to_owned(),
+        room: String::new(),
+        version: 1,
+        created_at: "2026-06-01T00:00:00Z".to_owned(),
+        updated_at: "2026-06-01T00:00:00Z".to_owned(),
+        truth_updated_at: "2026-06-01T00:00:00Z".to_owned(),
+        timeline_updated_at: "2026-06-01T00:00:00Z".to_owned(),
+    }
+}
+
+/// Deterministic heading-less journal prose of at least `target_bytes` bytes,
+/// built from short distinct paragraphs so paragraph-boundary splitting has
+/// realistic material to work with.
+fn journal_filler(target_bytes: usize, salt: usize) -> String {
+    const SENTENCES: [&str; 12] = [
+        "The morning started with light rain and a slow commute across the bridge.",
+        "Lunch was leftover soup, and the afternoon went to clearing the inbox.",
+        "The garden beds need mulch before the first frost arrives next month.",
+        "A long phone call with the contractor pushed the kitchen estimate again.",
+        "Evening reading covered two more chapters of the sailing memoir.",
+        "The dog insisted on the longer loop through the park by the river.",
+        "Groceries this week: oat milk, lentils, basil, and far too many snacks.",
+        "The neighbors are repainting their fence a surprisingly bright shade of blue.",
+        "Spent an hour tuning the squeaky derailleur on the commuter bike.",
+        "The book club picked an enormous doorstopper novel for December.",
+        "Tried a new pour-over ratio and the coffee finally tasted balanced.",
+        "The hallway light flickers again; probably the switch this time.",
+    ];
+
+    let mut out = String::new();
+    let mut index = salt;
+    while out.len() < target_bytes {
+        let first = SENTENCES[index % SENTENCES.len()];
+        let second = SENTENCES[(index + 5) % SENTENCES.len()];
+        out.push_str(&format!("Entry {}. {first} {second}\n\n", index + 1));
+        index += 1;
+    }
+    out
+}
+
+fn semantic_backend_available() -> bool {
+    matches!(
+        embedding_evidence_kind(),
+        Ok(EmbeddingEvidenceKind::Semantic)
+    )
+}
+
+fn cosine(a: &[f32], b: &[f32]) -> f32 {
+    // Embeddings are L2-normalized, so the dot product is the cosine.
+    a.iter().zip(b).map(|(x, y)| x * y).sum()
+}
+
+/// Length in bytes of the longest suffix of `a` that is also a prefix of `b`.
+fn suffix_prefix_overlap(a: &str, b: &str) -> usize {
+    let max = a.len().min(b.len());
+    (1..=max)
+        .rev()
+        .filter(|&n| b.is_char_boundary(n))
+        .find(|&n| a.ends_with(&b[..n]))
+        .unwrap_or(0)
+}
+
+/// Estimated-token cap mirrored from `src/core/chunking.rs`: chunks must fit
+/// the encoder's 512-token window with margin (len/4 estimate ≤ 480).
+const MAX_CHUNK_ESTIMATED_TOKENS: usize = 480;
+
+// ── Chunk-size capping ────────────────────────────────────────────────────────
+
+#[test]
+fn headingless_10kb_page_yields_multiple_overlapping_chunks_under_cap() {
+    let content = journal_filler(10_000, 0);
+    let page = test_page(&content, "");
+
+    let chunks = chunk_page(&page);
+    let truth_chunks: Vec<_> = chunks
+        .iter()
+        .filter(|chunk| chunk.chunk_type == "truth_section")
+        .collect();
+
+    assert!(
+        truth_chunks.len() >= 2,
+        "10KB heading-less page must be sub-split into multiple chunks, got {}",
+        truth_chunks.len()
+    );
+
+    for chunk in &truth_chunks {
+        assert!(
+            chunk.content.len() / 4 <= MAX_CHUNK_ESTIMATED_TOKENS,
+            "chunk exceeds the token-estimate cap: {} bytes (heading {:?})",
+            chunk.content.len(),
+            chunk.heading_path
+        );
+        assert!(
+            content.contains(&chunk.content),
+            "every chunk must be a contiguous slice of the original content"
+        );
+    }
+
+    // Both ends of the page must be covered.
+    let first_sentence = content.lines().next().unwrap();
+    let last_sentence = content.trim_end().lines().last().unwrap();
+    assert!(truth_chunks[0].content.contains(first_sentence));
+    assert!(truth_chunks.last().unwrap().content.contains(last_sentence));
+
+    // Consecutive chunks must overlap so facts near window boundaries are not
+    // split across vectors without shared context.
+    for pair in truth_chunks.windows(2) {
+        let overlap = suffix_prefix_overlap(&pair[0].content, &pair[1].content);
+        assert!(
+            overlap >= 80,
+            "consecutive chunks must share ≥80 bytes of context, got {overlap}"
+        );
+    }
+
+    // Sub-split chunks carry a part index in their heading path.
+    let total = truth_chunks.len();
+    assert!(
+        truth_chunks[0].heading_path.starts_with("[1/"),
+        "first part heading should carry a part index, got {:?}",
+        truth_chunks[0].heading_path
+    );
+    assert!(
+        truth_chunks
+            .last()
+            .unwrap()
+            .heading_path
+            .ends_with(&format!("[{total}/{total}]")),
+        "last part heading should carry the part count, got {:?}",
+        truth_chunks.last().unwrap().heading_path
+    );
+}
+
+#[test]
+fn oversized_section_under_heading_is_sub_split_with_suffixed_heading() {
+    let body = journal_filler(6_000, 3);
+    let content = format!("## Background\n{body}");
+    let page = test_page(&content, "");
+
+    let chunks = chunk_page(&page);
+    let truth_chunks: Vec<_> = chunks
+        .iter()
+        .filter(|chunk| chunk.chunk_type == "truth_section")
+        .collect();
+
+    assert!(truth_chunks.len() >= 2);
+    let total = truth_chunks.len();
+    for (index, chunk) in truth_chunks.iter().enumerate() {
+        assert_eq!(
+            chunk.heading_path,
+            format!("Background [{}/{total}]", index + 1),
+            "sub-split sections must suffix the heading path with a part index"
+        );
+        assert!(chunk.content.len() / 4 <= MAX_CHUNK_ESTIMATED_TOKENS);
+    }
+}
+
+#[test]
+fn oversized_timeline_entry_is_sub_split_under_cap() {
+    let entry = journal_filler(4_000, 6);
+    let timeline = format!("2026-06-01 Long retro\n{entry}\n---\n2026-06-02 Short note");
+    let page = test_page("", &timeline);
+
+    let chunks = chunk_page(&page);
+    let timeline_chunks: Vec<_> = chunks
+        .iter()
+        .filter(|chunk| chunk.chunk_type == "timeline_entry")
+        .collect();
+
+    assert!(
+        timeline_chunks.len() >= 3,
+        "oversized timeline entry must be sub-split (got {} chunks)",
+        timeline_chunks.len()
+    );
+    for chunk in &timeline_chunks {
+        assert!(chunk.content.len() / 4 <= MAX_CHUNK_ESTIMATED_TOKENS);
+    }
+}
+
+#[test]
+fn small_sectioned_page_chunking_is_unchanged() {
+    let page = test_page(
+        "## State\nAlice is investing.\n## Assessment\nStrong operator.\n## Network\nKnows top founders.",
+        "",
+    );
+
+    let chunks = chunk_page(&page);
+    let truth_chunks: Vec<_> = chunks
+        .iter()
+        .filter(|chunk| chunk.chunk_type == "truth_section")
+        .collect();
+
+    assert_eq!(truth_chunks.len(), 3);
+    assert_eq!(truth_chunks[0].heading_path, "State");
+    assert_eq!(truth_chunks[1].heading_path, "Assessment");
+    assert_eq!(truth_chunks[2].heading_path, "Network");
+}
+
+// ── Asymmetric query embedding (real embedded BGE-small, offline) ───────────
+
+#[test]
+fn query_embedding_differs_from_passage_embedding_of_same_text() {
+    if !semantic_backend_available() {
+        eprintln!("skipping: semantic embedding backend unavailable (hash shim)");
+        return;
+    }
+
+    let text = "Alice moved to Lisbon in March to join a robotics startup.";
+    let passage = embed_passage(text).expect("embed passage");
+    let query = embed_query(text).expect("embed query");
+
+    assert_eq!(passage.len(), query.len());
+    assert_ne!(
+        passage, query,
+        "BGE en-v1.5 query embeddings must carry the retrieval instruction prefix"
+    );
+}
+
+#[test]
+fn paraphrase_pair_cosine_exceeds_unrelated_pair() {
+    if !semantic_backend_available() {
+        eprintln!("skipping: semantic embedding backend unavailable (hash shim)");
+        return;
+    }
+
+    let query =
+        embed_query("How much did Marcus pay for the vintage motorcycle?").expect("embed query");
+    let paraphrase =
+        embed_passage("Marcus bought the old Triumph motorbike for nine thousand dollars.")
+            .expect("embed paraphrase");
+    let unrelated = embed_passage("The recipe calls for two cups of flour and a pinch of salt.")
+        .expect("embed unrelated");
+
+    let paraphrase_cosine = cosine(&query, &paraphrase);
+    let unrelated_cosine = cosine(&query, &unrelated);
+    assert!(
+        paraphrase_cosine > unrelated_cosine,
+        "paraphrase pair ({paraphrase_cosine}) must outscore unrelated pair ({unrelated_cosine})"
+    );
+}
+
+// ── Embedder-version driven re-embeds ────────────────────────────────────────
+
+fn embedding_row_ids(conn: &rusqlite::Connection) -> Vec<i64> {
+    let mut stmt = conn
+        .prepare("SELECT id FROM page_embeddings ORDER BY id")
+        .expect("prepare embedding id query");
+    let rows = stmt
+        .query_map([], |row| row.get(0))
+        .expect("query embedding ids");
+    rows.collect::<Result<Vec<i64>, _>>().expect("collect ids")
+}
+
+#[test]
+fn embedder_version_mismatch_forces_reembed_of_unchanged_content() {
+    let conn = open_test_db();
+    insert_page(
+        &conn,
+        "people/alice",
+        "Alice",
+        "Alice is investing in climate-tech startups.",
+    );
+
+    embed::run(&conn, None, true, false).expect("initial embed");
+    let initial_ids = embedding_row_ids(&conn);
+    assert!(!initial_ids.is_empty());
+
+    // Unchanged content at the current version is skipped.
+    embed::run(&conn, None, false, true).expect("no-op stale embed");
+    assert_eq!(embedding_row_ids(&conn), initial_ids);
+
+    // Simulate a store last embedded by an older pipeline version.
+    conn.execute(
+        "UPDATE quaid_config SET value = '1' WHERE key = 'embedder_version'",
+        [],
+    )
+    .expect("downgrade recorded embedder version");
+
+    embed::run(&conn, None, false, true).expect("stale embed after version change");
+    let refreshed_ids = embedding_row_ids(&conn);
+    assert_ne!(
+        refreshed_ids, initial_ids,
+        "an embedder-version mismatch must force a re-embed of unchanged content"
+    );
+
+    let recorded: String = conn
+        .query_row(
+            "SELECT value FROM quaid_config WHERE key = 'embedder_version'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("read recorded embedder version");
+    assert_eq!(
+        recorded,
+        EMBEDDER_VERSION.to_string(),
+        "a clean full pass must record the current embedder version"
+    );
+}
+
+// ── Acceptance: mid-page fact recall via the semantic arm ────────────────────
+
+/// THE acceptance test for the embedding-quality fix: a fact planted ~5,000
+/// characters into a heading-less page must be returned — ranked first, above
+/// related-domain distractor pages, and above the pre-fix score level — by
+/// `search_vec`. Before chunk capping, the whole page was one chunk silently
+/// truncated at 512 tokens, so the fact contributed nothing to the vector
+/// index: under the old pipeline this store scores the journal page 0.414
+/// (noise floor) and ranks the office-safe distractor (0.443) above it. With
+/// CLS pooling + the query instruction + capped overlapping chunks, the
+/// fact-bearing window scores ~0.50 while the distractors drop to ≤0.44.
+#[test]
+fn fact_planted_mid_page_is_returned_by_search_vec() {
+    if !semantic_backend_available() {
+        eprintln!("skipping: semantic embedding backend unavailable (hash shim)");
+        return;
+    }
+
+    let conn = open_test_db();
+
+    let fact =
+        "The launch codes are kept inside the red filing cabinet in the basement archive room.";
+    let truth = format!(
+        "{}{fact}\n\n{}",
+        journal_filler(5_000, 0),
+        journal_filler(5_000, 7)
+    );
+    insert_page(&conn, "journal/2026-06-01", "Journal 2026-06-01", &truth);
+    insert_page(
+        &conn,
+        "notes/office-safe",
+        "Office safe",
+        "The office safe in the records room holds the petty cash box and the master \
+         keys for the storage closets.",
+    );
+    insert_page(
+        &conn,
+        "notes/office-security",
+        "Office security",
+        "Building access requires a badge at every entrance. Visitors sign in at the \
+         front desk, and security cameras cover the lobby and the parking garage.",
+    );
+    insert_page(
+        &conn,
+        "notes/sourdough",
+        "Sourdough log",
+        "The starter doubled in six hours at room temperature. Next bake: increase \
+         hydration to 78 percent and proof overnight in the fridge.",
+    );
+
+    embed::run(&conn, None, true, false).expect("embed all pages");
+
+    let results = search_vec("Where are the launch codes kept?", 3, None, None, &conn)
+        .expect("vector search");
+
+    assert!(!results.is_empty(), "semantic search returned no results");
+    let ranking: Vec<_> = results
+        .iter()
+        .map(|result| (result.slug.clone(), result.score))
+        .collect();
+    assert_eq!(
+        results[0].slug, "journal/2026-06-01",
+        "the page holding the mid-page fact must rank first, got {ranking:?}"
+    );
+    assert!(
+        results[0].score > 0.45,
+        "the fact-bearing window must score above the pre-fix noise floor \
+         (~0.41 when the fact was truncated away), got {ranking:?}"
+    );
+}


### PR DESCRIPTION
Implements **Area 2 — Embedding semantic quality** of the codebase review (`docs/fable-review.md` on `code-review-2`). Targets the DAB paraphrase-recall failure mode (#219/#220, e.g. Q01's mid-page $75K line).

## Changes
- **CLS pooling**: `cls_pool_and_normalize` replaces masked mean pooling in both `embed_candle` and the XLM-R (bge-m3) path — BGE-en-v1.5 and m3 dense retrieval are CLS-pooled per spec; Quaid was driving them off-spec.
- **Asymmetric retrieval**: new `embed_query()` prepends `"Represent this sentence for searching relevant passages: "` for en-v1.5 aliases only (not m3/custom/hash-shim); wired into `search_vec_internal` only — novelty/supersede keep symmetric plain embeddings.
- **Chunk size cap** (`chunking.rs`): chunks over ~480 est. tokens sub-split into ~440-token windows with ~60-token overlap (paragraph→line→char boundaries); `heading_path` gets a ` [2/3]` part suffix. Previously a heading-less page was one chunk and everything past ~2,000 chars was invisible to semantic search (silent 512-token truncation).
- **Truncation warning** when the 512-token slice still truncates.
- **`embedder_version` = 2** (quaid_config KV — reaches existing v10 stores with zero DDL): `page_needs_refresh` returns true on mismatch so `quaid embed --all`/`--stale` performs a one-time re-embed; version recorded only after a clean pass so failures retry.

## Validation (real embedded BGE-small, offline)
- New `tests/embedding_quality.rs` 8/8 — including **the acceptance test**: a fact planted at char ~5000 of a heading-less 10KB page now ranks first in `search_vec` (0.498, floor 0.45); empirically verified to fail on stashed main both ways (ranked last at 0.414, below floor).
- Threshold-sensitive suites baselined pre-change and re-run post-change — fact_resolution, supersede_chain, file_edit_supersede, novelty: **all pass unchanged**; the 0.92/0.4 seeds needed no adjustment.
- Broad blast radius green (search_hardening, mcp query/search/list, graph_retrieval, corpus_reality, roundtrips, embedding_migration, + lib suites). fmt/clippy clean.

## Post-merge requirements (cannot run in the dev container)
1. One-time `quaid embed --all` on real stores (gated by the version bump — self-healing for watcher-only stores).
2. Re-run DAB/BEIR before tuning any seeds further — this changes every stored embedding.

## Notes
- One inline test's score bound relaxed 0.99→0.85 with comment: it pinned query==passage identity, which the query instruction legitimately breaks.
- Schema seed appended at end of the config block — trivially conflicts with sibling Wave-1 PRs doing the same; merge any order, fix-up is one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)