### PR TITLE
feat(search): rerank config/dedup/floor, graph hops plumbing, gap-loop fixes (areas 1.4-1.5, 14)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,7 @@ See `src/schema.sql` for the current DDL. Key tables:
 Core (Phase 1): `memory_get`, `memory_put`, `memory_query`, `memory_search`, `memory_list`
 
 Full surface (Phase 2+): `memory_link`, `memory_link_close`, `memory_backlinks`, `memory_graph`,
-`memory_timeline`, `memory_tags`, `memory_check`, `memory_gap`, `memory_gaps`, `memory_stats`, `memory_raw`
+`memory_timeline`, `memory_tags`, `memory_check`, `memory_gap`, `memory_gaps`, `memory_gap_resolve`, `memory_stats`, `memory_raw`
 
 ## Optimistic concurrency
 

--- a/openspec/changes/retrieval-quality-rerank/tasks.md
+++ b/openspec/changes/retrieval-quality-rerank/tasks.md
@@ -1,28 +1,48 @@
 ## 1. Config plumbing and result-shape extension
 
-- [ ] 1.1 Add `relevance_floor`, `mmr_lambda`, `max_chunks_per_doc_default`, `cross_ref_boost_weight`, `cross_ref_boost_cap`, `rerank_extractive`, `rerank_extractive_top_n`, `rerank_extractive_budget_ms` to the `config` table seed defaults in `src/schema.sql` (identity values for the no-op rollout: `mmr_lambda=1.0`, `relevance_floor=0.0`, `max_chunks_per_doc_default=0`, `cross_ref_boost_weight=0.0`, `rerank_extractive=false`)
-- [ ] 1.2 Add config-read helpers in `src/core/db.rs` or `src/core/config.rs` for each new key with typed getters and `[0.0, 1.0]` range validation on writes
-- [ ] 1.3 Extend `SearchResult` in `src/core/types.rs` with optional `mmr_score: Option<f32>`, `cross_ref_boost: f32`, `dedup_collapsed_count: u32` fields; default values when filters are inactive
-- [ ] 1.4 Update `cargo test` to confirm existing roundtrip and search tests still pass with the extended struct
+> **Naming decision (Sections 1–3 implementation):** all new config keys use
+> the established `search.*` prefix instead of the unprefixed names below —
+> `search.relevance_floor` (already seeded by the Wave 0 retrieval fixes;
+> reused, not duplicated), `search.mmr_lambda`,
+> `search.max_chunks_per_doc_default`, `search.cross_ref_boost_weight`,
+> `search.cross_ref_boost_cap`, `search.rerank_extractive`,
+> `search.rerank_extractive_top_n`, `search.rerank_extractive_budget_ms`.
+>
+> **Reconciliation with Wave 0:** `search.relevance_floor` landed in Wave 0
+> as an absolute raw-cosine floor on the vector arm pre-merge. That behavior
+> is kept; Sections 3.x add the post-fusion floor pass driven by the same
+> key (and the same per-call override). Both are identity no-ops at the
+> seeded `0.0`.
+
+- [x] 1.1 Add `relevance_floor`, `mmr_lambda`, `max_chunks_per_doc_default`, `cross_ref_boost_weight`, `cross_ref_boost_cap`, `rerank_extractive`, `rerank_extractive_top_n`, `rerank_extractive_budget_ms` to the `config` table seed defaults in `src/schema.sql` (identity values for the no-op rollout: `mmr_lambda=1.0`, `relevance_floor=0.0`, `max_chunks_per_doc_default=0`, `cross_ref_boost_weight=0.0`, `rerank_extractive=false`) — *done with the `search.*` prefix; `search.relevance_floor` was already seeded by Wave 0*
+- [x] 1.2 Add config-read helpers in `src/core/db.rs` or `src/core/config.rs` for each new key with typed getters and `[0.0, 1.0]` range validation on writes — *typed getters `configured_relevance_floor` / `configured_max_chunks_per_doc` live in `src/core/search.rs` next to the existing config readers; the floor getter clamps reads into `[0.0, 1.0]`. `quaid config set` is generic and has no per-key write validation today, so range validation is enforced on the CLI flags (clap value parser) and MCP parameters instead. Getters for the Section 4–6 keys land with their consuming sections to avoid dead plumbing.*
+- [x] 1.3 Extend `SearchResult` in `src/core/types.rs` with optional `mmr_score: Option<f32>`, `cross_ref_boost: f32`, `dedup_collapsed_count: u32` fields; default values when filters are inactive — *fields are `#[serde(default)]` and skipped during serialization at their inactive values, so default-config JSON output is unchanged*
+- [x] 1.4 Update `cargo test` to confirm existing roundtrip and search tests still pass with the extended struct — *validated with targeted runs of the search/gaps/progressive test files (full suite is too heavy for the dev container; CI runs it)*
 
 ## 2. Intra-document deduplication (`result-deduplication` capability)
 
-- [ ] 2.1 Implement `dedup_chunks_per_page(candidates, max_per_page)` in `src/core/search.rs` returning representatives with populated `dedup_collapsed_count`
-- [ ] 2.2 Wire `dedup_chunks_per_page` as the first post-fusion pass in `hybrid_search`
-- [ ] 2.3 Apply the same dedup pass on the initial set and on every expansion step inside `progressive_retrieve` (`src/core/progressive.rs`)
-- [ ] 2.4 Add `--max-chunks-per-doc N` CLI flag to `src/commands/search.rs` and `src/commands/query.rs`; flag value of `0` means "unlimited" per the spec
-- [ ] 2.5 Pass-through `max_chunks_per_doc` parameter on `memory_search` and `memory_query` MCP tools in `src/mcp/server.rs`
-- [ ] 2.6 Write `tests/search_dedup.rs` covering: three-chunk collapse, single-chunk passthrough, `dedup_collapsed_count` correctness, `--max-chunks-per-doc 2` behavior, `progressive_retrieve` re-application
+> **Note:** both retrieval arms currently emit page-level rows (FTS indexes
+> pages; the vector arm takes `MAX` cosine per page with `GROUP BY p.id`),
+> so the merged candidate set is already unique per page and this pass is an
+> identity safeguard until chunk-level candidates land. The pass is wired
+> and tested against synthetic multi-row-per-page candidate lists.
+
+- [x] 2.1 Implement `dedup_chunks_per_page(candidates, max_per_page)` in `src/core/search.rs` returning representatives with populated `dedup_collapsed_count`
+- [x] 2.2 Wire `dedup_chunks_per_page` as the first post-fusion pass in `hybrid_search`
+- [x] 2.3 Apply the same dedup pass on the initial set and on every expansion step inside `progressive_retrieve` (`src/core/progressive.rs`)
+- [x] 2.4 Add `--max-chunks-per-doc N` CLI flag to `src/commands/search.rs` and `src/commands/query.rs`; flag value of `0` means "unlimited" per the spec
+- [x] 2.5 Pass-through `max_chunks_per_doc` parameter on `memory_search` and `memory_query` MCP tools in `src/mcp/server.rs`
+- [x] 2.6 Write `tests/search_dedup.rs` covering: three-chunk collapse, single-chunk passthrough, `dedup_collapsed_count` correctness, `--max-chunks-per-doc 2` behavior, `progressive_retrieve` re-application
 
 ## 3. Confidence threshold filter (`confidence-thresholding` capability)
 
-- [ ] 3.1 Implement `filter_below_floor(candidates, floor)` in `src/core/search.rs`
-- [ ] 3.2 Wire the floor pass after dedup and cross-reference boost (after Section 4 lands) and before MMR
-- [ ] 3.3 Apply floor inside `progressive_retrieve` on initial and expansion-step candidates; below-floor candidates are not expanded
-- [ ] 3.4 Add `--relevance-floor F` CLI flag to `quaid search` and `quaid query` with `[0.0, 1.0]` validation
-- [ ] 3.5 Add `relevance_floor` parameter to `memory_search` and `memory_query` MCP tool schemas
-- [ ] 3.6 Confirm under-fill returns successfully (no error, no padding); update CLI/MCP response wording as needed
-- [ ] 3.7 Write `tests/search_confidence.rs` covering: below/at/above-floor cases, post-boost score comparison, empty-result success path, `--relevance-floor 0.0` disable, MCP parameter override
+- [x] 3.1 Implement `filter_below_floor(candidates, floor)` in `src/core/search.rs`
+- [x] 3.2 Wire the floor pass after dedup and cross-reference boost (after Section 4 lands) and before MMR — *wired after dedup and before graph expansion; the boost insertion point (Section 4) and MMR (Section 5) remain open*
+- [x] 3.3 Apply floor inside `progressive_retrieve` on initial and expansion-step candidates; below-floor candidates are not expanded
+- [x] 3.4 Add `--relevance-floor F` CLI flag to `quaid search` and `quaid query` with `[0.0, 1.0]` validation
+- [x] 3.5 Add `relevance_floor` parameter to `memory_search` and `memory_query` MCP tool schemas
+- [x] 3.6 Confirm under-fill returns successfully (no error, no padding); update CLI/MCP response wording as needed — *covered by tests; existing empty-result wording ("No results found." / empty JSON array) already matches the fewer-than-k contract*
+- [x] 3.7 Write `tests/search_confidence.rs` covering: below/at/above-floor cases, post-boost score comparison, empty-result success path, `--relevance-floor 0.0` disable, MCP parameter override — *post-boost comparison deferred to Section 4 (cross-ref boost not yet implemented)*
 
 ## 4. Cross-reference boost (`cross-reference-scoring` capability)
 

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -138,13 +138,19 @@ Always append to the `timeline` section with a sourced, dated entry. Never overw
 
 Once findings are ingested and a resolution page/slug exists:
 
-1. Obtain approval through the session's `memory_gap_approve` workflow, providing:
-   - `gap_id`
-   - `resolution_slug` — the slug of the page containing the answer
-
-2. After approval is granted, confirm the gap appears in resolved state:
+1. Resolve the gap with the page that answers it (resolution is brain-internal
+   and needs no approval — approval workflows only gate sensitivity escalation):
    ```bash
-   quaid gaps --resolved true --json | jq '.[] | select(.id == <gap_id>)'
+   quaid gaps resolve <gap_id> <resolution_slug>
+   # or via MCP:
+   quaid call memory_gap_resolve '{"id": <gap_id>, "slug": "<resolution_slug>"}'
+   ```
+   The slug must resolve to an existing page; unknown gap ids return a
+   not-found error.
+
+2. Confirm the gap appears in resolved state:
+   ```bash
+   quaid gaps --resolved --json | jq '.[] | select(.id == <gap_id>)'
    ```
 
 ---

--- a/src/commands/call.rs
+++ b/src/commands/call.rs
@@ -117,6 +117,13 @@ pub fn dispatch_tool(server: &QuaidServer, tool: &str, params: Value) -> Result<
                 serde_json::from_value(params).map_err(|e| format!("invalid params: {e}"))?;
             server.memory_gaps(input).map_err(|e| e.message.to_string())
         }
+        "memory_gap_resolve" => {
+            let input: MemoryGapResolveInput =
+                serde_json::from_value(params).map_err(|e| format!("invalid params: {e}"))?;
+            server
+                .memory_gap_resolve(input)
+                .map_err(|e| e.message.to_string())
+        }
         "memory_stats" => {
             let input: MemoryStatsInput =
                 serde_json::from_value(params).map_err(|e| format!("invalid params: {e}"))?;

--- a/src/commands/gaps.rs
+++ b/src/commands/gaps.rs
@@ -4,10 +4,69 @@
 )]
 
 use anyhow::Result;
+use clap::Subcommand;
 use rusqlite::Connection;
 use serde::Serialize;
 
-use crate::core::gaps::list_gaps;
+use crate::core::collections::{self, OpKind, SlugResolution};
+use crate::core::gaps::{list_gaps, resolve_gap};
+
+/// Subactions of `quaid gaps` (plain `quaid gaps` lists unresolved gaps).
+#[derive(Clone, Debug, Subcommand)]
+pub enum GapsAction {
+    /// Mark a knowledge gap resolved by the page that answered it
+    Resolve {
+        /// Numeric gap id (see `quaid gaps`)
+        id: i64,
+        /// Slug of the page that answers the gap
+        slug: String,
+    },
+}
+
+/// Handle `quaid gaps resolve <id> <slug>`: validate that the slug resolves
+/// to an existing page, then flip the gap's `resolved_at`/`resolved_by_slug`.
+pub fn resolve(db: &Connection, id: i64, slug: &str, json: bool) -> Result<()> {
+    let (collection_id, resolved_slug) = match collections::parse_slug(db, slug, OpKind::Read)? {
+        SlugResolution::Resolved {
+            collection_id,
+            slug,
+            ..
+        } => (collection_id, slug),
+        SlugResolution::NotFound { slug } => {
+            anyhow::bail!("page not found: {slug}");
+        }
+        SlugResolution::Ambiguous { slug, candidates } => {
+            anyhow::bail!(
+                "ambiguous slug `{slug}`; candidates: {}",
+                candidates
+                    .into_iter()
+                    .map(|candidate| candidate.full_address)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+        }
+    };
+    let page_exists: bool = db.query_row(
+        "SELECT EXISTS(SELECT 1 FROM pages WHERE collection_id = ?1 AND slug = ?2)",
+        rusqlite::params![collection_id, &resolved_slug],
+        |row| row.get(0),
+    )?;
+    if !page_exists {
+        anyhow::bail!("page not found: {resolved_slug}");
+    }
+
+    resolve_gap(id, &resolved_slug, db)?;
+
+    if json {
+        println!(
+            "{}",
+            serde_json::json!({"id": id, "resolved_by_slug": resolved_slug})
+        );
+    } else {
+        println!("Gap {id} resolved by {resolved_slug}.");
+    }
+    Ok(())
+}
 
 pub fn run(db: &Connection, limit: u32, resolved: bool, json: bool) -> Result<()> {
     let gaps = list_gaps(resolved, limit as usize, db)?;
@@ -21,6 +80,7 @@ pub fn run(db: &Connection, limit: u32, resolved: bool, json: bool) -> Result<()
             confidence_score: Option<f64>,
             sensitivity: String,
             resolved_at: Option<String>,
+            resolved_by_slug: Option<String>,
             detected_at: String,
         }
 
@@ -33,6 +93,7 @@ pub fn run(db: &Connection, limit: u32, resolved: bool, json: bool) -> Result<()
                 confidence_score: g.confidence_score,
                 sensitivity: g.sensitivity,
                 resolved_at: g.resolved_at,
+                resolved_by_slug: g.resolved_by_slug,
                 detected_at: g.detected_at,
             })
             .collect();

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -38,6 +38,8 @@ pub async fn run(
     include_superseded: bool,
     json: bool,
     hops: Option<u32>,
+    relevance_floor: Option<f64>,
+    max_chunks_per_doc: Option<usize>,
 ) -> Result<()> {
     crate::core::namespace::validate_optional_namespace(namespace)
         .map_err(|err| anyhow::anyhow!(err.to_string()))?;
@@ -52,13 +54,16 @@ pub async fn run(
             canonical: true,
             limit: limit as usize,
             hops,
+            relevance_floor,
+            max_chunks_per_doc,
             ..Default::default()
         },
     )?;
 
     // Auto-log knowledge gap on weak results
-    if results.len() < 2 || results.iter().all(|r| r.score < 0.3) {
-        if let Err(e) = gaps::log_gap(None, query, "", results.first().map(|r| r.score), db) {
+    if gaps::should_log_gap(&results) {
+        let context = gaps::auto_gap_context("hybrid_search", &results);
+        if let Err(e) = gaps::log_gap(None, query, &context, results.first().map(|r| r.score), db) {
             eprintln!("Warning: failed to log knowledge gap: {e}");
         } else {
             eprintln!("Knowledge gap logged.");
@@ -143,6 +148,7 @@ mod tests {
             summary: summary.to_owned(),
             score: 1.0,
             wing: "people".to_owned(),
+            ..Default::default()
         }
     }
 
@@ -218,6 +224,8 @@ mod tests {
             false,
             true,
             None,
+            None,
+            None,
         )
         .await;
         assert!(result.is_ok());
@@ -238,6 +246,8 @@ mod tests {
             false,
             false,
             None,
+            None,
+            None,
         )
         .await;
         assert!(result.is_ok());
@@ -249,7 +259,7 @@ mod tests {
         let conn = db::open(":memory:").unwrap();
         // depth="auto" triggers read_token_budget + progressive_retrieve path
         let result = run(
-            &conn, "anything", "auto", 5, 0, None, None, false, false, None,
+            &conn, "anything", "auto", 5, 0, None, None, false, false, None, None, None,
         )
         .await;
         assert!(result.is_ok());
@@ -260,7 +270,7 @@ mod tests {
         use crate::core::db;
         let conn = db::open(":memory:").unwrap();
         let result = run(
-            &conn, "query", "auto", 5, 2000, None, None, false, true, None,
+            &conn, "query", "auto", 5, 2000, None, None, false, true, None, None, None,
         )
         .await;
         assert!(result.is_ok());
@@ -291,6 +301,8 @@ mod tests {
             false,
             false,
             None,
+            None,
+            None,
         )
         .await;
         assert!(result.is_ok());
@@ -317,6 +329,8 @@ mod tests {
             None,
             false,
             true,
+            None,
+            None,
             None,
         )
         .await;

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -22,6 +22,8 @@ pub fn run(
     json: bool,
     raw: bool,
     hops: Option<u32>,
+    relevance_floor: Option<f64>,
+    max_chunks_per_doc: Option<usize>,
 ) -> Result<()> {
     crate::core::namespace::validate_optional_namespace(namespace)
         .map_err(|err| anyhow::anyhow!(err.to_string()))?;
@@ -58,6 +60,20 @@ pub fn run(
         }
     };
 
+    // Post-retrieval quality passes (dedup → floor); identity no-ops at the
+    // seeded config defaults. The flag values, when given, override the
+    // `search.max_chunks_per_doc_default` / `search.relevance_floor` keys.
+    let results = match apply_quality_passes(db, results, relevance_floor, max_chunks_per_doc) {
+        Ok(filtered) => filtered,
+        Err(e) => {
+            if json {
+                println!("{}", serde_json::json!({"error": e.to_string()}));
+                return Ok(());
+            }
+            return Err(e.into());
+        }
+    };
+
     let results: Vec<_> = results.into_iter().take(limit as usize).collect();
 
     // Apply graph expansion when the effective depth is non-zero. The CLI
@@ -87,6 +103,31 @@ pub fn run(
     }
 
     Ok(())
+}
+
+fn apply_quality_passes(
+    db: &Connection,
+    results: Vec<crate::core::types::SearchResult>,
+    relevance_floor: Option<f64>,
+    max_chunks_per_doc: Option<usize>,
+) -> std::result::Result<Vec<crate::core::types::SearchResult>, crate::core::types::SearchError> {
+    use crate::core::search::{
+        configured_max_chunks_per_doc, configured_relevance_floor, dedup_chunks_per_page,
+        filter_below_floor,
+    };
+
+    let max_per_page = match max_chunks_per_doc {
+        Some(value) => value,
+        None => configured_max_chunks_per_doc(db)?,
+    };
+    let floor = match relevance_floor {
+        Some(value) => value.clamp(0.0, 1.0),
+        None => configured_relevance_floor(db)?,
+    };
+    Ok(filter_below_floor(
+        dedup_chunks_per_page(results, max_per_page),
+        floor,
+    ))
 }
 
 fn expand_with_hops(
@@ -142,6 +183,8 @@ mod tests {
             false,
             false,
             None,
+            None,
+            None,
         );
         assert!(
             result.is_ok(),
@@ -163,6 +206,8 @@ mod tests {
             false,
             false,
             None,
+            None,
+            None,
         );
         assert!(
             result.is_ok(),
@@ -183,6 +228,8 @@ mod tests {
             false,
             false,
             false,
+            None,
+            None,
             None,
         );
         assert!(
@@ -206,6 +253,8 @@ mod tests {
             true,
             false,
             None,
+            None,
+            None,
         );
         assert!(
             result.is_ok(),
@@ -218,7 +267,9 @@ mod tests {
     fn run_raw_json_mode_with_invalid_fts5_returns_ok_not_panic() {
         let (_dir, conn) = open_test_db();
         // '?invalid' is invalid FTS5 with --raw; the error is printed as JSON, not propagated.
-        let result = run(&conn, "?invalid", None, None, 10, false, true, true, None);
+        let result = run(
+            &conn, "?invalid", None, None, 10, false, true, true, None, None, None,
+        );
         assert!(
             result.is_ok(),
             "--raw --json with bad FTS5 must return Ok (error JSON on stdout): {result:?}"

--- a/src/core/fts.rs
+++ b/src/core/fts.rs
@@ -566,6 +566,7 @@ fn search_fts_internal(
             summary: row.get(2)?,
             score: row.get(3)?,
             wing: row.get(4)?,
+            ..Default::default()
         })
     })?;
 

--- a/src/core/gaps.rs
+++ b/src/core/gaps.rs
@@ -1,7 +1,8 @@
 //! Knowledge-gap log: records queries the brain couldn't answer (keyed by
 //! SHA-256 for idempotent inserts), lists unresolved entries, and links them
-//! to pages that later answered them. Provides the data behind `quaid gap`,
-//! `quaid gaps`, and the matching MCP tools.
+//! to pages that later answered them. Provides the data behind `quaid gaps`
+//! (including `quaid gaps resolve`) and the matching MCP tools
+//! (`memory_gap`, `memory_gaps`, `memory_gap_resolve`).
 //!
 //! See also: `types::KnowledgeGap` for the row shape, and `search` for the
 //! query path that detects low-confidence retrievals.
@@ -10,7 +11,7 @@ use rusqlite::{params, Connection};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
 
-use super::types::KnowledgeGap;
+use super::types::{KnowledgeGap, SearchResult};
 
 /// Failure mode raised by gap logging, listing, or resolution.
 #[derive(Debug, Error)]
@@ -25,6 +26,37 @@ pub enum GapsError {
         /// The requested gap id.
         id: i64,
     },
+}
+
+/// Decide whether a retrieval outcome should be auto-logged as a knowledge
+/// gap.
+///
+/// A top result scoring `>= 0.99` is a perfect hit (the exact-slug
+/// short-circuit returns `1.0`, and a top-normalized strong hybrid hit
+/// approaches `1.0` under both merge strategies) and is never a gap.
+/// Otherwise a gap is logged when the result set is empty or every result
+/// scores below `0.3`. Both hybrid merge strategies emit scores on a
+/// `[0, 1]` scale, so the single threshold applies to either.
+pub fn should_log_gap(results: &[SearchResult]) -> bool {
+    if results.first().is_some_and(|result| result.score >= 0.99) {
+        return false;
+    }
+    results.is_empty() || results.iter().all(|result| result.score < 0.3)
+}
+
+/// Build the machine-generated, query-free diagnostics string recorded as
+/// the `context` of an auto-logged gap (e.g. `auto: hybrid_search results=3
+/// top=0.02`). Never includes query text, preserving the privacy-by-default
+/// posture of the gap log.
+pub fn auto_gap_context(source: &str, results: &[SearchResult]) -> String {
+    match results.first() {
+        Some(top) => format!(
+            "auto: {source} results={} top={:.2}",
+            results.len(),
+            top.score
+        ),
+        None => format!("auto: {source} results=0"),
+    }
 }
 
 /// Log a knowledge gap using the SHA-256 of the query for idempotency.

--- a/src/core/inference.rs
+++ b/src/core/inference.rs
@@ -1489,6 +1489,7 @@ fn search_vec_internal(
             summary: row.get(2)?,
             score: row.get(3)?,
             wing: row.get(4)?,
+            ..Default::default()
         })
     })?;
 

--- a/src/core/progressive.rs
+++ b/src/core/progressive.rs
@@ -3,6 +3,10 @@ use std::collections::HashSet;
 use rusqlite::Connection;
 
 use super::collections::{self, OpKind, SlugResolution};
+use super::search::{
+    configured_max_chunks_per_doc, configured_relevance_floor, dedup_chunks_per_page,
+    filter_below_floor,
+};
 use super::types::{SearchError, SearchResult};
 
 /// Hard safety cap on expansion depth regardless of caller-supplied value.
@@ -13,7 +17,10 @@ const MAX_DEPTH: u32 = 3;
 ///
 /// Token count is approximated as `len(compiled_truth) / 4`.
 /// Results are deduplicated by slug. Initial results appear first, followed
-/// by expansion results ordered by link distance.
+/// by expansion results ordered by link distance. The post-fusion quality
+/// passes from `core::search` (per-page dedup, relevance floor) are applied
+/// to the initial set and re-applied on every expansion step; both are
+/// identity no-ops at their seeded config defaults.
 ///
 /// `collection_filter` restricts expansion to pages belonging to the given
 /// collection ID. Pass `None` to allow cross-collection expansion (CLI path).
@@ -54,6 +61,17 @@ pub fn progressive_retrieve_with_namespace(
             .filter(|result| page_is_head(&result.slug, conn))
             .collect()
     };
+
+    // Apply the same post-fusion quality passes as `hybrid_search` (dedup →
+    // floor) so token-budget expansion sees the same filtered candidate set
+    // as the top-k API. Both passes are identity no-ops at their seeded
+    // defaults. Below-floor candidates are never expanded.
+    let max_chunks_per_doc = configured_max_chunks_per_doc(conn)?;
+    let relevance_floor = configured_relevance_floor(conn)?;
+    let initial = filter_below_floor(
+        dedup_chunks_per_page(initial, max_chunks_per_doc),
+        relevance_floor,
+    );
     if initial.is_empty() || depth == 0 {
         return Ok(initial);
     }
@@ -83,30 +101,38 @@ pub fn progressive_retrieve_with_namespace(
             break;
         }
 
-        let mut next_frontier: Vec<String> = Vec::new();
-
+        let mut hop_candidates: Vec<SearchResult> = Vec::new();
         for slug in &frontier {
-            let neighbours = outbound_neighbours(
+            hop_candidates.extend(outbound_neighbours(
                 slug,
                 collection_filter,
                 namespace_filter,
                 include_superseded,
                 conn,
-            )?;
-            for neighbour in neighbours {
-                if !seen.insert(neighbour.slug.clone()) {
-                    continue;
-                }
+            )?);
+        }
+        // Re-apply dedup + floor on every expansion step (identity at the
+        // seeded defaults) so each hop honours the same quality bar as the
+        // initial candidate set.
+        let hop_candidates = filter_below_floor(
+            dedup_chunks_per_page(hop_candidates, max_chunks_per_doc),
+            relevance_floor,
+        );
 
-                let cost = token_cost(&neighbour.slug, conn);
-                if tokens_used + cost > budget {
-                    continue;
-                }
-
-                tokens_used += cost;
-                next_frontier.push(neighbour.slug.clone());
-                results.push(neighbour);
+        let mut next_frontier: Vec<String> = Vec::new();
+        for neighbour in hop_candidates {
+            if !seen.insert(neighbour.slug.clone()) {
+                continue;
             }
+
+            let cost = token_cost(&neighbour.slug, conn);
+            if tokens_used + cost > budget {
+                continue;
+            }
+
+            tokens_used += cost;
+            next_frontier.push(neighbour.slug.clone());
+            results.push(neighbour);
         }
 
         frontier = next_frontier;
@@ -213,6 +239,7 @@ fn outbound_neighbours(
                     summary: row.get(2)?,
                     score: 0.0,
                     wing: row.get(3)?,
+                    ..Default::default()
                 })
             },
         )
@@ -298,6 +325,7 @@ mod tests {
             summary: slug.to_owned(),
             score: 1.0,
             wing: "".to_owned(),
+            ..Default::default()
         }
     }
 

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -71,6 +71,16 @@ pub struct HybridSearch<'a> {
     /// read from `config.graph_depth` (default `0`). Set `Some(0)` to
     /// disable graph expansion for this invocation.
     pub hops: Option<u32>,
+    /// Optional per-call relevance floor in `[0.0, 1.0]`. When `None`, the
+    /// floor is read from `config.search.relevance_floor` (seeded `0.0` =
+    /// disabled). Applied to the vector arm's raw cosine scores pre-merge
+    /// and to the merged scores post-fusion; results below the floor are
+    /// dropped even if fewer than `limit` rows remain.
+    pub relevance_floor: Option<f64>,
+    /// Optional per-call cap on rows retained per page in the merged
+    /// results. When `None`, the cap is read from
+    /// `config.search.max_chunks_per_doc_default` (seeded `0` = unlimited).
+    pub max_chunks_per_doc: Option<usize>,
 }
 
 /// Hybrid search with exact-slug short-circuit, FTS5, and vector search.
@@ -150,20 +160,96 @@ pub fn hybrid_search(
     // Absolute cosine floor on the vector arm, applied to the raw cosine
     // scores before the per-arm normalization in the merge step. The seeded
     // default `0.0` is identity behaviour: no hit is dropped.
-    let relevance_floor = read_config_f64(conn, "search.relevance_floor", 0.0)?;
+    let relevance_floor = match q.relevance_floor {
+        Some(floor) => floor.clamp(0.0, 1.0),
+        None => configured_relevance_floor(conn)?,
+    };
     if relevance_floor > 0.0 {
         vec_results.retain(|result| result.score >= relevance_floor);
     }
 
-    let mut merged = match read_merge_strategy(conn)? {
+    let merged = match read_merge_strategy(conn)? {
         SearchMergeStrategy::SetUnion => merge_set_union(&fts_results, &vec_results),
         SearchMergeStrategy::Rrf => merge_rrf(&fts_results, &vec_results),
     };
+
+    // Post-fusion quality passes (dedup → floor), each an identity no-op at
+    // its seeded default. The floor runs before graph expansion so a
+    // below-floor noise hit is never used as an expansion seed.
+    let max_chunks_per_doc = match q.max_chunks_per_doc {
+        Some(value) => value,
+        None => configured_max_chunks_per_doc(conn)?,
+    };
+    let merged = dedup_chunks_per_page(merged, max_chunks_per_doc);
+    let mut merged = filter_below_floor(merged, relevance_floor);
 
     apply_graph_expansion(conn, &mut merged, q.hops, q.collection)?;
 
     merged.truncate(q.limit);
     Ok(merged)
+}
+
+/// Read the configured post-fusion relevance floor
+/// (`config.search.relevance_floor`, seeded `0.0` = disabled), clamped into
+/// the valid `[0.0, 1.0]` range.
+pub fn configured_relevance_floor(conn: &Connection) -> Result<f64, SearchError> {
+    Ok(read_config_f64(conn, "search.relevance_floor", 0.0)?.clamp(0.0, 1.0))
+}
+
+/// Read the configured per-page result cap
+/// (`config.search.max_chunks_per_doc_default`, seeded `0` = unlimited).
+pub fn configured_max_chunks_per_doc(conn: &Connection) -> Result<usize, SearchError> {
+    read_config_usize(conn, "search.max_chunks_per_doc_default", 0)
+}
+
+/// Collapse multi-chunk hits from the same page down to at most
+/// `max_per_page` representatives, accumulating the number of collapsed
+/// siblings into the strongest surviving row's `dedup_collapsed_count`.
+///
+/// Candidates are expected in score-descending order (the order every
+/// retrieval arm and merge strategy produces); relative order is preserved.
+/// `max_per_page == 0` means unlimited and returns the input unchanged —
+/// the seeded identity default.
+pub fn dedup_chunks_per_page(
+    candidates: Vec<SearchResult>,
+    max_per_page: usize,
+) -> Vec<SearchResult> {
+    if max_per_page == 0 {
+        return candidates;
+    }
+
+    let mut kept: Vec<SearchResult> = Vec::with_capacity(candidates.len());
+    let mut kept_by_page: HashMap<String, Vec<usize>> = HashMap::new();
+    for candidate in candidates {
+        let entry = kept_by_page.entry(candidate.slug.clone()).or_default();
+        if entry.len() < max_per_page {
+            entry.push(kept.len());
+            kept.push(candidate);
+        } else {
+            let strongest = entry
+                .iter()
+                .copied()
+                .max_by(|left, right| kept[*left].score.total_cmp(&kept[*right].score))
+                .unwrap_or(entry[0]);
+            kept[strongest].dedup_collapsed_count += 1 + candidate.dedup_collapsed_count;
+        }
+    }
+    kept
+}
+
+/// Drop candidates whose score falls below `floor`, even if fewer than the
+/// requested number of results remain ("fewer-than-k" contract).
+///
+/// `floor <= 0.0` disables filtering and returns the input unchanged — the
+/// seeded identity default. Scores exactly at the floor are kept.
+pub fn filter_below_floor(candidates: Vec<SearchResult>, floor: f64) -> Vec<SearchResult> {
+    if floor <= 0.0 {
+        return candidates;
+    }
+    candidates
+        .into_iter()
+        .filter(|candidate| candidate.score >= floor)
+        .collect()
 }
 
 /// Bounded outbound graph expansion knobs.
@@ -380,6 +466,7 @@ pub fn expand_graph(
                         summary,
                         score,
                         wing,
+                        ..Default::default()
                     });
                 if visited.insert(target_slug.clone()) {
                     total_visited += 1;
@@ -537,6 +624,7 @@ fn exact_slug_result_with_namespace(
             summary: row.get(2)?,
             score: 1.0,
             wing: row.get(3)?,
+            ..Default::default()
         })
     });
 
@@ -729,6 +817,7 @@ fn query_exact_slug_canonical(
             summary: row.get(2)?,
             score: 1.0,
             wing: row.get(3)?,
+            ..Default::default()
         })
     })
 }
@@ -775,6 +864,11 @@ fn merge_set_union(
 
 fn merge_rrf(fts_results: &[SearchResult], vec_results: &[SearchResult]) -> Vec<SearchResult> {
     const RRF_K: f64 = 60.0;
+    // Normalize the raw reciprocal-rank sum (max 2/(RRF_K+1) for a rank-0
+    // hit in both lists) onto the same [0, 1] scale as set-union scores, so
+    // one relevance floor and one gap-logging threshold work for both
+    // strategies.
+    let rrf_scale = (RRF_K + 1.0) / 2.0;
 
     let mut merged: HashMap<String, SearchResult> = HashMap::new();
 
@@ -798,6 +892,10 @@ fn merge_rrf(fts_results: &[SearchResult], vec_results: &[SearchResult]) -> Vec<
                 score: contribution,
                 ..result.clone()
             });
+    }
+
+    for result in merged.values_mut() {
+        result.score *= rrf_scale;
     }
 
     let mut results: Vec<_> = merged.into_values().collect();
@@ -852,6 +950,7 @@ mod tests {
             summary: format!("summary for {slug}"),
             score,
             wing: "people".to_owned(),
+            ..Default::default()
         }
     }
 
@@ -1617,6 +1716,33 @@ mod tests {
 
         assert_eq!(slugs, vec!["b", "a", "c"]);
         assert!(results[0].score > results[1].score);
+        // Normalized scale: a dual-list hit at ranks 1 and 0 lands just
+        // below 1.0; single-list hits land near 0.5.
+        assert!(
+            results[0].score > 0.9 && results[0].score <= 1.0,
+            "dual-list RRF hit must score near 1.0, got {}",
+            results[0].score
+        );
+        assert!(
+            (results[1].score - 0.5).abs() < 0.01,
+            "rank-0 single-list RRF hit must score ~0.5, got {}",
+            results[1].score
+        );
+    }
+
+    #[test]
+    fn merge_rrf_dual_rank_zero_hit_scores_exactly_one() {
+        let fts = vec![result("a", 10.0)];
+        let vec = vec![result("a", 8.0)];
+
+        let results = merge_rrf(&fts, &vec);
+
+        assert_eq!(results.len(), 1);
+        assert!(
+            (results[0].score - 1.0).abs() < 1e-12,
+            "rank-0 hit in both lists must normalize to 1.0, got {}",
+            results[0].score
+        );
     }
 
     #[test]

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -154,7 +154,7 @@ pub struct TimelineEntry {
 // ── SearchResult ──────────────────────────────────────────────
 
 /// A single result from FTS5, vector, or hybrid search.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SearchResult {
     /// Slug of the page that produced the hit.
     pub slug: String,
@@ -166,6 +166,29 @@ pub struct SearchResult {
     pub score: f64,
     /// Memory-palace wing of the page, exposed for downstream filtering.
     pub wing: String,
+    /// MMR-adjusted relevance score; populated only when the MMR rerank
+    /// pass is active (absent under the identity default `mmr_lambda=1.0`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mmr_score: Option<f32>,
+    /// Additive cross-reference boost folded into `score`; `0.0` (and
+    /// omitted from JSON) while cross-reference scoring is inactive.
+    #[serde(default, skip_serializing_if = "f32_is_zero")]
+    pub cross_ref_boost: f32,
+    /// Number of same-page sibling hits collapsed into this representative
+    /// row by the per-page dedup pass; `0` (and omitted from JSON) when no
+    /// collapse occurred.
+    #[serde(default, skip_serializing_if = "u32_is_zero")]
+    pub dedup_collapsed_count: u32,
+}
+
+/// `skip_serializing_if` helper: omit inactive (zero) boost values.
+fn f32_is_zero(value: &f32) -> bool {
+    *value == 0.0
+}
+
+/// `skip_serializing_if` helper: omit zero collapse counters.
+fn u32_is_zero(value: &u32) -> bool {
+    *value == 0
 }
 
 // ── Chunk ───────────────────────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,6 +89,12 @@ enum Commands {
         /// Override `config.graph_depth` for this invocation. `0` disables graph expansion.
         #[arg(long)]
         hops: Option<u32>,
+        /// Drop results scoring below this floor (0.0-1.0); may return fewer results. `0.0` disables. Overrides `config.search.relevance_floor`.
+        #[arg(long, value_parser = parse_unit_interval)]
+        relevance_floor: Option<f64>,
+        /// Maximum results retained per page; `0` means unlimited. Overrides `config.search.max_chunks_per_doc_default`.
+        #[arg(long)]
+        max_chunks_per_doc: Option<usize>,
     },
     /// Semantic / hybrid query
     Query {
@@ -109,6 +115,12 @@ enum Commands {
         /// Override `config.graph_depth` for this invocation. `0` disables graph expansion.
         #[arg(long)]
         hops: Option<u32>,
+        /// Drop results scoring below this floor (0.0-1.0); may return fewer results. `0.0` disables. Overrides `config.search.relevance_floor`.
+        #[arg(long, value_parser = parse_unit_interval)]
+        relevance_floor: Option<f64>,
+        /// Maximum results retained per page; `0` means unlimited. Overrides `config.search.max_chunks_per_doc_default`.
+        #[arg(long)]
+        max_chunks_per_doc: Option<usize>,
     },
     /// Ingest a source document
     Ingest {
@@ -224,8 +236,10 @@ enum Commands {
         #[arg(long)]
         r#type: Option<String>,
     },
-    /// List unresolved knowledge gaps
+    /// List unresolved knowledge gaps, or resolve one (`gaps resolve <id> <slug>`)
     Gaps {
+        #[command(subcommand)]
+        action: Option<commands::gaps::GapsAction>,
         #[arg(long, default_value = "20")]
         limit: u32,
         #[arg(long)]
@@ -337,6 +351,18 @@ fn early_command(cli: &Cli) -> EarlyCommand {
     }
 }
 
+/// Clap value parser for floor-style flags constrained to `[0.0, 1.0]`.
+fn parse_unit_interval(value: &str) -> Result<f64, String> {
+    let parsed: f64 = value
+        .parse()
+        .map_err(|err| format!("not a number: {err}"))?;
+    if (0.0..=1.0).contains(&parsed) {
+        Ok(parsed)
+    } else {
+        Err(format!("must be between 0.0 and 1.0, got {parsed}"))
+    }
+}
+
 fn validate_flags_from_args(
     all: bool,
     links: bool,
@@ -404,6 +430,8 @@ async fn main() -> Result<()> {
             include_superseded,
             raw,
             hops,
+            relevance_floor,
+            max_chunks_per_doc,
         } => commands::search::run(
             &db,
             &query,
@@ -414,6 +442,8 @@ async fn main() -> Result<()> {
             cli.json,
             raw,
             hops,
+            relevance_floor,
+            max_chunks_per_doc,
         ),
         Commands::Query {
             query,
@@ -424,6 +454,8 @@ async fn main() -> Result<()> {
             namespace,
             include_superseded,
             hops,
+            relevance_floor,
+            max_chunks_per_doc,
         } => {
             commands::query::run(
                 &db,
@@ -436,6 +468,8 @@ async fn main() -> Result<()> {
                 include_superseded,
                 cli.json,
                 hops,
+                relevance_floor,
+                max_chunks_per_doc,
             )
             .await
         }
@@ -486,7 +520,16 @@ async fn main() -> Result<()> {
         Commands::Check { slug, all, r#type } => {
             commands::check::run(&db, slug, all, r#type, cli.json)
         }
-        Commands::Gaps { limit, resolved } => commands::gaps::run(&db, limit, resolved, cli.json),
+        Commands::Gaps {
+            action,
+            limit,
+            resolved,
+        } => match action {
+            Some(commands::gaps::GapsAction::Resolve { id, slug }) => {
+                commands::gaps::resolve(&db, id, &slug, cli.json)
+            }
+            None => commands::gaps::run(&db, limit, resolved, cli.json),
+        },
         Commands::Compact => commands::compact::run(&db),
         Commands::Collection { action } => commands::collection::run(&db, action, cli.json),
         Commands::Namespace { action } => commands::namespace::run(&db, action, cli.json),

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -320,6 +320,12 @@ pub struct MemoryQueryInput {
     pub depth: Option<String>,
     /// Include superseded historical pages in results
     pub include_superseded: Option<bool>,
+    /// Graph-expansion hop count override; absent reads `config.graph_depth`, `0` disables
+    pub hops: Option<u32>,
+    /// Relevance floor (0.0-1.0) below which results are dropped (may return fewer results); absent reads `config.search.relevance_floor`
+    pub relevance_floor: Option<f64>,
+    /// Maximum results retained per page (`0` = unlimited); absent reads `config.search.max_chunks_per_doc_default`
+    pub max_chunks_per_doc: Option<u32>,
 }
 
 /// Input schema for the `memory_search` MCP tool.
@@ -337,6 +343,10 @@ pub struct MemorySearchInput {
     pub limit: Option<u32>,
     /// Include superseded historical pages in results
     pub include_superseded: Option<bool>,
+    /// Relevance floor (0.0-1.0) below which results are dropped (may return fewer results); absent reads `config.search.relevance_floor`
+    pub relevance_floor: Option<f64>,
+    /// Maximum results retained per page (`0` = unlimited); absent reads `config.search.max_chunks_per_doc_default`
+    pub max_chunks_per_doc: Option<u32>,
 }
 
 /// Input schema for the `memory_list` MCP tool.
@@ -435,7 +445,7 @@ pub struct MemoryGapInput {
     pub query: String,
     /// Optional page slug to bind the gap to
     pub slug: Option<String>,
-    /// Optional context about the gap
+    /// Optional context about the gap. Discarded by default to avoid leaking sensitive query text; persisted (length-capped) only when the `gaps.store_context` config key is `true`
     pub context: Option<String>,
 }
 
@@ -446,6 +456,15 @@ pub struct MemoryGapsInput {
     pub resolved: Option<bool>,
     /// Maximum number of gaps to return (default: 20, max: 1000)
     pub limit: Option<u32>,
+}
+
+/// Input schema for the `memory_gap_resolve` MCP tool.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct MemoryGapResolveInput {
+    /// Numeric id of the gap to resolve (see `memory_gaps`)
+    pub id: i64,
+    /// Slug of the page that answers the gap
+    pub slug: String,
 }
 
 /// Input schema for the `memory_stats` MCP tool (no parameters).
@@ -514,6 +533,7 @@ impl QuaidServer {
         // gaps
         memory_gap,
         memory_gaps,
+        memory_gap_resolve,
         // conversation
         memory_add_turn,
         memory_close_session,
@@ -585,7 +605,7 @@ mod tests {
     /// test catches it before the post-split MCP wire surface diverges from
     /// the pre-split baseline.
     #[test]
-    fn tool_registry_lists_all_24_tools() {
+    fn tool_registry_lists_all_25_tools() {
         let names: std::collections::BTreeSet<String> = QuaidServer::tool_box()
             .list()
             .into_iter()
@@ -607,6 +627,7 @@ mod tests {
             "memory_tags",
             "memory_gap",
             "memory_gaps",
+            "memory_gap_resolve",
             "memory_stats",
             "memory_collections",
             "memory_namespace_create",
@@ -621,7 +642,7 @@ mod tests {
         .map(|s| (*s).to_string())
         .collect();
         assert_eq!(names, expected, "tool registry drift");
-        assert_eq!(names.len(), 24, "expected 24 tools, got {}", names.len());
+        assert_eq!(names.len(), 25, "expected 25 tools, got {}", names.len());
     }
 
     #[test]
@@ -1240,6 +1261,9 @@ mod tests {
                 limit: None,
                 depth: None,
                 include_superseded: None,
+                hops: None,
+                relevance_floor: None,
+                max_chunks_per_doc: None,
             })
             .unwrap();
 

--- a/src/mcp/tools/gaps.rs
+++ b/src/mcp/tools/gaps.rs
@@ -1,22 +1,25 @@
 //! Knowledge-gap tool bodies: `memory_gap` (record an unanswered query as
-//! a SHA-256 hash with optional page binding) and `memory_gaps` (paginated
-//! list, optionally including resolved gaps). Errors from the
-//! `crate::core::gaps` layer route through `mcp::errors::map_gaps_error`;
-//! none of the bodies in this file construct `rmcp::Error` directly, in
-//! line with the §2.4 audit convention.
+//! a SHA-256 hash with optional page binding), `memory_gaps` (paginated
+//! list, optionally including resolved gaps), and `memory_gap_resolve`
+//! (mark a gap answered by a page). Errors from the `crate::core::gaps`
+//! layer route through `mcp::errors::map_gaps_error`; none of the bodies
+//! in this file construct `rmcp::Error` directly, in line with the §2.4
+//! audit convention.
 
 use rmcp::model::{CallToolResult, Content};
 use rmcp::tool;
 
 use crate::core::collections::OpKind;
+use crate::core::db;
 use crate::core::gaps;
 use crate::core::vault_sync;
 use crate::mcp::errors::{
-    invalid_params, map_db_error, map_gaps_error, map_serialize_error, map_vault_sync_error,
-    serialize_response,
+    invalid_params, map_config_error, map_db_error, map_gaps_error, map_serialize_error,
+    map_vault_sync_error, serialize_response,
 };
 use crate::mcp::server::{
-    page_id_for_resolved, resolve_slug_for_mcp, MemoryGapInput, MemoryGapsInput, QuaidServer,
+    page_id_for_resolved, resolve_slug_for_mcp, MemoryGapInput, MemoryGapResolveInput,
+    MemoryGapsInput, QuaidServer,
 };
 use crate::mcp::validation::{validate_slug, MAX_GAP_CONTEXT_LEN, MAX_LIMIT};
 
@@ -41,11 +44,17 @@ impl QuaidServer {
                 "context exceeds maximum length of {MAX_GAP_CONTEXT_LEN} characters"
             )));
         }
-        if !context.is_empty() {
-            // Do not persist caller-provided context to avoid leaking sensitive query text.
-            context.clear();
-        }
         let db = self.db().lock().unwrap_or_else(|e| e.into_inner());
+        if !context.is_empty() {
+            // Caller-provided context is discarded by default to avoid
+            // leaking sensitive query text; persisted (already length-capped
+            // above) only when `gaps.store_context` is opted in.
+            let store_context = db::read_config_value_or(&db, "gaps.store_context", "false")
+                .map_err(map_config_error)?;
+            if store_context != "true" {
+                context.clear();
+            }
+        }
         let page_id = if let Some(slug) = input.slug.as_deref() {
             validate_slug(slug)?;
             let resolved = resolve_slug_for_mcp(&db, slug, OpKind::WriteUpdate)?;
@@ -107,5 +116,33 @@ impl QuaidServer {
 
         let json = serde_json::to_string_pretty(&gap_list).map_err(map_serialize_error)?;
         Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
+
+    /// `memory_gap_resolve` MCP tool: mark a knowledge gap resolved by the
+    /// page that answered it, after validating that the slug resolves to an
+    /// existing page. Unknown gap ids map to a not-found error.
+    #[tool(description = "Resolve a knowledge gap with the page that answers it")]
+    /// `memory_gap_resolve` MCP tool: mark a knowledge gap resolved by the
+    /// page that answered it, after validating that the slug resolves to an
+    /// existing page. Unknown gap ids map to a not-found error.
+    pub fn memory_gap_resolve(
+        &self,
+        #[tool(aggr)] input: MemoryGapResolveInput,
+    ) -> Result<CallToolResult, rmcp::Error> {
+        validate_slug(&input.slug)?;
+        let db = self.db().lock().unwrap_or_else(|e| e.into_inner());
+        let resolved = resolve_slug_for_mcp(&db, &input.slug, OpKind::Read)?;
+        // Ensure the resolving page actually exists before flipping the gap.
+        page_id_for_resolved(&db, &resolved)?;
+
+        gaps::resolve_gap(input.id, &resolved.slug, &db).map_err(map_gaps_error)?;
+
+        let result = serde_json::json!({
+            "id": input.id,
+            "resolved_by_slug": resolved.slug,
+        });
+        Ok(CallToolResult::success(vec![Content::text(
+            serialize_response(&result)?,
+        )]))
     }
 }

--- a/src/mcp/tools/search.rs
+++ b/src/mcp/tools/search.rs
@@ -14,12 +14,29 @@ use crate::core::fts::{sanitize_fts_query, search_fts_tiered, FtsQuery};
 use crate::core::gaps;
 use crate::core::namespace;
 use crate::core::progressive::progressive_retrieve_with_namespace;
-use crate::core::search::{hybrid_search, HybridSearch};
-use crate::mcp::errors::{map_namespace_error, map_search_error, map_serialize_error};
+use crate::core::search::{
+    configured_max_chunks_per_doc, configured_relevance_floor, dedup_chunks_per_page,
+    filter_below_floor, hybrid_search, HybridSearch,
+};
+use crate::mcp::errors::{
+    invalid_params, map_namespace_error, map_search_error, map_serialize_error,
+};
 use crate::mcp::server::{
     resolve_memory_collection_filter_for_mcp, MemoryQueryInput, MemorySearchInput, QuaidServer,
 };
 use crate::mcp::validation::MAX_LIMIT;
+
+/// Reject a caller-supplied relevance floor outside `[0.0, 1.0]`.
+fn validate_relevance_floor(floor: Option<f64>) -> Result<Option<f64>, rmcp::Error> {
+    if let Some(value) = floor {
+        if !(0.0..=1.0).contains(&value) {
+            return Err(invalid_params(format!(
+                "relevance_floor must be between 0.0 and 1.0, got {value}"
+            )));
+        }
+    }
+    Ok(floor)
+}
 
 impl QuaidServer {
     /// `memory_query` MCP tool: run hybrid semantic + FTS5 retrieval with
@@ -41,6 +58,8 @@ impl QuaidServer {
             resolve_memory_collection_filter_for_mcp(&db, input.collection.as_deref())?;
         let include_superseded = input.include_superseded.unwrap_or(false);
 
+        let relevance_floor = validate_relevance_floor(input.relevance_floor)?;
+
         let limit = input.limit.unwrap_or(10).min(MAX_LIMIT) as usize;
         let results = hybrid_search(
             &db,
@@ -52,17 +71,20 @@ impl QuaidServer {
                 include_superseded,
                 canonical: true,
                 limit,
-                hops: None,
+                hops: input.hops,
+                relevance_floor,
+                max_chunks_per_doc: input.max_chunks_per_doc.map(|value| value as usize),
             },
         )
         .map_err(map_search_error)?;
 
-        // Auto-log knowledge gap on weak results
-        if results.len() < 2 || results.iter().all(|r| r.score < 0.3) {
+        // Auto-log knowledge gap on weak results, recording query-free
+        // diagnostics as the context (never the query text itself).
+        if gaps::should_log_gap(&results) {
             let _ = gaps::log_gap(
                 None,
                 &input.query,
-                "",
+                &gaps::auto_gap_context("hybrid_search", &results),
                 results.first().map(|r| r.score),
                 &db,
             );
@@ -121,6 +143,8 @@ impl QuaidServer {
             resolve_memory_collection_filter_for_mcp(&db, input.collection.as_deref())?;
         let include_superseded = input.include_superseded.unwrap_or(false);
 
+        let relevance_floor = validate_relevance_floor(input.relevance_floor)?;
+
         let limit = input.limit.unwrap_or(50).min(MAX_LIMIT) as usize;
         // `search_fts_tiered` applies numeric-alias expansion in its AND
         // pass, so sanitization is the only preprocessing needed here.
@@ -138,6 +162,19 @@ impl QuaidServer {
             },
         )
         .map_err(map_search_error)?;
+
+        // Post-retrieval quality passes (dedup → floor); identity no-ops at
+        // the seeded config defaults. Parameter values, when given, override
+        // the `search.*` config keys.
+        let max_per_page = match input.max_chunks_per_doc {
+            Some(value) => value as usize,
+            None => configured_max_chunks_per_doc(&db).map_err(map_search_error)?,
+        };
+        let floor = match relevance_floor {
+            Some(value) => value,
+            None => configured_relevance_floor(&db).map_err(map_search_error)?,
+        };
+        let results = filter_below_floor(dedup_chunks_per_page(results, max_per_page), floor);
 
         let json = serde_json::to_string_pretty(&results).map_err(map_serialize_error)?;
         Ok(CallToolResult::success(vec![Content::text(json)]))

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -463,7 +463,19 @@ INSERT OR IGNORE INTO config (key, value) VALUES
     ('graph_expansion_max',          '50'),
     ('edge_weight_frontmatter',      '1.0'),
     ('edge_weight_entity_pattern',   '0.7'),
-    ('edge_weight_wikilink',         '0.5');
+    ('edge_weight_wikilink',         '0.5'),
+    -- retrieval-quality-rerank knobs (identity defaults; flipped only after
+    -- the documented DAB benchmark gate passes)
+    ('search.mmr_lambda',                  '1.0'),
+    ('search.max_chunks_per_doc_default',  '0'),
+    ('search.cross_ref_boost_weight',      '0.0'),
+    ('search.cross_ref_boost_cap',         '0.15'),
+    ('search.rerank_extractive',           'false'),
+    ('search.rerank_extractive_top_n',     '3'),
+    ('search.rerank_extractive_budget_ms', '10'),
+    -- knowledge-gap loop: persist caller-provided memory_gap context only
+    -- when 'true' (auto-logged query-free diagnostics are always stored)
+    ('gaps.store_context',                 'false');
 
 -- ============================================================
 -- contradictions: detected inconsistencies

--- a/tests/extraction_end_to_end_smoke.rs
+++ b/tests/extraction_end_to_end_smoke.rs
@@ -208,6 +208,8 @@ fn turn_capture_close_extract_fact_and_search_smoke() {
             wing: None,
             limit: Some(5),
             include_superseded: Some(false),
+            relevance_floor: None,
+            max_chunks_per_doc: None,
         })
         .unwrap();
     let rows: Vec<serde_json::Value> = serde_json::from_str(&extract_text(&search)).unwrap();

--- a/tests/file_edit_supersede.rs
+++ b/tests/file_edit_supersede.rs
@@ -200,6 +200,8 @@ fn editing_chained_extracted_preference_preserves_one_linear_chain() {
                 wing: None,
                 limit: None,
                 include_superseded: None,
+                relevance_floor: None,
+                max_chunks_per_doc: None,
             })
             .unwrap(),
     ))
@@ -218,6 +220,8 @@ fn editing_chained_extracted_preference_preserves_one_linear_chain() {
                 wing: None,
                 limit: None,
                 include_superseded: Some(true),
+                relevance_floor: None,
+                max_chunks_per_doc: None,
             })
             .unwrap(),
     ))

--- a/tests/gap_loop.rs
+++ b/tests/gap_loop.rs
@@ -1,0 +1,290 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::print_stdout,
+    reason = "test fixtures legitimately panic on setup failure and print diagnostics; per-site #[expect] would generate noise across thousands of test sites"
+)]
+
+//! Knowledge-gap auto-logging heuristic tests (fable-review area 14).
+//!
+//! Scenarios tested:
+//!   1. exact-slug lookups (score 1.0) no longer log phantom gaps, on both
+//!      the CLI `quaid query` path and the MCP `memory_query` path
+//!   2. under `search_merge_strategy='rrf'` a strong result logs no gap
+//!      while an empty result set does — the normalized RRF scale makes the
+//!      single 0.3 threshold meaningful for both merge strategies
+//!   3. a rank-0 dual-list RRF hit scores >= 0.9 after normalization
+//!   4. auto-logged gaps carry query-free diagnostics context instead of ""
+
+mod common;
+#[path = "common/subprocess.rs"]
+mod common_subprocess;
+#[path = "common/mcp_harness.rs"]
+mod harness;
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use harness::{create_page, extract_text};
+use quaid::commands::embed;
+use quaid::core::db;
+use quaid::core::gaps::should_log_gap;
+use quaid::core::search::{hybrid_search, HybridSearch};
+use quaid::core::types::SearchResult;
+use quaid::mcp::server::{MemoryGapsInput, MemoryQueryInput, QuaidServer};
+use rusqlite::Connection;
+
+fn open_test_db(path: &Path) -> Connection {
+    db::open(path.to_str().expect("utf-8 db path")).expect("open test db")
+}
+
+/// Deterministic RFC-4122-shaped uuid derived from the slug; `quaid embed`
+/// refuses pages without one.
+fn test_uuid(seed: &str) -> String {
+    let mut hex = String::new();
+    for byte in seed.as_bytes() {
+        hex.push_str(&format!("{byte:02x}"));
+        if hex.len() >= 32 {
+            break;
+        }
+    }
+    while hex.len() < 32 {
+        hex.push('0');
+    }
+    format!(
+        "{}-{}-{}-{}-{}",
+        &hex[0..8],
+        &hex[8..12],
+        &hex[12..16],
+        &hex[16..20],
+        &hex[20..32]
+    )
+}
+
+fn insert_page(conn: &Connection, slug: &str, title: &str, truth: &str) {
+    conn.execute(
+        "INSERT INTO pages (slug, uuid, type, title, summary, compiled_truth, timeline, \
+                            frontmatter, wing, room, version) \
+         VALUES (?1, ?2, 'concept', ?3, ?3, ?4, '', '{}', 'notes', '', 1)",
+        rusqlite::params![slug, test_uuid(slug), title, truth],
+    )
+    .expect("insert page");
+}
+
+fn run_quaid(db_path: &Path, args: &[&str]) -> std::process::Output {
+    let mut command = Command::new(common::quaid_bin());
+    common_subprocess::configure_test_command(&mut command);
+    command.arg("--db").arg(db_path).args(args);
+    command.output().expect("run quaid")
+}
+
+fn test_db_path(dir: &tempfile::TempDir, name: &str) -> PathBuf {
+    dir.path().join(name)
+}
+
+fn gap_count(conn: &Connection) -> i64 {
+    conn.query_row("SELECT COUNT(*) FROM knowledge_gaps", [], |row| row.get(0))
+        .expect("count gaps")
+}
+
+fn memory_query_input(query: &str) -> MemoryQueryInput {
+    MemoryQueryInput {
+        query: query.to_string(),
+        collection: None,
+        namespace: None,
+        wing: None,
+        limit: None,
+        depth: None,
+        include_superseded: None,
+        hops: None,
+        relevance_floor: None,
+        max_chunks_per_doc: None,
+    }
+}
+
+fn list_gaps_json(server: &QuaidServer) -> Vec<serde_json::Value> {
+    let result = server
+        .memory_gaps(MemoryGapsInput {
+            resolved: None,
+            limit: None,
+        })
+        .expect("memory_gaps");
+    serde_json::from_str(&extract_text(&result)).expect("gaps JSON")
+}
+
+// ── 1. exact-slug lookups log no gap ──────────────────────────────────────────
+
+#[test]
+fn cli_exact_slug_query_logs_no_gap() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let db_path = test_db_path(&dir, "gap-exact-slug-cli.db");
+    let conn = open_test_db(&db_path);
+    insert_page(&conn, "notes/target", "Target", "the answer lives here");
+    drop(conn);
+
+    let output = run_quaid(
+        &db_path,
+        &["--json", "query", "notes/target", "--depth", "none"],
+    );
+
+    assert!(output.status.success(), "{output:?}");
+    let rows: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(rows.as_array().unwrap().len(), 1, "slug lookup must hit");
+
+    let conn = open_test_db(&db_path);
+    assert_eq!(
+        gap_count(&conn),
+        0,
+        "a successful exact-slug lookup (score 1.0) must not log a phantom gap"
+    );
+}
+
+#[test]
+fn mcp_exact_slug_query_logs_no_gap() {
+    let (_dir, conn) = harness::open_test_db();
+    let server = QuaidServer::new(conn);
+    create_page(
+        &server,
+        "notes/target",
+        "---\ntitle: Target\ntype: concept\n---\nthe answer lives here\n",
+    );
+
+    let result = server
+        .memory_query(memory_query_input("notes/target"))
+        .unwrap();
+    let rows: Vec<serde_json::Value> = serde_json::from_str(&extract_text(&result)).unwrap();
+    assert_eq!(rows.len(), 1, "slug lookup must hit");
+
+    assert!(
+        list_gaps_json(&server).is_empty(),
+        "a successful exact-slug lookup must not log a phantom gap"
+    );
+}
+
+// ── 2. RRF heuristic behaviour ────────────────────────────────────────────────
+
+#[test]
+fn rrf_strong_single_result_logs_no_gap_and_empty_results_do() {
+    let (_dir, conn) = harness::open_test_db();
+    conn.execute(
+        "UPDATE config SET value = 'rrf' WHERE key = 'search_merge_strategy'",
+        [],
+    )
+    .expect("switch to rrf");
+    let server = QuaidServer::new(conn);
+    create_page(
+        &server,
+        "notes/widget",
+        "---\ntitle: Widget\ntype: concept\n---\nwidget assembly notes\n",
+    );
+
+    // Strong lexical hit: rank-0 single-list RRF normalizes to ~0.5 — above
+    // the 0.3 gap threshold (pre-normalization it capped at ~0.016 and every
+    // RRF query was logged as a gap).
+    let result = server
+        .memory_query(memory_query_input("widget assembly"))
+        .unwrap();
+    let rows: Vec<serde_json::Value> = serde_json::from_str(&extract_text(&result)).unwrap();
+    assert_eq!(rows.len(), 1);
+    let top_score = rows[0]["score"].as_f64().unwrap();
+    assert!(
+        top_score >= 0.3,
+        "normalized RRF score must clear the gap threshold, got {top_score}"
+    );
+    assert!(
+        list_gaps_json(&server).is_empty(),
+        "a strong RRF result must not log a gap"
+    );
+
+    // Empty result set: gap logged with query-free diagnostics context.
+    let result = server
+        .memory_query(memory_query_input("entirely unknown moon colony"))
+        .unwrap();
+    let rows: Vec<serde_json::Value> = serde_json::from_str(&extract_text(&result)).unwrap();
+    assert!(rows.is_empty());
+
+    let gaps = list_gaps_json(&server);
+    assert_eq!(gaps.len(), 1, "empty results must log a gap");
+    assert_eq!(
+        gaps[0]["context"].as_str().unwrap(),
+        "auto: hybrid_search results=0",
+        "auto-context must be query-free diagnostics, not empty"
+    );
+}
+
+// ── 3. normalized RRF dual-list rank-0 hit ────────────────────────────────────
+
+#[test]
+fn rrf_dual_list_rank_zero_hit_scores_above_point_nine() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let db_path = test_db_path(&dir, "gap-rrf-dual.db");
+    let conn = open_test_db(&db_path);
+    conn.execute(
+        "UPDATE config SET value = 'rrf' WHERE key = 'search_merge_strategy'",
+        [],
+    )
+    .expect("switch to rrf");
+    // The target's truth is byte-identical to the query, so it is rank 0 in
+    // both the FTS arm and the vector arm under any deterministic backend.
+    insert_page(
+        &conn,
+        "notes/target",
+        "Target",
+        "violet umbrella daydream symposium",
+    );
+    insert_page(
+        &conn,
+        "notes/junk",
+        "Junk",
+        "Quarterly ledger review for the harbor warehouse.",
+    );
+    embed::run(&conn, None, true, false).expect("embed pages");
+
+    let results = hybrid_search(
+        &conn,
+        HybridSearch {
+            query: "violet umbrella daydream symposium",
+            limit: 10,
+            ..Default::default()
+        },
+    )
+    .expect("hybrid search");
+
+    assert_eq!(results[0].slug, "notes/target");
+    assert!(
+        results[0].score >= 0.9,
+        "rank-0 dual-list RRF hit must normalize to >= 0.9, got {}",
+        results[0].score
+    );
+    assert!(
+        !should_log_gap(&results),
+        "a near-1.0 RRF hit must never be classified as a gap"
+    );
+}
+
+// ── 4. should_log_gap unit shape ──────────────────────────────────────────────
+
+fn scored(score: f64) -> SearchResult {
+    SearchResult {
+        slug: "notes/x".to_owned(),
+        title: "X".to_owned(),
+        summary: String::new(),
+        score,
+        wing: String::new(),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn should_log_gap_contract() {
+    // Perfect hit (exact slug) — never a gap, even as the only result.
+    assert!(!should_log_gap(&[scored(1.0)]));
+    assert!(!should_log_gap(&[scored(0.99)]));
+    // Single mediocre hit — not a gap (the old `len() < 2` heuristic fired).
+    assert!(!should_log_gap(&[scored(0.5)]));
+    // All-weak results — gap.
+    assert!(should_log_gap(&[scored(0.1), scored(0.05)]));
+    // Empty — gap.
+    assert!(should_log_gap(&[]));
+}

--- a/tests/gaps_resolve.rs
+++ b/tests/gaps_resolve.rs
@@ -1,0 +1,326 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::print_stdout,
+    reason = "test fixtures legitimately panic on setup failure and print diagnostics; per-site #[expect] would generate noise across thousands of test sites"
+)]
+
+//! Knowledge-gap resolve surface and context-persistence tests
+//! (fable-review area 14, items 3-4).
+//!
+//! Scenarios tested:
+//!   1. `quaid gaps resolve <id> <slug>` flips `resolved_at` /
+//!      `resolved_by_slug`; unknown ids and slugs fail
+//!   2. the `memory_gap_resolve` MCP tool does the same and 404s unknown
+//!      ids; `quaid call` dispatch routes it (registry/dispatch parity)
+//!   3. `memory_gap` persists caller context only when the
+//!      `gaps.store_context` config key is `true`
+
+mod common;
+#[path = "common/subprocess.rs"]
+mod common_subprocess;
+#[path = "common/mcp_harness.rs"]
+mod harness;
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use harness::{create_page, extract_text};
+use quaid::commands::call::dispatch_tool;
+use quaid::core::{db, gaps};
+use quaid::mcp::server::{MemoryGapInput, MemoryGapResolveInput, MemoryGapsInput, QuaidServer};
+use rusqlite::Connection;
+use serde_json::json;
+
+fn open_test_db(path: &Path) -> Connection {
+    db::open(path.to_str().expect("utf-8 db path")).expect("open test db")
+}
+
+fn insert_page(conn: &Connection, slug: &str) {
+    conn.execute(
+        "INSERT INTO pages (slug, type, title, summary, compiled_truth, timeline, \
+                            frontmatter, wing, room, version) \
+         VALUES (?1, 'concept', ?1, '', '', '', '{}', 'notes', '', 1)",
+        rusqlite::params![slug],
+    )
+    .expect("insert page");
+}
+
+fn run_quaid(db_path: &Path, args: &[&str]) -> std::process::Output {
+    let mut command = Command::new(common::quaid_bin());
+    common_subprocess::configure_test_command(&mut command);
+    command.arg("--db").arg(db_path).args(args);
+    command.output().expect("run quaid")
+}
+
+fn test_db_path(dir: &tempfile::TempDir, name: &str) -> PathBuf {
+    dir.path().join(name)
+}
+
+fn gap_row(conn: &Connection, id: i64) -> (Option<String>, Option<String>) {
+    conn.query_row(
+        "SELECT resolved_at, resolved_by_slug FROM knowledge_gaps WHERE id = ?1",
+        [id],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )
+    .expect("gap row")
+}
+
+// ── 1. CLI resolve ────────────────────────────────────────────────────────────
+
+#[test]
+fn cli_gaps_resolve_flips_resolved_fields() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let db_path = test_db_path(&dir, "gaps-resolve-cli.db");
+    let conn = open_test_db(&db_path);
+    insert_page(&conn, "notes/answer");
+    gaps::log_gap(None, "what is the answer", "", Some(0.1), &conn).expect("log gap");
+    let gap_id: i64 = conn
+        .query_row("SELECT id FROM knowledge_gaps LIMIT 1", [], |r| r.get(0))
+        .unwrap();
+    drop(conn);
+
+    let output = run_quaid(
+        &db_path,
+        &["gaps", "resolve", &gap_id.to_string(), "notes/answer"],
+    );
+    assert!(output.status.success(), "resolve must succeed: {output:?}");
+
+    let conn = open_test_db(&db_path);
+    let (resolved_at, resolved_by_slug) = gap_row(&conn, gap_id);
+    assert!(resolved_at.is_some(), "resolved_at must be set");
+    assert_eq!(resolved_by_slug.as_deref(), Some("notes/answer"));
+    drop(conn);
+
+    // The resolved listing surfaces the resolution slug.
+    let listing = run_quaid(&db_path, &["--json", "gaps", "--resolved"]);
+    assert!(listing.status.success(), "{listing:?}");
+    let entries: serde_json::Value = serde_json::from_slice(&listing.stdout).unwrap();
+    assert_eq!(
+        entries.as_array().unwrap()[0]["resolved_by_slug"],
+        json!("notes/answer")
+    );
+}
+
+#[test]
+fn cli_gaps_resolve_unknown_id_fails() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let db_path = test_db_path(&dir, "gaps-resolve-cli-404.db");
+    let conn = open_test_db(&db_path);
+    insert_page(&conn, "notes/answer");
+    drop(conn);
+
+    let output = run_quaid(&db_path, &["gaps", "resolve", "9999", "notes/answer"]);
+
+    assert!(!output.status.success(), "unknown gap id must fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("gap not found"),
+        "stderr should report the missing gap: {stderr}"
+    );
+}
+
+#[test]
+fn cli_gaps_resolve_unknown_slug_fails() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let db_path = test_db_path(&dir, "gaps-resolve-cli-noslug.db");
+    let conn = open_test_db(&db_path);
+    gaps::log_gap(None, "dangling question", "", None, &conn).expect("log gap");
+    let gap_id: i64 = conn
+        .query_row("SELECT id FROM knowledge_gaps LIMIT 1", [], |r| r.get(0))
+        .unwrap();
+    drop(conn);
+
+    let output = run_quaid(
+        &db_path,
+        &["gaps", "resolve", &gap_id.to_string(), "notes/ghost"],
+    );
+
+    assert!(!output.status.success(), "unknown slug must fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("page not found"),
+        "stderr should report the missing page: {stderr}"
+    );
+
+    let conn = open_test_db(&db_path);
+    let (resolved_at, _) = gap_row(&conn, gap_id);
+    assert!(resolved_at.is_none(), "gap must stay unresolved");
+}
+
+// ── 2. MCP resolve ────────────────────────────────────────────────────────────
+
+#[test]
+fn memory_gap_resolve_flips_resolved_fields() {
+    let (_dir, conn) = harness::open_test_db();
+    let server = QuaidServer::new(conn);
+    create_page(
+        &server,
+        "notes/answer",
+        "---\ntitle: Answer\ntype: concept\n---\nthe answer\n",
+    );
+    let logged = server
+        .memory_gap(MemoryGapInput {
+            query: "what is the answer".to_string(),
+            slug: None,
+            context: None,
+        })
+        .unwrap();
+    let logged_json: serde_json::Value = serde_json::from_str(&extract_text(&logged)).unwrap();
+    let gap_id = logged_json["id"].as_i64().unwrap();
+
+    let resolved = server
+        .memory_gap_resolve(MemoryGapResolveInput {
+            id: gap_id,
+            slug: "notes/answer".to_string(),
+        })
+        .unwrap();
+    let resolved_json: serde_json::Value = serde_json::from_str(&extract_text(&resolved)).unwrap();
+    assert_eq!(resolved_json["id"], json!(gap_id));
+    assert_eq!(resolved_json["resolved_by_slug"], json!("notes/answer"));
+
+    let listing = server
+        .memory_gaps(MemoryGapsInput {
+            resolved: Some(true),
+            limit: None,
+        })
+        .unwrap();
+    let entries: Vec<serde_json::Value> = serde_json::from_str(&extract_text(&listing)).unwrap();
+    assert_eq!(entries.len(), 1);
+    assert!(entries[0]["resolved_at"].is_string());
+    assert_eq!(entries[0]["resolved_by_slug"], json!("notes/answer"));
+}
+
+#[test]
+fn memory_gap_resolve_unknown_id_returns_not_found() {
+    let (_dir, conn) = harness::open_test_db();
+    let server = QuaidServer::new(conn);
+    create_page(
+        &server,
+        "notes/answer",
+        "---\ntitle: Answer\ntype: concept\n---\nthe answer\n",
+    );
+
+    let err = server
+        .memory_gap_resolve(MemoryGapResolveInput {
+            id: 9999,
+            slug: "notes/answer".to_string(),
+        })
+        .expect_err("unknown gap id must error");
+    assert!(
+        err.message.contains("gap not found"),
+        "error must report the missing gap: {}",
+        err.message
+    );
+}
+
+#[test]
+fn memory_gap_resolve_unknown_slug_returns_not_found() {
+    let (_dir, conn) = harness::open_test_db();
+    let server = QuaidServer::new(conn);
+
+    let err = server
+        .memory_gap_resolve(MemoryGapResolveInput {
+            id: 1,
+            slug: "notes/ghost".to_string(),
+        })
+        .expect_err("unknown slug must error");
+    assert!(
+        err.message.contains("not found"),
+        "error must report the missing page: {}",
+        err.message
+    );
+}
+
+#[test]
+fn call_dispatch_routes_memory_gap_resolve() {
+    let (_dir, conn) = harness::open_test_db();
+    let server = QuaidServer::new(conn);
+    create_page(
+        &server,
+        "notes/answer",
+        "---\ntitle: Answer\ntype: concept\n---\nthe answer\n",
+    );
+    let logged = dispatch_tool(&server, "memory_gap", json!({"query": "dispatch question"}))
+        .expect("dispatch memory_gap");
+    let gap_id = logged["id"].as_i64().unwrap();
+
+    let resolved = dispatch_tool(
+        &server,
+        "memory_gap_resolve",
+        json!({"id": gap_id, "slug": "notes/answer"}),
+    )
+    .expect("dispatch memory_gap_resolve");
+
+    assert_eq!(resolved["resolved_by_slug"], json!("notes/answer"));
+}
+
+// ── 3. context persistence gating ─────────────────────────────────────────────
+
+fn logged_contexts(server: &QuaidServer) -> Vec<String> {
+    let listing = server
+        .memory_gaps(MemoryGapsInput {
+            resolved: None,
+            limit: None,
+        })
+        .unwrap();
+    serde_json::from_str::<Vec<serde_json::Value>>(&extract_text(&listing))
+        .unwrap()
+        .into_iter()
+        .map(|entry| entry["context"].as_str().unwrap().to_owned())
+        .collect()
+}
+
+#[test]
+fn memory_gap_discards_context_by_default() {
+    let (_dir, conn) = harness::open_test_db();
+    let seeded: String = conn
+        .query_row(
+            "SELECT value FROM config WHERE key = 'gaps.store_context'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("gaps.store_context must be seeded");
+    assert_eq!(seeded, "false", "schema must seed default-discard");
+    let server = QuaidServer::new(conn);
+
+    server
+        .memory_gap(MemoryGapInput {
+            query: "question one".to_string(),
+            slug: None,
+            context: Some("caller-provided context".to_string()),
+        })
+        .unwrap();
+
+    assert_eq!(
+        logged_contexts(&server),
+        vec![String::new()],
+        "default posture discards caller context"
+    );
+}
+
+#[test]
+fn memory_gap_persists_context_when_store_context_enabled() {
+    let (_dir, conn) = harness::open_test_db();
+    conn.execute(
+        "UPDATE config SET value = 'true' WHERE key = 'gaps.store_context'",
+        [],
+    )
+    .unwrap();
+    let server = QuaidServer::new(conn);
+
+    server
+        .memory_gap(MemoryGapInput {
+            query: "question two".to_string(),
+            slug: None,
+            context: Some("caller-provided context".to_string()),
+        })
+        .unwrap();
+
+    assert_eq!(
+        logged_contexts(&server),
+        vec!["caller-provided context".to_owned()],
+        "opted-in gap must persist its (length-capped) context"
+    );
+}

--- a/tests/graph_retrieval.rs
+++ b/tests/graph_retrieval.rs
@@ -60,6 +60,7 @@ fn result(slug: &str, score: f64) -> SearchResult {
         summary: slug.to_owned(),
         score,
         wing: String::new(),
+        ..Default::default()
     }
 }
 

--- a/tests/mcp_hops_passthrough.rs
+++ b/tests/mcp_hops_passthrough.rs
@@ -1,0 +1,134 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::print_stdout,
+    reason = "test fixtures legitimately panic on setup failure and print diagnostics; per-site #[expect] would generate noise across thousands of test sites"
+)]
+
+//! MCP `memory_query` graph-hops pass-through tests (fable-review #1 step 5).
+//!
+//! The shipped graph-expansion layer is gated behind `config.graph_depth`
+//! (seeded `0`); the `hops` input field lets an MCP caller override the
+//! depth per query without flipping the seed. Scenarios tested:
+//!   1. `hops: 1` surfaces a linked neighbour alongside the direct hit
+//!   2. absent `hops` honours the seeded `graph_depth = 0` (no expansion)
+//!   3. `hops: 0` explicitly disables expansion even when `graph_depth > 0`
+
+#[path = "common/mcp_harness.rs"]
+mod harness;
+
+use harness::{create_page, extract_text, open_test_db};
+use quaid::mcp::server::{MemoryLinkInput, MemoryQueryInput, QuaidServer};
+
+fn memory_query_input(query: &str, hops: Option<u32>) -> MemoryQueryInput {
+    MemoryQueryInput {
+        query: query.to_string(),
+        collection: None,
+        namespace: None,
+        wing: None,
+        limit: None,
+        depth: None,
+        include_superseded: None,
+        hops,
+        relevance_floor: None,
+        max_chunks_per_doc: None,
+    }
+}
+
+fn seed_linked_corpus(server: &QuaidServer) {
+    create_page(
+        server,
+        "concepts/anchor",
+        "---\ntitle: Anchor\ntype: concept\n---\nalpha anchor content\n",
+    );
+    create_page(
+        server,
+        "concepts/neighbour",
+        "---\ntitle: Neighbour\ntype: concept\n---\nlinked neighbour content\n",
+    );
+    server
+        .memory_link(MemoryLinkInput {
+            from_slug: "concepts/anchor".to_string(),
+            to_slug: "concepts/neighbour".to_string(),
+            relationship: "related".to_string(),
+            valid_from: None,
+            valid_until: None,
+        })
+        .unwrap();
+}
+
+fn query_slugs(server: &QuaidServer, query: &str, hops: Option<u32>) -> Vec<String> {
+    let result = server
+        .memory_query(memory_query_input(query, hops))
+        .unwrap();
+    let rows: Vec<serde_json::Value> = serde_json::from_str(&extract_text(&result)).unwrap();
+    rows.into_iter()
+        .map(|row| row["slug"].as_str().unwrap().to_owned())
+        .collect()
+}
+
+#[test]
+fn memory_query_hops_one_surfaces_linked_neighbour() {
+    let (_dir, conn) = open_test_db();
+    let server = QuaidServer::new(conn);
+    seed_linked_corpus(&server);
+
+    let slugs = query_slugs(&server, "alpha anchor", Some(1));
+
+    assert!(
+        slugs.contains(&"default::concepts/anchor".to_owned()),
+        "direct hit must surface: {slugs:?}"
+    );
+    assert!(
+        slugs.contains(&"default::concepts/neighbour".to_owned()),
+        "hops=1 must walk the link graph and surface the neighbour: {slugs:?}"
+    );
+}
+
+#[test]
+fn memory_query_without_hops_honours_seeded_graph_depth_zero() {
+    let (_dir, conn) = open_test_db();
+    let seeded: String = conn
+        .query_row(
+            "SELECT value FROM config WHERE key = 'graph_depth'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("graph_depth must be seeded");
+    assert_eq!(seeded, "0", "graph_depth seed stays 0 pending the DAB gate");
+    let server = QuaidServer::new(conn);
+    seed_linked_corpus(&server);
+
+    let slugs = query_slugs(&server, "alpha anchor", None);
+
+    assert!(slugs.contains(&"default::concepts/anchor".to_owned()));
+    assert!(
+        !slugs.contains(&"default::concepts/neighbour".to_owned()),
+        "absent hops must keep the seeded no-expansion default: {slugs:?}"
+    );
+}
+
+#[test]
+fn memory_query_hops_zero_disables_configured_expansion() {
+    let (_dir, conn) = open_test_db();
+    conn.execute(
+        "UPDATE config SET value = '2' WHERE key = 'graph_depth'",
+        [],
+    )
+    .unwrap();
+    let server = QuaidServer::new(conn);
+    seed_linked_corpus(&server);
+
+    let expanded = query_slugs(&server, "alpha anchor", None);
+    assert!(
+        expanded.contains(&"default::concepts/neighbour".to_owned()),
+        "config graph_depth=2 must expand when no override is given: {expanded:?}"
+    );
+
+    let disabled = query_slugs(&server, "alpha anchor", Some(0));
+    assert!(
+        !disabled.contains(&"default::concepts/neighbour".to_owned()),
+        "hops=0 must override the configured depth and disable expansion: {disabled:?}"
+    );
+}

--- a/tests/mcp_server_query_search_list.rs
+++ b/tests/mcp_server_query_search_list.rs
@@ -58,6 +58,9 @@ fn memory_query_auto_depth_expands_linked_results() {
             limit: Some(1),
             depth: Some("auto".to_string()),
             include_superseded: None,
+            hops: None,
+            relevance_floor: None,
+            max_chunks_per_doc: None,
         })
         .unwrap();
 
@@ -106,6 +109,9 @@ fn memory_query_auto_depth_does_not_expand_across_collections() {
             limit: Some(5),
             depth: Some("auto".to_string()),
             include_superseded: None,
+            hops: None,
+            relevance_floor: None,
+            max_chunks_per_doc: None,
         })
         .unwrap();
 
@@ -144,6 +150,9 @@ fn memory_query_explicit_collection_filter_returns_only_named_collection() {
             limit: None,
             depth: None,
             include_superseded: None,
+            hops: None,
+            relevance_floor: None,
+            max_chunks_per_doc: None,
         })
         .unwrap();
 
@@ -178,6 +187,9 @@ fn memory_query_defaults_to_write_target_when_multiple_collections_are_active() 
             limit: None,
             depth: None,
             include_superseded: None,
+            hops: None,
+            relevance_floor: None,
+            max_chunks_per_doc: None,
         })
         .unwrap();
 
@@ -220,6 +232,9 @@ fn memory_query_defaults_to_memory_collection_when_dedicated_memory_location_is_
             limit: None,
             depth: None,
             include_superseded: None,
+            hops: None,
+            relevance_floor: None,
+            max_chunks_per_doc: None,
         })
         .unwrap();
 
@@ -249,6 +264,8 @@ fn memory_search_returns_matching_pages() {
             wing: None,
             limit: None,
             include_superseded: None,
+            relevance_floor: None,
+            max_chunks_per_doc: None,
         })
         .unwrap();
 
@@ -288,6 +305,8 @@ fn memory_search_defaults_to_memory_collection_when_dedicated_memory_location_is
             wing: None,
             limit: None,
             include_superseded: None,
+            relevance_floor: None,
+            max_chunks_per_doc: None,
         })
         .unwrap();
 
@@ -312,6 +331,8 @@ fn memory_search_natural_language_question_mark_returns_valid_response() {
         wing: None,
         limit: None,
         include_superseded: None,
+        relevance_floor: None,
+        max_chunks_per_doc: None,
     });
 
     assert!(
@@ -353,6 +374,8 @@ fn memory_search_explicit_collection_filter_returns_only_named_collection() {
             wing: None,
             limit: None,
             include_superseded: None,
+            relevance_floor: None,
+            max_chunks_per_doc: None,
         })
         .unwrap();
 
@@ -382,6 +405,8 @@ fn memory_search_defaults_to_single_active_collection() {
             wing: None,
             limit: None,
             include_superseded: None,
+            relevance_floor: None,
+            max_chunks_per_doc: None,
         })
         .unwrap();
 
@@ -541,6 +566,9 @@ fn read_tools_unknown_collection_filter_errors_clearly() {
             limit: None,
             depth: None,
             include_superseded: None,
+            hops: None,
+            relevance_floor: None,
+            max_chunks_per_doc: None,
         })
         .unwrap_err();
     assert_eq!(query_error.code, ErrorCode(-32001));
@@ -556,6 +584,8 @@ fn read_tools_unknown_collection_filter_errors_clearly() {
             wing: None,
             limit: None,
             include_superseded: None,
+            relevance_floor: None,
+            max_chunks_per_doc: None,
         })
         .unwrap_err();
     assert_eq!(search_error.code, ErrorCode(-32001));

--- a/tests/search_confidence.rs
+++ b/tests/search_confidence.rs
@@ -1,0 +1,373 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::print_stdout,
+    reason = "test fixtures legitimately panic on setup failure and print diagnostics; per-site #[expect] would generate noise across thousands of test sites"
+)]
+
+//! Confidence-threshold filter tests (`confidence-thresholding` capability,
+//! openspec change `retrieval-quality-rerank` task 3.7).
+//!
+//! Scenarios tested:
+//!   1. `filter_below_floor` mechanics: below dropped, at/above kept,
+//!      `0.0` disables (identity)
+//!   2. post-fusion floor in `hybrid_search`: config-driven, per-call
+//!      override, empty-result success path (fewer-than-k contract)
+//!   3. `--relevance-floor` CLI flag including the `0.0` disable escape
+//!      hatch and out-of-range rejection
+//!   4. MCP `memory_query` parameter override and `[0,1]` validation
+//!   5. `progressive_retrieve` floor application (below-floor candidates
+//!      are not expanded)
+
+mod common;
+#[path = "common/subprocess.rs"]
+mod common_subprocess;
+#[path = "common/mcp_harness.rs"]
+mod harness;
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use harness::{create_page, extract_text};
+use quaid::core::db;
+use quaid::core::progressive::progressive_retrieve;
+use quaid::core::search::{filter_below_floor, hybrid_search, HybridSearch};
+use quaid::core::types::SearchResult;
+use quaid::mcp::server::{MemoryQueryInput, QuaidServer};
+use rusqlite::Connection;
+
+fn candidate(slug: &str, score: f64) -> SearchResult {
+    SearchResult {
+        slug: slug.to_owned(),
+        title: slug.to_owned(),
+        summary: format!("summary for {slug}"),
+        score,
+        wing: "notes".to_owned(),
+        ..Default::default()
+    }
+}
+
+fn open_test_db(path: &Path) -> Connection {
+    db::open(path.to_str().expect("utf-8 db path")).expect("open test db")
+}
+
+fn insert_page(conn: &Connection, slug: &str, title: &str, truth: &str) {
+    conn.execute(
+        "INSERT INTO pages (slug, type, title, summary, compiled_truth, timeline, \
+                            frontmatter, wing, room, version) \
+         VALUES (?1, 'concept', ?2, ?2, ?3, '', '{}', 'notes', '', 1)",
+        rusqlite::params![slug, title, truth],
+    )
+    .expect("insert page");
+}
+
+fn run_quaid(db_path: &Path, args: &[&str]) -> std::process::Output {
+    let mut command = Command::new(common::quaid_bin());
+    common_subprocess::configure_test_command(&mut command);
+    command.arg("--db").arg(db_path).args(args);
+    command.output().expect("run quaid")
+}
+
+fn test_db_path(dir: &tempfile::TempDir, name: &str) -> PathBuf {
+    dir.path().join(name)
+}
+
+// ── 1. filter_below_floor mechanics ───────────────────────────────────────────
+
+#[test]
+fn floor_drops_below_keeps_at_and_above() {
+    let candidates = vec![
+        candidate("notes/above", 0.8),
+        candidate("notes/at", 0.5),
+        candidate("notes/below", 0.49),
+    ];
+
+    let filtered = filter_below_floor(candidates, 0.5);
+
+    let slugs: Vec<&str> = filtered.iter().map(|r| r.slug.as_str()).collect();
+    assert_eq!(
+        slugs,
+        vec!["notes/above", "notes/at"],
+        "below-floor dropped; at-floor and above kept"
+    );
+}
+
+#[test]
+fn floor_zero_disables_filtering_identity() {
+    let candidates = vec![
+        candidate("notes/strong", 0.9),
+        candidate("notes/weak", 0.01),
+        candidate("notes/zero", 0.0),
+    ];
+
+    let filtered = filter_below_floor(candidates.clone(), 0.0);
+
+    assert_eq!(filtered.len(), candidates.len(), "0.0 disables the floor");
+}
+
+// ── 2. hybrid_search post-fusion floor ────────────────────────────────────────
+
+/// A lexical-only hit normalizes to 0.4 under set-union (single-arm FTS
+/// weight); a floor above that drops it even though it leaves zero results.
+#[test]
+fn hybrid_floor_config_drops_weak_fused_hit_and_underfills() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let db_path = test_db_path(&dir, "confidence-hybrid.db");
+    let conn = open_test_db(&db_path);
+    insert_page(&conn, "notes/widget", "Widget", "widget assembly notes");
+
+    let baseline = hybrid_search(
+        &conn,
+        HybridSearch {
+            query: "widget assembly",
+            limit: 10,
+            ..Default::default()
+        },
+    )
+    .expect("baseline hybrid search");
+    assert_eq!(baseline.len(), 1, "FTS-only hit surfaces at identity floor");
+    assert!(
+        (baseline[0].score - 0.4).abs() < 1e-9,
+        "single-arm FTS hit normalizes to 0.4, got {}",
+        baseline[0].score
+    );
+
+    conn.execute(
+        "UPDATE config SET value = '0.5' WHERE key = 'search.relevance_floor'",
+        [],
+    )
+    .expect("raise floor");
+
+    let floored = hybrid_search(
+        &conn,
+        HybridSearch {
+            query: "widget assembly",
+            limit: 10,
+            ..Default::default()
+        },
+    )
+    .expect("floored hybrid search must succeed (no error, no padding)");
+    assert!(
+        floored.is_empty(),
+        "below-floor hit must be dropped even when it under-fills"
+    );
+}
+
+#[test]
+fn hybrid_floor_per_call_override_beats_config() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let db_path = test_db_path(&dir, "confidence-override.db");
+    let conn = open_test_db(&db_path);
+    insert_page(&conn, "notes/widget", "Widget", "widget assembly notes");
+    conn.execute(
+        "UPDATE config SET value = '0.5' WHERE key = 'search.relevance_floor'",
+        [],
+    )
+    .expect("raise config floor");
+
+    // Per-call 0.0 disables the config floor; the 0.4 fused hit returns.
+    let disabled = hybrid_search(
+        &conn,
+        HybridSearch {
+            query: "widget assembly",
+            limit: 10,
+            relevance_floor: Some(0.0),
+            ..Default::default()
+        },
+    )
+    .expect("override hybrid search");
+    assert_eq!(disabled.len(), 1, "0.0 override disables the config floor");
+
+    // Per-call high floor drops the hit even when the config floor is 0.0.
+    conn.execute(
+        "UPDATE config SET value = '0.0' WHERE key = 'search.relevance_floor'",
+        [],
+    )
+    .expect("reset config floor");
+    let raised = hybrid_search(
+        &conn,
+        HybridSearch {
+            query: "widget assembly",
+            limit: 10,
+            relevance_floor: Some(0.5),
+            ..Default::default()
+        },
+    )
+    .expect("override hybrid search");
+    assert!(raised.is_empty(), "per-call floor drops the 0.4 fused hit");
+}
+
+// ── 3. CLI flag ───────────────────────────────────────────────────────────────
+
+#[test]
+fn query_cli_relevance_floor_zero_is_documented_escape_hatch() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let db_path = test_db_path(&dir, "confidence-cli.db");
+    let conn = open_test_db(&db_path);
+    insert_page(&conn, "notes/widget", "Widget", "widget assembly notes");
+    conn.execute(
+        "UPDATE config SET value = '0.5' WHERE key = 'search.relevance_floor'",
+        [],
+    )
+    .expect("raise config floor");
+    drop(conn);
+
+    let floored = run_quaid(
+        &db_path,
+        &["--json", "query", "widget assembly", "--depth", "none"],
+    );
+    assert!(floored.status.success(), "{floored:?}");
+    let floored_json: serde_json::Value = serde_json::from_slice(&floored.stdout).unwrap();
+    assert_eq!(
+        floored_json.as_array().unwrap().len(),
+        0,
+        "config floor drops the weak hit"
+    );
+
+    let disabled = run_quaid(
+        &db_path,
+        &[
+            "--json",
+            "query",
+            "widget assembly",
+            "--depth",
+            "none",
+            "--relevance-floor",
+            "0.0",
+        ],
+    );
+    assert!(disabled.status.success(), "{disabled:?}");
+    let disabled_json: serde_json::Value = serde_json::from_slice(&disabled.stdout).unwrap();
+    assert_eq!(
+        disabled_json.as_array().unwrap().len(),
+        1,
+        "--relevance-floor 0.0 must disable the config floor"
+    );
+}
+
+#[test]
+fn cli_relevance_floor_rejects_out_of_range_values() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let db_path = test_db_path(&dir, "confidence-cli-range.db");
+    let _conn = open_test_db(&db_path);
+
+    let output = run_quaid(&db_path, &["query", "anything", "--relevance-floor", "1.5"]);
+
+    assert!(
+        !output.status.success(),
+        "out-of-range floor must be rejected at parse time"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("0.0") && stderr.contains("1.0"),
+        "error should state the valid range: {stderr}"
+    );
+}
+
+// ── 4. MCP parameter override ─────────────────────────────────────────────────
+
+fn memory_query_input(query: &str, relevance_floor: Option<f64>) -> MemoryQueryInput {
+    MemoryQueryInput {
+        query: query.to_string(),
+        collection: None,
+        namespace: None,
+        wing: None,
+        limit: None,
+        depth: None,
+        include_superseded: None,
+        hops: None,
+        relevance_floor,
+        max_chunks_per_doc: None,
+    }
+}
+
+#[test]
+fn memory_query_relevance_floor_overrides_config() {
+    let (_dir, conn) = harness::open_test_db();
+    let server = QuaidServer::new(conn);
+    create_page(
+        &server,
+        "notes/widget",
+        "---\ntitle: Widget\ntype: concept\n---\nwidget assembly notes\n",
+    );
+
+    let unfloored = server
+        .memory_query(memory_query_input("widget assembly", None))
+        .unwrap();
+    let rows: Vec<serde_json::Value> = serde_json::from_str(&extract_text(&unfloored)).unwrap();
+    assert_eq!(rows.len(), 1, "identity default returns the weak hit");
+
+    let floored = server
+        .memory_query(memory_query_input("widget assembly", Some(0.5)))
+        .unwrap();
+    let rows: Vec<serde_json::Value> = serde_json::from_str(&extract_text(&floored)).unwrap();
+    assert!(
+        rows.is_empty(),
+        "per-call floor must drop the 0.4 fused hit (success, no padding)"
+    );
+}
+
+#[test]
+fn memory_query_rejects_out_of_range_relevance_floor() {
+    let (_dir, conn) = harness::open_test_db();
+    let server = QuaidServer::new(conn);
+
+    let err = server
+        .memory_query(memory_query_input("anything", Some(1.5)))
+        .expect_err("floor > 1.0 must be rejected");
+    assert!(
+        err.message.contains("relevance_floor"),
+        "error should name the parameter: {}",
+        err.message
+    );
+}
+
+// ── 5. progressive_retrieve floor ─────────────────────────────────────────────
+
+#[test]
+fn progressive_retrieve_does_not_expand_below_floor_candidates() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let db_path = test_db_path(&dir, "confidence-progressive.db");
+    let conn = open_test_db(&db_path);
+    insert_page(&conn, "notes/weak", "Weak", &"x".repeat(100));
+    insert_page(&conn, "notes/neighbour", "Neighbour", &"y".repeat(100));
+    let weak_id: i64 = conn
+        .query_row("SELECT id FROM pages WHERE slug = 'notes/weak'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    let neighbour_id: i64 = conn
+        .query_row(
+            "SELECT id FROM pages WHERE slug = 'notes/neighbour'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    conn.execute(
+        "INSERT INTO links (from_page_id, to_page_id, relationship, source_kind) \
+         VALUES (?1, ?2, 'related', 'programmatic')",
+        rusqlite::params![weak_id, neighbour_id],
+    )
+    .unwrap();
+
+    // Identity default: the weak candidate survives and is expanded.
+    let initial = vec![candidate("notes/weak", 0.1)];
+    let expanded = progressive_retrieve(initial.clone(), 100_000, 1, None, false, &conn).unwrap();
+    assert!(
+        expanded.iter().any(|r| r.slug == "notes/neighbour"),
+        "identity floor expands the weak candidate"
+    );
+
+    // With an active floor the candidate is dropped before expansion.
+    conn.execute(
+        "UPDATE config SET value = '0.5' WHERE key = 'search.relevance_floor'",
+        [],
+    )
+    .expect("raise floor");
+    let filtered = progressive_retrieve(initial, 100_000, 1, None, false, &conn).unwrap();
+    assert!(
+        filtered.is_empty(),
+        "below-floor candidates must not be expanded"
+    );
+}

--- a/tests/search_dedup.rs
+++ b/tests/search_dedup.rs
@@ -1,0 +1,273 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::print_stdout,
+    reason = "test fixtures legitimately panic on setup failure and print diagnostics; per-site #[expect] would generate noise across thousands of test sites"
+)]
+
+//! Intra-document deduplication tests (`result-deduplication` capability,
+//! openspec change `retrieval-quality-rerank` task 2.6).
+//!
+//! Scenarios tested:
+//!   1. `dedup_chunks_per_page` collapse mechanics on synthetic candidate
+//!      lists (three-row collapse, passthrough, count correctness,
+//!      `max_per_page=2`, `0` = unlimited identity)
+//!   2. the seeded `search.max_chunks_per_doc_default` identity default
+//!   3. `--max-chunks-per-doc` CLI flag plumbing on `quaid search` and
+//!      `quaid query`
+//!   4. `progressive_retrieve` re-application of the dedup pass
+
+mod common;
+#[path = "common/subprocess.rs"]
+mod common_subprocess;
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use quaid::core::db;
+use quaid::core::progressive::progressive_retrieve;
+use quaid::core::search::dedup_chunks_per_page;
+use quaid::core::types::SearchResult;
+use rusqlite::Connection;
+
+fn candidate(slug: &str, score: f64) -> SearchResult {
+    SearchResult {
+        slug: slug.to_owned(),
+        title: slug.to_owned(),
+        summary: format!("summary for {slug}"),
+        score,
+        wing: "notes".to_owned(),
+        ..Default::default()
+    }
+}
+
+fn open_test_db(path: &Path) -> Connection {
+    db::open(path.to_str().expect("utf-8 db path")).expect("open test db")
+}
+
+fn insert_page(conn: &Connection, slug: &str, title: &str, truth: &str) {
+    conn.execute(
+        "INSERT INTO pages (slug, type, title, summary, compiled_truth, timeline, \
+                            frontmatter, wing, room, version) \
+         VALUES (?1, 'concept', ?2, ?2, ?3, '', '{}', 'notes', '', 1)",
+        rusqlite::params![slug, title, truth],
+    )
+    .expect("insert page");
+}
+
+fn run_quaid(db_path: &Path, args: &[&str]) -> std::process::Output {
+    let mut command = Command::new(common::quaid_bin());
+    common_subprocess::configure_test_command(&mut command);
+    command.arg("--db").arg(db_path).args(args);
+    command.output().expect("run quaid")
+}
+
+fn test_db_path(dir: &tempfile::TempDir, name: &str) -> PathBuf {
+    dir.path().join(name)
+}
+
+// ── 1. dedup_chunks_per_page mechanics ────────────────────────────────────────
+
+#[test]
+fn dedup_collapses_three_rows_of_same_page_to_strongest() {
+    let candidates = vec![
+        candidate("notes/long-page", 0.9),
+        candidate("notes/long-page", 0.7),
+        candidate("notes/long-page", 0.5),
+    ];
+
+    let deduped = dedup_chunks_per_page(candidates, 1);
+
+    assert_eq!(deduped.len(), 1);
+    assert_eq!(deduped[0].slug, "notes/long-page");
+    assert!((deduped[0].score - 0.9).abs() < 1e-12, "strongest row wins");
+    assert_eq!(
+        deduped[0].dedup_collapsed_count, 2,
+        "two siblings collapsed into the representative"
+    );
+}
+
+#[test]
+fn dedup_passes_through_single_row_per_page_unchanged() {
+    let candidates = vec![
+        candidate("notes/alpha", 0.9),
+        candidate("notes/beta", 0.7),
+        candidate("notes/gamma", 0.5),
+    ];
+
+    let deduped = dedup_chunks_per_page(candidates.clone(), 1);
+
+    assert_eq!(deduped.len(), 3);
+    for (kept, original) in deduped.iter().zip(candidates.iter()) {
+        assert_eq!(kept.slug, original.slug, "order preserved");
+        assert_eq!(kept.dedup_collapsed_count, 0, "nothing collapsed");
+    }
+}
+
+#[test]
+fn dedup_collapsed_count_tracks_per_page_collapse_magnitude() {
+    let candidates = vec![
+        candidate("notes/alpha", 0.9),
+        candidate("notes/beta", 0.8),
+        candidate("notes/alpha", 0.6),
+        candidate("notes/alpha", 0.4),
+        candidate("notes/beta", 0.3),
+    ];
+
+    let deduped = dedup_chunks_per_page(candidates, 1);
+
+    assert_eq!(deduped.len(), 2);
+    let alpha = deduped.iter().find(|r| r.slug == "notes/alpha").unwrap();
+    let beta = deduped.iter().find(|r| r.slug == "notes/beta").unwrap();
+    assert_eq!(alpha.dedup_collapsed_count, 2);
+    assert_eq!(beta.dedup_collapsed_count, 1);
+}
+
+#[test]
+fn dedup_max_two_keeps_two_strongest_rows_per_page() {
+    let candidates = vec![
+        candidate("notes/alpha", 0.9),
+        candidate("notes/alpha", 0.7),
+        candidate("notes/alpha", 0.5),
+    ];
+
+    let deduped = dedup_chunks_per_page(candidates, 2);
+
+    assert_eq!(deduped.len(), 2);
+    assert!((deduped[0].score - 0.9).abs() < 1e-12);
+    assert!((deduped[1].score - 0.7).abs() < 1e-12);
+    assert_eq!(
+        deduped[0].dedup_collapsed_count, 1,
+        "the third row collapses into the strongest representative"
+    );
+    assert_eq!(deduped[1].dedup_collapsed_count, 0);
+}
+
+#[test]
+fn dedup_zero_means_unlimited_identity() {
+    let candidates = vec![
+        candidate("notes/alpha", 0.9),
+        candidate("notes/alpha", 0.7),
+        candidate("notes/alpha", 0.5),
+    ];
+
+    let deduped = dedup_chunks_per_page(candidates.clone(), 0);
+
+    assert_eq!(deduped.len(), candidates.len(), "0 = unlimited (identity)");
+    assert!(deduped.iter().all(|r| r.dedup_collapsed_count == 0));
+}
+
+// ── 2. seeded identity default ────────────────────────────────────────────────
+
+#[test]
+fn schema_seeds_max_chunks_per_doc_identity_default() {
+    let conn = db::open(":memory:").expect("open in-memory db");
+    let seeded: String = conn
+        .query_row(
+            "SELECT value FROM config WHERE key = 'search.max_chunks_per_doc_default'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("seeded key");
+    assert_eq!(seeded, "0", "identity default: unlimited");
+}
+
+// ── 3. CLI flag plumbing ──────────────────────────────────────────────────────
+
+#[test]
+fn search_cli_accepts_max_chunks_per_doc_flag() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let db_path = test_db_path(&dir, "dedup-search-cli.db");
+    let conn = open_test_db(&db_path);
+    insert_page(&conn, "notes/widget", "Widget", "widget assembly notes");
+    drop(conn);
+
+    let output = run_quaid(
+        &db_path,
+        &["--json", "search", "widget", "--max-chunks-per-doc", "2"],
+    );
+
+    assert!(
+        output.status.success(),
+        "search must exit cleanly: {output:?}"
+    );
+    let parsed: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout must be JSON");
+    let results = parsed.as_array().expect("JSON array");
+    assert_eq!(results.len(), 1, "page-level FTS hit survives the cap");
+}
+
+#[test]
+fn query_cli_accepts_max_chunks_per_doc_flag() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let db_path = test_db_path(&dir, "dedup-query-cli.db");
+    let conn = open_test_db(&db_path);
+    insert_page(&conn, "notes/widget", "Widget", "widget assembly notes");
+    drop(conn);
+
+    let output = run_quaid(
+        &db_path,
+        &[
+            "--json",
+            "query",
+            "widget assembly",
+            "--depth",
+            "none",
+            "--max-chunks-per-doc",
+            "1",
+        ],
+    );
+
+    assert!(
+        output.status.success(),
+        "query must exit cleanly: {output:?}"
+    );
+    let parsed: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout must be JSON");
+    assert_eq!(
+        parsed.as_array().expect("JSON array").len(),
+        1,
+        "page-level hybrid hit survives the cap"
+    );
+}
+
+// ── 4. progressive_retrieve re-application ────────────────────────────────────
+
+#[test]
+fn progressive_retrieve_reapplies_dedup_on_initial_set() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let db_path = test_db_path(&dir, "dedup-progressive.db");
+    let conn = open_test_db(&db_path);
+    insert_page(&conn, "notes/alpha", "Alpha", &"x".repeat(100));
+    conn.execute(
+        "UPDATE config SET value = '1' WHERE key = 'search.max_chunks_per_doc_default'",
+        [],
+    )
+    .expect("activate dedup");
+
+    // Two rows for the same page in the initial set: dedup collapses them
+    // before the budget walk.
+    let initial = vec![candidate("notes/alpha", 0.9), candidate("notes/alpha", 0.6)];
+    let results = progressive_retrieve(initial, 100_000, 0, None, false, &conn).unwrap();
+
+    assert_eq!(results.len(), 1, "duplicate-page rows collapse to one");
+    assert_eq!(results[0].dedup_collapsed_count, 1);
+}
+
+#[test]
+fn progressive_retrieve_identity_default_keeps_duplicate_rows() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let db_path = test_db_path(&dir, "dedup-progressive-identity.db");
+    let conn = open_test_db(&db_path);
+    insert_page(&conn, "notes/alpha", "Alpha", &"x".repeat(100));
+
+    let initial = vec![candidate("notes/alpha", 0.9), candidate("notes/alpha", 0.6)];
+    let results = progressive_retrieve(initial, 100_000, 0, None, false, &conn).unwrap();
+
+    assert_eq!(
+        results.len(),
+        2,
+        "seeded default (0 = unlimited) must not collapse rows"
+    );
+}

--- a/tests/supersede_chain.rs
+++ b/tests/supersede_chain.rs
@@ -78,6 +78,7 @@ fn search_result(slug: &str) -> SearchResult {
         summary: slug.to_string(),
         score: 1.0,
         wing: "facts".to_string(),
+        ..Default::default()
     }
 }
 
@@ -228,6 +229,8 @@ fn retrieval_defaults_to_heads_and_include_superseded_restores_history() {
                 wing: None,
                 limit: None,
                 include_superseded: None,
+                relevance_floor: None,
+                max_chunks_per_doc: None,
             })
             .unwrap(),
     ))
@@ -241,6 +244,8 @@ fn retrieval_defaults_to_heads_and_include_superseded_restores_history() {
                 wing: None,
                 limit: None,
                 include_superseded: Some(true),
+                relevance_floor: None,
+                max_chunks_per_doc: None,
             })
             .unwrap(),
     ))
@@ -265,6 +270,9 @@ fn retrieval_defaults_to_heads_and_include_superseded_restores_history() {
                 limit: Some(10),
                 depth: None,
                 include_superseded: None,
+                hops: None,
+                relevance_floor: None,
+                max_chunks_per_doc: None,
             })
             .unwrap(),
     ))
@@ -279,6 +287,9 @@ fn retrieval_defaults_to_heads_and_include_superseded_restores_history() {
                 limit: Some(10),
                 depth: None,
                 include_superseded: Some(true),
+                hops: None,
+                relevance_floor: None,
+                max_chunks_per_doc: None,
             })
             .unwrap(),
     ))


### PR DESCRIPTION
**Stacked on #224** (`fable/w0-retrieval-fixes`) — GitHub will auto-retarget to main when #224 merges. Implements **Area 1 steps 4–5** (executing openspec `retrieval-quality-rerank` tasks 1–3) and **Area 14 — knowledge-gap feedback loop** of the codebase review.

## Part A — retrieval-quality-rerank tasks 1–3 (identity defaults)
- Config plumbing: `search.mmr_lambda`, `search.max_chunks_per_doc_default`, `search.cross_ref_boost_*`, `search.rerank_extractive*` seeded with the `search.*` prefix (reuses Wave 0's `search.relevance_floor`; naming reconciliation annotated in tasks.md, all task-group 1–3 boxes checked).
- `dedup_chunks_per_page` + `filter_below_floor` post-fusion in `hybrid_search`, re-applied on progressive expansion hops; `SearchResult` gains `mmr_score`/`cross_ref_boost`/`dedup_collapsed_count` (serde-skipped at inactive values — default JSON unchanged).
- New CLI flags `--max-chunks-per-doc`/`--relevance-floor` and matching MCP params on `memory_search`/`memory_query` with [0,1] validation.

## Part B — graph hops
`MemoryQueryInput` gains `hops`, threaded through `tools/search.rs` (previously hardcoded `None` — the entire shipped graph layer was unreachable over MCP). `graph_depth` seed stays `'0'` pending a DAB gate run.

## Part C — gap loop (Area 14)
- `merge_rrf` scores normalized ×(RRF_K+1)/2 — a rank-0 dual-list hit now scores 1.0 instead of ~0.033, so the gap heuristic stops logging every RRF query as a gap.
- Shared `gaps::should_log_gap` replaces both inline heuristics; exact-slug lookups (score ≥0.99) no longer log phantom gaps; auto-context becomes query-free diagnostics (`"auto: hybrid_search results=0"`).
- Resolve surface: `quaid gaps resolve <id> <slug>` + new MCP tool `memory_gap_resolve` (registry now 25 tools; `call.rs` dispatch arm added to keep the #225 parity test green when both merge).
- `gaps.store_context` config (default off): `memory_gap` persists capped context only when enabled; input doc states default-discard.

## Validation
fmt/clippy (-D warnings) clean. Suites green: new gap/rerank/hops integration tests + search_hardening, search_fusion, mcp_server_query_search_list, graph_retrieval, corpus_reality, command_surface_coverage; lib search/fts/gaps modules. Full details in the branch commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)