### PR TITLE
feat(assertions): fuzzy supersede matching, extraction-fact mirroring, contradiction resolution (area 13)

### DIFF
--- a/skills/maintain/SKILL.md
+++ b/skills/maintain/SKILL.md
@@ -12,13 +12,13 @@ description: |
 ## Operations
 
 - `quaid check --all` — run full contradiction detection across all assertions
+- `quaid check --resolve <id> --keep <slug>` — resolve a contradiction by keeping one page (the other is superseded by it); omit `--keep` to dismiss without superseding
 - `quaid validate --all` — check referential integrity, stale embeddings, broken links
 - `quaid gaps` — list unresolved knowledge gaps
 - Manual orphan review: pages with no links in or out
 
 ## TODO
 
-- [ ] Contradiction resolution workflow
 - [ ] Orphan page detection heuristics
 - [ ] Stale assertion cleanup rules
 - [ ] Knowledge gap prioritization

--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -4,17 +4,31 @@
 )]
 
 use anyhow::{anyhow, Result};
-use rusqlite::Connection;
+use rusqlite::{Connection, OptionalExtension};
+use serde::Serialize;
 
 use crate::commands::get::get_page_by_key;
 use crate::core::assertions::{self, Contradiction};
 use crate::core::collections::OpKind;
+use crate::core::supersede;
 use crate::core::vault_sync;
 
 #[derive(Debug)]
 pub struct CheckReport {
     contradictions: Vec<Contradiction>,
     processed_pages: usize,
+}
+
+/// Outcome of resolving one contradiction via `quaid check --resolve` or the
+/// MCP `memory_check` resolve parameter.
+#[derive(Debug, Serialize)]
+pub struct ResolveReport {
+    /// Id of the contradiction that was resolved.
+    pub contradiction_id: i64,
+    /// Canonical slug of the page kept as truth, when `--keep` was supplied.
+    pub kept_slug: Option<String>,
+    /// Canonical slug of the page superseded by the kept page, if any.
+    pub superseded_slug: Option<String>,
 }
 
 struct CheckTarget {
@@ -77,6 +91,126 @@ pub fn execute_check(
     })
 }
 
+/// CLI entry for `quaid check --resolve <id> [--keep <slug>]`.
+pub fn run_resolve(
+    db: &Connection,
+    contradiction_id: i64,
+    keep: Option<&str>,
+    json: bool,
+) -> Result<()> {
+    let report = execute_resolve(db, contradiction_id, keep)?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+        return Ok(());
+    }
+
+    match (&report.kept_slug, &report.superseded_slug) {
+        (Some(kept), Some(superseded)) => println!(
+            "Resolved contradiction {} — kept [{kept}], superseded [{superseded}].",
+            report.contradiction_id
+        ),
+        _ => println!("Resolved contradiction {}.", report.contradiction_id),
+    }
+
+    Ok(())
+}
+
+/// Resolve one contradiction without printing. With `keep`, the named page
+/// must be one side of the contradiction; the other side is superseded by it
+/// before the contradiction is stamped resolved. Safe to call from MCP.
+pub fn execute_resolve(
+    db: &Connection,
+    contradiction_id: i64,
+    keep: Option<&str>,
+) -> Result<ResolveReport> {
+    let row: Option<(i64, Option<i64>, Option<String>)> = db
+        .query_row(
+            "SELECT page_id, other_page_id, resolved_at FROM contradictions WHERE id = ?1",
+            [contradiction_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .optional()?;
+    let Some((page_id, other_page_id, resolved_at)) = row else {
+        return Err(anyhow!("contradiction not found: {contradiction_id}"));
+    };
+    if resolved_at.is_some() {
+        return Err(anyhow!(
+            "contradiction {contradiction_id} is already resolved"
+        ));
+    }
+
+    let mut kept_slug = None;
+    let mut superseded_slug = None;
+    if let Some(keep) = keep {
+        let resolved = vault_sync::resolve_slug_for_op(db, keep, OpKind::WriteUpdate)
+            .map_err(|err| anyhow!(err.to_string()))?;
+        vault_sync::ensure_collection_write_allowed(db, resolved.collection_id)
+            .map_err(|err| anyhow!(err.to_string()))?;
+        let keeper_id: i64 = db
+            .query_row(
+                "SELECT id FROM pages WHERE collection_id = ?1 AND slug = ?2",
+                rusqlite::params![resolved.collection_id, &resolved.slug],
+                |row| row.get(0),
+            )
+            .map_err(|error| match error {
+                rusqlite::Error::QueryReturnedNoRows => anyhow!("page not found: {keep}"),
+                other => anyhow!(other),
+            })?;
+
+        let loser_id = if keeper_id == page_id {
+            other_page_id
+        } else if Some(keeper_id) == other_page_id {
+            Some(page_id)
+        } else {
+            return Err(anyhow!(
+                "page {keep} is not part of contradiction {contradiction_id}"
+            ));
+        };
+        let Some(loser_id) = loser_id.filter(|loser| *loser != keeper_id) else {
+            return Err(anyhow!(
+                "contradiction {contradiction_id} involves a single page; resolve without --keep"
+            ));
+        };
+
+        supersede::mark_page_superseded(db, keeper_id, loser_id)
+            .map_err(|err| anyhow!(err.to_string()))?;
+
+        // Re-extract the superseded page so its mirrored extraction triples
+        // drop out of future detection runs.
+        let (loser_collection_id, loser_page_slug): (i64, String) = db.query_row(
+            "SELECT collection_id, slug FROM pages WHERE id = ?1",
+            [loser_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        let loser_page = get_page_by_key(db, loser_collection_id, &loser_page_slug)?;
+        assertions::extract_assertions(&loser_page, db)?;
+
+        kept_slug = Some(canonical_slug(db, keeper_id)?);
+        superseded_slug = Some(canonical_slug(db, loser_id)?);
+    }
+
+    assertions::resolve_contradiction(contradiction_id, db)
+        .map_err(|err| anyhow!(err.to_string()))?;
+
+    Ok(ResolveReport {
+        contradiction_id,
+        kept_slug,
+        superseded_slug,
+    })
+}
+
+fn canonical_slug(db: &Connection, page_id: i64) -> Result<String> {
+    Ok(db.query_row(
+        "SELECT c.name || '::' || p.slug
+         FROM pages p
+         JOIN collections c ON c.id = p.collection_id
+         WHERE p.id = ?1",
+        [page_id],
+        |row| row.get(0),
+    )?)
+}
+
 fn resolve_target(db: &Connection, slug: &str) -> Result<CheckTarget> {
     let resolved = vault_sync::resolve_slug_for_op(db, slug, OpKind::WriteUpdate)
         .map_err(|err| anyhow!(err.to_string()))?;
@@ -132,7 +266,8 @@ fn fetch_unresolved_contradictions(
     all: bool,
     check_type: Option<&str>,
 ) -> Result<Vec<Contradiction>> {
-    let base_sql = "SELECT cp.name || '::' || p.slug,
+    let base_sql = "SELECT c.id,
+                           cp.name || '::' || p.slug,
                            COALESCE(co.name || '::' || other.slug, cp.name || '::' || p.slug),
                            c.type,
                            c.description,
@@ -185,11 +320,12 @@ where
     let contradictions = statement
         .query_map(params, |row| {
             Ok(Contradiction {
-                page_slug: row.get(0)?,
-                other_page_slug: row.get(1)?,
-                r#type: row.get(2)?,
-                description: row.get(3)?,
-                detected_at: row.get(4)?,
+                id: row.get(0)?,
+                page_slug: row.get(1)?,
+                other_page_slug: row.get(2)?,
+                r#type: row.get(3)?,
+                description: row.get(4)?,
+                detected_at: row.get(5)?,
             })
         })?
         .collect::<std::result::Result<Vec<_>, _>>()?;
@@ -208,8 +344,11 @@ fn render_output(report: &CheckReport, json: bool) -> Result<String> {
     } else {
         lines.extend(report.contradictions.iter().map(|contradiction| {
             format!(
-                "[{}] ↔ [{}]: {}",
-                contradiction.page_slug, contradiction.other_page_slug, contradiction.description
+                "#{} [{}] ↔ [{}]: {}",
+                contradiction.id,
+                contradiction.page_slug,
+                contradiction.other_page_slug,
+                contradiction.description
             )
         }));
     }

--- a/src/core/assertions.rs
+++ b/src/core/assertions.rs
@@ -1,10 +1,15 @@
 //! Heuristic subject-predicate-object extraction plus pairwise contradiction
 //! detection across pages. Regex patterns scan a page's `## Assertions`
-//! section and a small frontmatter allowlist, persist the resulting triples,
-//! and compare them under temporal validity to surface conflicts.
+//! section and a small frontmatter allowlist, extracted-fact pages written by
+//! the conversation pipeline are mirrored as `(type_key, kind, summary)`
+//! triples, and the persisted triples are compared under temporal validity to
+//! surface conflicts. Resolution stamps `contradictions.resolved_at`, either
+//! directly or when a participating page is superseded.
 //!
-//! See also: `types` for `Page` and frontmatter helpers, and `markdown` for
-//! the section-splitting primitives the scanner builds on.
+//! See also: `types` for `Page` and frontmatter helpers, `markdown` for
+//! the section-splitting primitives the scanner builds on, and
+//! `crate::core::supersede` for the page-level supersede helpers that
+//! auto-resolve contradictions touching a superseded page.
 
 #![expect(
     clippy::expect_used,
@@ -26,6 +31,14 @@ const OPEN_RANGE_START: &str = "";
 const OPEN_RANGE_END: &str = "9999-12-31T23:59:59Z";
 const MIN_OBJECT_LEN: usize = 6;
 const SUPPORTED_FRONTMATTER_PREDICATES: [&str; 3] = ["is_a", "works_at", "founded"];
+/// `(kind, type-key field)` pairs for extracted-fact pages written by the
+/// conversation pipeline; mirrors `RawFact::type_key_field`.
+const EXTRACTED_FACT_KINDS: [(&str, &str); 4] = [
+    ("decision", "chose"),
+    ("preference", "about"),
+    ("fact", "about"),
+    ("action_item", "what"),
+];
 
 /// A heuristic subject-predicate-object triple extracted from page content.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -41,6 +54,8 @@ pub struct Triple {
 /// A stored contradiction row surfaced by `quaid check`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct Contradiction {
+    /// Row id; pass to `quaid check --resolve <id>` to mark it resolved.
+    pub id: i64,
     /// Slug of the page where the contradiction was attributed.
     pub page_slug: String,
     /// Slug of the other page involved in the conflict (same as `page_slug` for
@@ -65,6 +80,13 @@ pub enum AssertionError {
         slug: String,
     },
 
+    /// Requested contradiction id does not exist in the database.
+    #[error("contradiction not found: {id}")]
+    ContradictionNotFound {
+        /// Contradiction id that could not be resolved.
+        id: i64,
+    },
+
     /// Underlying SQLite failure.
     #[error("SQLite error: {0}")]
     Sqlite(#[from] rusqlite::Error),
@@ -74,6 +96,7 @@ pub enum AssertionError {
 struct ExtractedAssertion {
     triple: Triple,
     evidence_text: String,
+    asserted_by: &'static str,
 }
 
 #[derive(Debug, Clone)]
@@ -97,14 +120,17 @@ pub fn extract_assertions(page: &Page, conn: &Connection) -> Result<usize, Asser
         .map(|assertion| assertion.triple.clone())
         .collect();
 
-    for assertion in extract_from_content(&page.compiled_truth) {
+    for assertion in extract_from_content(&page.compiled_truth)
+        .into_iter()
+        .chain(extract_from_fact_page(page))
+    {
         if seen.insert(assertion.triple.clone()) {
             extracted.push(assertion);
         }
     }
 
     conn.execute(
-        "DELETE FROM assertions WHERE page_id = ?1 AND asserted_by = 'import'",
+        "DELETE FROM assertions WHERE page_id = ?1 AND asserted_by IN ('import', 'extraction')",
         [page_id],
     )?;
 
@@ -113,18 +139,108 @@ pub fn extract_assertions(page: &Page, conn: &Connection) -> Result<usize, Asser
             "INSERT INTO assertions (
                 page_id, subject, predicate, object, valid_from, valid_until,
                 confidence, asserted_by, source_ref, evidence_text
-            ) VALUES (?1, ?2, ?3, ?4, NULL, NULL, 0.8, 'import', '', ?5)",
+            ) VALUES (?1, ?2, ?3, ?4, NULL, NULL, 0.8, ?5, '', ?6)",
             rusqlite::params![
                 page_id,
                 assertion.triple.subject,
                 assertion.triple.predicate,
                 assertion.triple.object,
+                assertion.asserted_by,
                 assertion.evidence_text,
             ],
         )?;
     }
 
     Ok(extracted.len())
+}
+
+/// Mirror an extracted-fact page (written by the conversation pipeline) into
+/// a `(type_key, kind, summary)` triple so contradiction detection sees SLM
+/// facts without requiring a literal `## Assertions` section. Superseded
+/// pages are skipped: their content is resolved history, not current truth.
+fn extract_from_fact_page(page: &Page) -> Option<ExtractedAssertion> {
+    if page.superseded_by.is_some() {
+        return None;
+    }
+
+    let kind = crate::core::types::frontmatter_get_str(&page.frontmatter, "kind")?;
+    let key_field = EXTRACTED_FACT_KINDS
+        .iter()
+        .find(|(fact_kind, _)| *fact_kind == kind)
+        .map(|(_, key_field)| *key_field)?;
+    let type_key = normalize_evidence(crate::core::types::frontmatter_get_str(
+        &page.frontmatter,
+        key_field,
+    )?);
+    if type_key.is_empty() {
+        return None;
+    }
+
+    let summary = if page.summary.trim().is_empty() {
+        page.compiled_truth.trim()
+    } else {
+        page.summary.trim()
+    };
+    let object = normalize_evidence(summary);
+    if !is_valid_object(&object) {
+        return None;
+    }
+
+    Some(ExtractedAssertion {
+        triple: Triple {
+            subject: type_key,
+            predicate: kind.to_string(),
+            object,
+        },
+        evidence_text: "extracted fact".to_string(),
+        asserted_by: "extraction",
+    })
+}
+
+/// Stamp `resolved_at` on a contradiction. Returns `true` when the row was
+/// newly resolved, `false` when it already carried a `resolved_at`, and
+/// [`AssertionError::ContradictionNotFound`] when the id does not exist.
+pub fn resolve_contradiction(
+    contradiction_id: i64,
+    conn: &Connection,
+) -> Result<bool, AssertionError> {
+    let updated = conn.execute(
+        "UPDATE contradictions
+         SET resolved_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+         WHERE id = ?1 AND resolved_at IS NULL",
+        [contradiction_id],
+    )?;
+    if updated > 0 {
+        return Ok(true);
+    }
+
+    let exists: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM contradictions WHERE id = ?1",
+        [contradiction_id],
+        |row| row.get(0),
+    )?;
+    if exists > 0 {
+        Ok(false)
+    } else {
+        Err(AssertionError::ContradictionNotFound {
+            id: contradiction_id,
+        })
+    }
+}
+
+/// Stamp `resolved_at` on every open contradiction touching `page_id`;
+/// called from the supersede write path so conflicts involving a superseded
+/// page do not linger as open items. Returns the number of resolved rows.
+pub fn resolve_open_contradictions_for_page(
+    page_id: i64,
+    conn: &Connection,
+) -> Result<usize, rusqlite::Error> {
+    conn.execute(
+        "UPDATE contradictions
+         SET resolved_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+         WHERE resolved_at IS NULL AND (page_id = ?1 OR other_page_id = ?1)",
+        [page_id],
+    )
 }
 
 fn assertion_subject(page: &Page) -> &str {
@@ -274,6 +390,10 @@ fn load_assertions_for_subject(
     Ok(assertions)
 }
 
+/// Returns whether a contradiction with the same pair, type, and description
+/// has already been recorded — resolved or not. Resolved rows count so a
+/// deliberate resolution (`resolve_contradiction`) acts as a durable
+/// dismissal instead of being re-raised on the next check run.
 fn contradiction_exists(
     conn: &Connection,
     page_id: i64,
@@ -285,8 +405,7 @@ fn contradiction_exists(
          WHERE page_id = ?1
            AND other_page_id = ?2
            AND type = ?3
-           AND description = ?4
-           AND resolved_at IS NULL",
+           AND description = ?4",
         rusqlite::params![page_id, other_page_id, CONTRADICTION_TYPE, description],
         |row| row.get(0),
     )?;
@@ -298,7 +417,8 @@ fn load_contradiction(
     contradiction_id: i64,
 ) -> Result<Contradiction, AssertionError> {
     conn.query_row(
-        "SELECT p.slug,
+        "SELECT c.id,
+                p.slug,
                 COALESCE(other.slug, p.slug),
                 c.type,
                 c.description,
@@ -310,11 +430,12 @@ fn load_contradiction(
         [contradiction_id],
         |row| {
             Ok(Contradiction {
-                page_slug: row.get(0)?,
-                other_page_slug: row.get(1)?,
-                r#type: row.get(2)?,
-                description: row.get(3)?,
-                detected_at: row.get(4)?,
+                id: row.get(0)?,
+                page_slug: row.get(1)?,
+                other_page_slug: row.get(2)?,
+                r#type: row.get(3)?,
+                description: row.get(4)?,
+                detected_at: row.get(5)?,
             })
         },
     )
@@ -429,6 +550,7 @@ fn extract_from_frontmatter(
                     object,
                 },
                 evidence_text: "frontmatter".to_string(),
+                asserted_by: "import",
             })
         })
         .collect()
@@ -495,6 +617,7 @@ fn collect_pattern_matches(
                 evidence_text: normalize_evidence(
                     captures.get(0).map(|m| m.as_str()).unwrap_or_default(),
                 ),
+                asserted_by: "import",
             });
         }
     }
@@ -1062,7 +1185,7 @@ mod tests {
         }
 
         #[test]
-        fn resolved_conflict_is_redetected() {
+        fn resolved_conflict_is_not_redetected_for_identical_description() {
             let conn = open_test_db();
             insert_page(&conn, "people/alice", "Alice timeline.");
             insert_assertion(
@@ -1097,16 +1220,11 @@ mod tests {
 
             let contradictions = check_assertions("people/alice", &conn).unwrap();
 
-            assert_eq!(
-                contradictions.len(),
-                1,
-                "resolved contradiction should be re-detected"
+            assert!(
+                contradictions.is_empty(),
+                "resolution acts as a durable dismissal for the identical conflict"
             );
-            assert_eq!(
-                contradiction_count(&conn),
-                2,
-                "old resolved + new unresolved"
-            );
+            assert_eq!(contradiction_count(&conn), 1, "only the resolved row");
         }
 
         #[test]

--- a/src/core/conversation/supersede.rs
+++ b/src/core/conversation/supersede.rs
@@ -35,6 +35,10 @@ use crate::core::{collections, markdown, namespace};
 
 const DEFAULT_DEDUP_COSINE_MIN: f64 = 0.92;
 const DEFAULT_SUPERSEDE_COSINE_MIN: f64 = 0.4;
+const DEFAULT_KEY_MATCH_COSINE_MIN: f64 = 0.85;
+/// Required cosine gap between the best and second-best fuzzy key match;
+/// anything closer is ambiguous and falls back to `Coexist`.
+const KEY_MATCH_COSINE_MARGIN: f64 = 0.05;
 const DEFAULT_MODEL_ALIAS: &str = "phi-3.5-mini";
 const MAX_SLUG_COLLISION_ATTEMPTS: u32 = 5;
 
@@ -237,7 +241,14 @@ pub fn resolve_in_scope(
     collection_id: i64,
     namespace: &str,
 ) -> Result<Resolution, FactResolutionError> {
-    let candidates = head_candidates(conn, collection_id, namespace, raw_fact)?;
+    let candidates = select_head_candidates(
+        conn,
+        collection_id,
+        namespace,
+        raw_fact,
+        &cosine_similarity,
+        true,
+    )?;
     resolve_from_candidates(raw_fact, conn, candidates, cosine_similarity, true)
 }
 
@@ -254,7 +265,8 @@ pub fn resolve_in_scope_with_similarity<F>(
 where
     F: Fn(&str, &str) -> Result<f64, FactResolutionError>,
 {
-    let candidates = head_candidates(conn, collection_id, namespace, raw_fact)?;
+    let candidates =
+        select_head_candidates(conn, collection_id, namespace, raw_fact, &similarity, false)?;
     resolve_from_candidates(raw_fact, conn, candidates, similarity, false)
 }
 
@@ -502,6 +514,158 @@ fn source_turn_refs(window: &WindowedTurns) -> Vec<String> {
         &window.new_turns
     };
     turns.iter().map(|turn| turn.ordinal.to_string()).collect()
+}
+
+/// Select the head candidates a fresh fact resolves against: exact type-key
+/// matches when they exist, otherwise a fuzzy embedding-cosine match over the
+/// normalized type keys of same-kind heads in the scope.
+fn select_head_candidates<F>(
+    conn: &Connection,
+    collection_id: i64,
+    namespace: &str,
+    raw_fact: &RawFact,
+    similarity: &F,
+    require_trustworthy_embeddings: bool,
+) -> Result<Vec<HeadCandidate>, FactResolutionError>
+where
+    F: Fn(&str, &str) -> Result<f64, FactResolutionError>,
+{
+    let exact = head_candidates(conn, collection_id, namespace, raw_fact)?;
+    if !exact.is_empty() {
+        return Ok(exact);
+    }
+    fuzzy_head_candidates(
+        conn,
+        collection_id,
+        namespace,
+        raw_fact,
+        similarity,
+        require_trustworthy_embeddings,
+    )
+}
+
+/// Fall back to fuzzy type-key matching when no head shares the exact key:
+/// rank unsuperseded same-kind heads by `similarity` over normalized
+/// (lowercased/trimmed) keys, and accept the top match only when it clears
+/// `fact_resolution.key_match_cosine_min` with a clear margin over the
+/// runner-up. Anything weaker or ambiguous returns no candidates so the
+/// caller resolves to `Coexist`.
+fn fuzzy_head_candidates<F>(
+    conn: &Connection,
+    collection_id: i64,
+    namespace: &str,
+    raw_fact: &RawFact,
+    similarity: &F,
+    require_trustworthy_embeddings: bool,
+) -> Result<Vec<HeadCandidate>, FactResolutionError>
+where
+    F: Fn(&str, &str) -> Result<f64, FactResolutionError>,
+{
+    let new_key = normalize_type_key(raw_fact.type_key());
+    if new_key.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let key_path = format!("$.{}", raw_fact.type_key_field());
+    let mut stmt = conn.prepare(
+        "SELECT slug,
+                COALESCE(NULLIF(compiled_truth, ''), summary, title, ''),
+                json_extract(IIF(json_valid(frontmatter), frontmatter, '{}'), ?4)
+         FROM pages
+         WHERE collection_id = ?1
+           AND namespace = ?2
+           AND type = ?3
+           AND superseded_by IS NULL
+           AND json_extract(IIF(json_valid(frontmatter), frontmatter, '{}'), ?4) IS NOT NULL
+         ORDER BY id",
+    )?;
+    let rows = stmt.query_map(
+        params![collection_id, namespace, raw_fact.kind_str(), key_path],
+        |row| {
+            Ok((
+                HeadCandidate {
+                    slug: row.get(0)?,
+                    body: row.get(1)?,
+                },
+                row.get::<_, String>(2)?,
+            ))
+        },
+    )?;
+
+    let mut keyed_candidates = Vec::new();
+    for row in rows {
+        let (candidate, raw_key) = row?;
+        let normalized_key = normalize_type_key(&raw_key);
+        if !normalized_key.is_empty() {
+            keyed_candidates.push((candidate, normalized_key));
+        }
+    }
+    if keyed_candidates.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    if require_trustworthy_embeddings
+        && !matches!(
+            embedding_evidence_kind(),
+            Ok(EmbeddingEvidenceKind::Semantic)
+        )
+    {
+        eprintln!(
+            "INFO: fact_resolution decision=coexist reason=fuzzy_key_match_skipped_untrustworthy_embeddings kind={} key={}",
+            raw_fact.kind_str(),
+            raw_fact.type_key()
+        );
+        return Ok(Vec::new());
+    }
+
+    let key_match_cosine_min = read_f64_config(
+        conn,
+        "fact_resolution.key_match_cosine_min",
+        DEFAULT_KEY_MATCH_COSINE_MIN,
+    )?;
+
+    let mut scored = Vec::with_capacity(keyed_candidates.len());
+    for (candidate, candidate_key) in keyed_candidates {
+        let cosine = similarity(&new_key, &candidate_key)?;
+        scored.push((candidate, cosine));
+    }
+    scored.sort_by(|left, right| {
+        right
+            .1
+            .partial_cmp(&left.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    let top_cosine = scored[0].1;
+    if top_cosine < key_match_cosine_min {
+        return Ok(Vec::new());
+    }
+    if let Some((_, runner_up_cosine)) = scored.get(1) {
+        if top_cosine - runner_up_cosine < KEY_MATCH_COSINE_MARGIN {
+            eprintln!(
+                "INFO: fact_resolution decision=coexist reason=fuzzy_key_match_ambiguous kind={} key={} top={:.4} runner_up={:.4}",
+                raw_fact.kind_str(),
+                raw_fact.type_key(),
+                top_cosine,
+                runner_up_cosine
+            );
+            return Ok(Vec::new());
+        }
+    }
+
+    let (top_candidate, _) = scored.swap_remove(0);
+    eprintln!(
+        "INFO: fact_resolution decision=fuzzy_key_match matched_head={} kind={} key={} cosine={:.4}",
+        top_candidate.slug,
+        raw_fact.kind_str(),
+        raw_fact.type_key(),
+        top_cosine
+    );
+    Ok(vec![top_candidate])
+}
+
+fn normalize_type_key(raw: &str) -> String {
+    raw.trim().to_lowercase()
 }
 
 fn head_candidates(

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -288,6 +288,7 @@ fn open_connection(path: &str) -> Result<Connection, DbError> {
     ensure_serve_session_columns(&conn)?;
     ensure_collection_name_guards(&conn)?;
     ensure_raw_import_hash_schema(&conn)?;
+    ensure_assertions_extraction_provenance(&conn)?;
     set_version(&conn)?;
     ensure_default_collection(&conn)?;
 
@@ -617,6 +618,75 @@ fn ensure_raw_import_hash_schema(conn: &Connection) -> Result<(), DbError> {
         }
         tx.commit()?;
     }
+
+    Ok(())
+}
+
+/// Rebuild the `assertions` table when its `asserted_by` CHECK constraint
+/// predates the `'extraction'` provenance value used to mirror SLM-extracted
+/// facts into the assertions table.
+fn ensure_assertions_extraction_provenance(conn: &Connection) -> Result<(), DbError> {
+    if !table_exists(conn, "assertions")? {
+        return Ok(());
+    }
+
+    let table_sql: Option<String> = conn
+        .query_row(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'assertions'",
+            [],
+            |row| row.get(0),
+        )
+        .optional()?;
+    if table_sql
+        .as_deref()
+        .is_some_and(|sql| sql.contains("'extraction'"))
+    {
+        return Ok(());
+    }
+
+    let foreign_keys_enabled: i64 = conn.query_row("PRAGMA foreign_keys", [], |row| row.get(0))?;
+
+    conn.execute_batch(
+        "PRAGMA foreign_keys = OFF;
+         BEGIN;
+         CREATE TABLE assertions_new (
+             id              INTEGER PRIMARY KEY AUTOINCREMENT,
+             page_id         INTEGER NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
+             subject         TEXT    NOT NULL,
+             predicate       TEXT    NOT NULL,
+             object          TEXT    NOT NULL,
+             valid_from      TEXT    DEFAULT NULL,
+             valid_until     TEXT    DEFAULT NULL,
+             supersedes_id   INTEGER DEFAULT NULL REFERENCES assertions(id),
+             confidence      REAL    DEFAULT 1.0,
+             asserted_by     TEXT    NOT NULL DEFAULT 'agent',
+             source_ref      TEXT    NOT NULL DEFAULT '',
+             evidence_text   TEXT    NOT NULL DEFAULT '',
+             created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+             CHECK (valid_from IS NULL OR valid_until IS NULL OR valid_until >= valid_from),
+             CHECK (asserted_by IN ('agent', 'manual', 'import', 'enrichment', 'extraction'))
+         );
+         INSERT INTO assertions_new (
+             id, page_id, subject, predicate, object, valid_from, valid_until,
+             supersedes_id, confidence, asserted_by, source_ref, evidence_text,
+             created_at
+         )
+         SELECT
+             id, page_id, subject, predicate, object, valid_from, valid_until,
+             supersedes_id, confidence, asserted_by, source_ref, evidence_text,
+             created_at
+         FROM assertions;
+         DROP TABLE assertions;
+         ALTER TABLE assertions_new RENAME TO assertions;
+         CREATE INDEX IF NOT EXISTS idx_assertions_subj ON assertions(subject);
+         CREATE INDEX IF NOT EXISTS idx_assertions_pred ON assertions(predicate);
+         COMMIT;",
+    )?;
+
+    if foreign_keys_enabled != 0 {
+        conn.execute_batch("PRAGMA foreign_keys = ON;")?;
+    }
+    conn.execute_batch("PRAGMA foreign_key_check;")?;
 
     Ok(())
 }

--- a/src/core/supersede.rs
+++ b/src/core/supersede.rs
@@ -8,6 +8,7 @@
 use rusqlite::{params, Connection, OptionalExtension};
 use thiserror::Error;
 
+use crate::core::assertions;
 use crate::core::collections::{self, OpKind, SlugResolution};
 
 /// Failure mode raised when establishing or validating a supersede relationship
@@ -159,8 +160,91 @@ pub fn reconcile_supersede_chain(
                     .unwrap_or_else(|| page_slug.to_owned()),
             });
         }
+        resolve_contradictions_for_superseded_page(conn, target.id)?;
     }
 
+    Ok(())
+}
+
+/// Flip `superseded_by` on `predecessor_id` so it points at `successor_id`,
+/// validating self-reference, cross-collection moves, and head-only rules for
+/// both ends, then auto-resolve open contradictions touching the superseded
+/// page. Used by the contradiction-resolution surface (`quaid check
+/// --resolve <id> --keep <slug>` and MCP `memory_check`).
+pub fn mark_page_superseded(
+    conn: &Connection,
+    successor_id: i64,
+    predecessor_id: i64,
+) -> Result<(), SupersedeError> {
+    let successor_slug = canonical_slug_by_page_id(conn, successor_id)?;
+    if successor_id == predecessor_id {
+        return Err(SupersedeError::SelfReference {
+            slug: successor_slug,
+        });
+    }
+
+    let predecessor_slug = canonical_slug_by_page_id(conn, predecessor_id)?;
+    let (successor_collection, successor_successor): (i64, Option<i64>) = conn.query_row(
+        "SELECT collection_id, superseded_by FROM pages WHERE id = ?1",
+        [successor_id],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )?;
+    let predecessor_collection: i64 = conn.query_row(
+        "SELECT collection_id FROM pages WHERE id = ?1",
+        [predecessor_id],
+        |row| row.get(0),
+    )?;
+    if successor_collection != predecessor_collection {
+        return Err(SupersedeError::CrossCollection {
+            slug: predecessor_slug,
+        });
+    }
+    if let Some(successor_successor_id) = successor_successor {
+        return Err(SupersedeError::NonHeadTarget {
+            slug: successor_slug,
+            successor_slug: canonical_slug_by_page_id(conn, successor_successor_id)?,
+        });
+    }
+
+    let updated = conn.execute(
+        "UPDATE pages
+         SET superseded_by = ?1
+         WHERE id = ?2 AND superseded_by IS NULL",
+        params![successor_id, predecessor_id],
+    )?;
+    if updated == 0 {
+        let existing_successor: Option<i64> = conn
+            .query_row(
+                "SELECT superseded_by FROM pages WHERE id = ?1",
+                [predecessor_id],
+                |row| row.get(0),
+            )
+            .optional()?
+            .flatten();
+        return Err(SupersedeError::NonHeadTarget {
+            slug: predecessor_slug,
+            successor_slug: successor_slug_by_id(conn, existing_successor)?
+                .unwrap_or(successor_slug),
+        });
+    }
+
+    resolve_contradictions_for_superseded_page(conn, predecessor_id)?;
+    Ok(())
+}
+
+/// Auto-resolve open contradictions touching a page that just lost its head
+/// status; the superseding revision is now the authoritative truth, so the
+/// conflict no longer needs triage.
+fn resolve_contradictions_for_superseded_page(
+    conn: &Connection,
+    superseded_page_id: i64,
+) -> Result<(), SupersedeError> {
+    let resolved = assertions::resolve_open_contradictions_for_page(superseded_page_id, conn)?;
+    if resolved > 0 {
+        eprintln!(
+            "INFO: supersede auto-resolved {resolved} open contradiction(s) touching superseded page id={superseded_page_id}"
+        );
+    }
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -216,13 +216,21 @@ enum Commands {
     },
     /// N-hop graph neighbourhood
     Graph(commands::graph::GraphArgs),
-    /// Check for contradictions using assertions from frontmatter or ## Assertions sections
+    /// Check for contradictions across assertions (frontmatter allowlist,
+    /// ## Assertions sections, extracted facts), or resolve one by id
     Check {
         slug: Option<String>,
         #[arg(long)]
         all: bool,
         #[arg(long)]
         r#type: Option<String>,
+        /// Mark a contradiction resolved by id (stamps resolved_at)
+        #[arg(long, conflicts_with_all = ["slug", "all", "type"])]
+        resolve: Option<i64>,
+        /// Slug of the page to keep when resolving; the other page in the
+        /// contradiction is superseded by it
+        #[arg(long, requires = "resolve")]
+        keep: Option<String>,
     },
     /// List unresolved knowledge gaps
     Gaps {
@@ -483,9 +491,18 @@ async fn main() -> Result<()> {
             detail,
         } => commands::timeline::add(&db, &slug, &date, &summary, source, detail),
         Commands::Graph(args) => commands::graph::run_cli(&db, args, cli.json),
-        Commands::Check { slug, all, r#type } => {
-            commands::check::run(&db, slug, all, r#type, cli.json)
-        }
+        Commands::Check {
+            slug,
+            all,
+            r#type,
+            resolve,
+            keep,
+        } => match resolve {
+            Some(contradiction_id) => {
+                commands::check::run_resolve(&db, contradiction_id, keep.as_deref(), cli.json)
+            }
+            None => commands::check::run(&db, slug, all, r#type, cli.json),
+        },
         Commands::Gaps { limit, resolved } => commands::gaps::run(&db, limit, resolved, cli.json),
         Commands::Compact => commands::compact::run(&db),
         Commands::Collection { action } => commands::collection::run(&db, action, cli.json),

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -406,6 +406,12 @@ pub struct MemoryCheckInput {
     /// Optional slug restricting the check to a single page; omitted runs
     /// detection across every page.
     pub slug: Option<String>,
+    /// Optional contradiction id to mark resolved (stamps `resolved_at`)
+    /// instead of running detection.
+    pub resolve: Option<i64>,
+    /// Optional slug of the page to keep when resolving; the other page in
+    /// the contradiction is superseded by it. Requires `resolve`.
+    pub keep: Option<String>,
 }
 
 /// Input schema for the `memory_timeline` MCP tool.
@@ -2404,6 +2410,8 @@ mod tests {
         let error = server
             .memory_check(MemoryCheckInput {
                 slug: Some("notes/check-restoring".to_string()),
+                resolve: None,
+                keep: None,
             })
             .unwrap_err();
 
@@ -2435,6 +2443,8 @@ mod tests {
         let error = server
             .memory_check(MemoryCheckInput {
                 slug: Some("notes/check-needs-sync".to_string()),
+                resolve: None,
+                keep: None,
             })
             .unwrap_err();
 

--- a/src/mcp/tools/assertions.rs
+++ b/src/mcp/tools/assertions.rs
@@ -1,9 +1,11 @@
 //! Assertion / contradiction-detection tool body: `memory_check`. Runs
 //! `crate::core::assertions::extract_assertions` and `check_assertions*`
 //! over a single resolved page (or every page when no slug is provided)
-//! and returns the unresolved contradictions as JSON. Errors route through
-//! `mcp::errors::map_*` helpers so JSON-RPC error codes stay consistent
-//! with the rest of the MCP surface.
+//! and returns the unresolved contradictions as JSON. A `resolve` id flips
+//! the tool into resolution mode: it stamps `resolved_at` (optionally
+//! superseding the non-kept page when `keep` is supplied) instead of
+//! running detection. Errors route through `mcp::errors::map_*` helpers so
+//! JSON-RPC error codes stay consistent with the rest of the MCP surface.
 
 use rmcp::model::{CallToolResult, Content};
 use rmcp::tool;
@@ -23,7 +25,9 @@ impl QuaidServer {
     /// `memory_check` MCP tool: run heuristic contradiction detection
     /// over a single resolved page (when a slug is provided) or every
     /// page, returning the unresolved contradictions as JSON.
-    #[tool(description = "Run contradiction detection on a page or all pages")]
+    #[tool(
+        description = "Run contradiction detection on a page or all pages, or resolve a contradiction by id"
+    )]
     /// `memory_check` MCP tool: run heuristic contradiction detection
     /// over a single resolved page (when a slug is provided) or every
     /// page, returning the unresolved contradictions as JSON.
@@ -34,7 +38,18 @@ impl QuaidServer {
         if let Some(slug) = input.slug.as_deref() {
             validate_slug(slug)?;
         }
+        if let Some(keep) = input.keep.as_deref() {
+            validate_slug(keep)?;
+        }
         let db = self.db().lock().unwrap_or_else(|e| e.into_inner());
+
+        if let Some(contradiction_id) = input.resolve {
+            let report = check::execute_resolve(&db, contradiction_id, input.keep.as_deref())
+                .map_err(map_anyhow_error)?;
+            return Ok(CallToolResult::success(vec![Content::text(
+                serde_json::to_string_pretty(&report).map_err(map_serialize_error)?,
+            )]));
+        }
         let slug_filter = input
             .slug
             .as_deref()
@@ -62,7 +77,7 @@ impl QuaidServer {
         let contradictions: Vec<Contradiction> = if let Some(page_id) = selected_page_id {
             let mut stmt = db
                 .prepare(
-                    "SELECT cp.name || '::' || p.slug, \
+                    "SELECT c.id, cp.name || '::' || p.slug, \
                             COALESCE(co.name || '::' || other.slug, cp.name || '::' || p.slug), \
                             c.type, c.description, c.detected_at \
                       FROM contradictions c \
@@ -78,11 +93,12 @@ impl QuaidServer {
             let rows = stmt
                 .query_map([page_id], |row| {
                     Ok(Contradiction {
-                        page_slug: row.get(0)?,
-                        other_page_slug: row.get(1)?,
-                        r#type: row.get(2)?,
-                        description: row.get(3)?,
-                        detected_at: row.get(4)?,
+                        id: row.get(0)?,
+                        page_slug: row.get(1)?,
+                        other_page_slug: row.get(2)?,
+                        r#type: row.get(3)?,
+                        description: row.get(4)?,
+                        detected_at: row.get(5)?,
                     })
                 })
                 .map_err(map_db_error)?;
@@ -91,7 +107,7 @@ impl QuaidServer {
         } else {
             let mut stmt = db
                 .prepare(
-                    "SELECT cp.name || '::' || p.slug, \
+                    "SELECT c.id, cp.name || '::' || p.slug, \
                             COALESCE(co.name || '::' || other.slug, cp.name || '::' || p.slug), \
                             c.type, c.description, c.detected_at \
                       FROM contradictions c \
@@ -107,11 +123,12 @@ impl QuaidServer {
             let rows = stmt
                 .query_map([], |row| {
                     Ok(Contradiction {
-                        page_slug: row.get(0)?,
-                        other_page_slug: row.get(1)?,
-                        r#type: row.get(2)?,
-                        description: row.get(3)?,
-                        detected_at: row.get(4)?,
+                        id: row.get(0)?,
+                        page_slug: row.get(1)?,
+                        other_page_slug: row.get(2)?,
+                        r#type: row.get(3)?,
+                        description: row.get(4)?,
+                        detected_at: row.get(5)?,
                     })
                 })
                 .map_err(map_db_error)?;

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -272,7 +272,7 @@ CREATE TABLE IF NOT EXISTS assertions (
     evidence_text   TEXT    NOT NULL DEFAULT '',
     created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
     CHECK (valid_from IS NULL OR valid_until IS NULL OR valid_until >= valid_from),
-    CHECK (asserted_by IN ('agent', 'manual', 'import', 'enrichment'))
+    CHECK (asserted_by IN ('agent', 'manual', 'import', 'enrichment', 'extraction'))
 );
 
 CREATE INDEX IF NOT EXISTS idx_assertions_subj ON assertions(subject);
@@ -462,7 +462,10 @@ INSERT OR IGNORE INTO config (key, value) VALUES
     ('graph_expansion_max',          '50'),
     ('edge_weight_frontmatter',      '1.0'),
     ('edge_weight_entity_pattern',   '0.7'),
-    ('edge_weight_wikilink',         '0.5');
+    ('edge_weight_wikilink',         '0.5'),
+    -- Minimum embed(type_key) cosine for fuzzy head matching when no exact
+    -- type-key match exists during fact resolution.
+    ('fact_resolution.key_match_cosine_min', '0.85');
 
 -- ============================================================
 -- contradictions: detected inconsistencies

--- a/tests/contradiction_resolution.rs
+++ b/tests/contradiction_resolution.rs
@@ -1,0 +1,769 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::print_stdout,
+    reason = "test fixtures legitimately panic on setup failure and print diagnostics; per-site #[expect] would generate noise across thousands of test sites"
+)]
+
+//! Integration tests for the contradiction detection & resolution slice:
+//! fuzzy type-key head matching in the fact resolver, extracted-fact pages
+//! mirrored into the `assertions` table, and the `resolved_at` resolution
+//! surface (`commands::check::execute_resolve`, the `quaid check --resolve`
+//! CLI, and MCP `memory_check`).
+
+mod common;
+#[path = "common/subprocess.rs"]
+mod common_subprocess;
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+use quaid::commands::check;
+use quaid::core::assertions;
+use quaid::core::conversation::supersede::{resolve_in_scope_with_similarity, Resolution};
+use quaid::core::db;
+use quaid::core::types::RawFact;
+use quaid::mcp::server::{MemoryCheckInput, MemoryStatsInput, QuaidServer};
+use rmcp::model::RawContent;
+use rusqlite::{params, Connection};
+
+fn open_test_db(path: &Path) -> Connection {
+    let conn = db::open(path.to_str().unwrap()).unwrap();
+    conn.execute(
+        "UPDATE collections
+         SET root_path = ?1,
+             state = 'active'
+         WHERE id = 1",
+        [path.parent().unwrap().display().to_string()],
+    )
+    .unwrap();
+    conn
+}
+
+fn insert_head_page(
+    conn: &Connection,
+    slug: &str,
+    kind: &str,
+    key_name: &str,
+    key_value: &str,
+    summary: &str,
+) -> i64 {
+    let frontmatter = serde_json::json!({
+        "kind": kind,
+        key_name: key_value,
+    })
+    .to_string();
+    conn.execute(
+        "INSERT INTO pages
+             (collection_id, namespace, slug, uuid, type, title, summary, compiled_truth, timeline,
+              frontmatter, wing, room, version)
+         VALUES
+             (1, '', ?1, ?2, ?3, ?1, ?4, ?4, '', ?5, '', '', 1)",
+        params![slug, format!("uuid-{slug}"), kind, summary, frontmatter],
+    )
+    .unwrap();
+    conn.last_insert_rowid()
+}
+
+fn fact_about(about: &str, summary: &str) -> RawFact {
+    RawFact::Fact {
+        about: about.to_string(),
+        summary: summary.to_string(),
+    }
+}
+
+fn extract_text(result: &rmcp::model::CallToolResult) -> String {
+    result
+        .content
+        .iter()
+        .filter_map(|content| match &content.raw {
+            RawContent::Text(text) => Some(text.text.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+// ── fuzzy type-key head matching ─────────────────────────────
+
+#[test]
+fn paraphrased_key_supersedes_existing_head_via_fuzzy_match() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let conn = open_test_db(&dir.path().join("memory.db"));
+    insert_head_page(
+        &conn,
+        "salary-fact",
+        "fact",
+        "about",
+        "salary",
+        "Matt earns 100k",
+    );
+
+    let resolution = resolve_in_scope_with_similarity(
+        &fact_about("compensation", "Matt now earns 120k"),
+        &conn,
+        1,
+        "",
+        |left, right| {
+            if left == "compensation" && right == "salary" {
+                return Ok(0.9); // paraphrased key clears key_match_cosine_min
+            }
+            Ok(0.6) // body similarity lands in the supersede band
+        },
+    )
+    .unwrap();
+
+    assert!(matches!(
+        resolution,
+        Resolution::Supersede { prior_slug, .. } if prior_slug == "salary-fact"
+    ));
+}
+
+#[test]
+fn fuzzy_key_match_normalizes_case_and_whitespace() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let conn = open_test_db(&dir.path().join("memory.db"));
+    insert_head_page(
+        &conn,
+        "salary-fact",
+        "fact",
+        "about",
+        "  Salary  ",
+        "Matt earns 100k",
+    );
+
+    let resolution = resolve_in_scope_with_similarity(
+        &fact_about("salary band", "Matt now earns 120k"),
+        &conn,
+        1,
+        "",
+        |left, right| {
+            // Keys arrive lowercased and trimmed.
+            if left == "salary band" && right == "salary" {
+                return Ok(0.92);
+            }
+            Ok(0.6)
+        },
+    )
+    .unwrap();
+
+    assert!(matches!(
+        resolution,
+        Resolution::Supersede { prior_slug, .. } if prior_slug == "salary-fact"
+    ));
+}
+
+#[test]
+fn fuzzy_key_margin_ambiguity_falls_back_to_coexist() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let conn = open_test_db(&dir.path().join("memory.db"));
+    insert_head_page(
+        &conn,
+        "salary-acme",
+        "fact",
+        "about",
+        "salary at acme",
+        "100k at Acme",
+    );
+    insert_head_page(
+        &conn,
+        "salary-beta",
+        "fact",
+        "about",
+        "salary at beta",
+        "90k at Beta",
+    );
+
+    // Both candidates clear the threshold but sit within the 0.05 margin:
+    // resolution must coexist rather than guess (and must NOT surface an
+    // AmbiguousMatchingHeads error).
+    let resolution = resolve_in_scope_with_similarity(
+        &fact_about("compensation", "Matt earns 120k"),
+        &conn,
+        1,
+        "",
+        |_, right| match right {
+            "salary at acme" => Ok(0.90),
+            "salary at beta" => Ok(0.88),
+            _ => panic!("body similarity should not run for ambiguous fuzzy key matches"),
+        },
+    )
+    .unwrap();
+
+    assert_eq!(resolution, Resolution::Coexist);
+}
+
+#[test]
+fn fuzzy_key_below_threshold_falls_back_to_coexist() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let conn = open_test_db(&dir.path().join("memory.db"));
+    insert_head_page(
+        &conn,
+        "editor-fact",
+        "fact",
+        "about",
+        "editor",
+        "Matt uses Helix",
+    );
+
+    let resolution = resolve_in_scope_with_similarity(
+        &fact_about("compensation", "Matt earns 120k"),
+        &conn,
+        1,
+        "",
+        |_, right| match right {
+            "editor" => Ok(0.4),
+            _ => panic!("body similarity should not run below the fuzzy key threshold"),
+        },
+    )
+    .unwrap();
+
+    assert_eq!(resolution, Resolution::Coexist);
+}
+
+#[test]
+fn key_match_cosine_min_is_seeded_and_configurable() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let conn = open_test_db(&dir.path().join("memory.db"));
+
+    let seeded: String = conn
+        .query_row(
+            "SELECT value FROM config WHERE key = 'fact_resolution.key_match_cosine_min'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(seeded, "0.85");
+
+    // Raise the threshold above the reported cosine: the fuzzy match must
+    // no longer fire.
+    conn.execute(
+        "UPDATE config SET value = '0.95' WHERE key = 'fact_resolution.key_match_cosine_min'",
+        [],
+    )
+    .unwrap();
+    insert_head_page(
+        &conn,
+        "salary-fact",
+        "fact",
+        "about",
+        "salary",
+        "Matt earns 100k",
+    );
+
+    let resolution = resolve_in_scope_with_similarity(
+        &fact_about("compensation", "Matt earns 120k"),
+        &conn,
+        1,
+        "",
+        |_, right| match right {
+            "salary" => Ok(0.9),
+            _ => panic!("body similarity should not run below the configured threshold"),
+        },
+    )
+    .unwrap();
+
+    assert_eq!(resolution, Resolution::Coexist);
+}
+
+// ── extracted facts mirrored into assertions ─────────────────
+
+#[test]
+fn extracted_fact_pages_yield_assertion_rows_and_check_detects_conflict() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let conn = open_test_db(&dir.path().join("memory.db"));
+    // Two coexisting extracted-fact heads about the same key; neither page
+    // contains a literal "## Assertions" heading.
+    insert_head_page(
+        &conn,
+        "extracted/facts/timezone-1",
+        "fact",
+        "about",
+        "timezone",
+        "Matt is based in UTC+9",
+    );
+    insert_head_page(
+        &conn,
+        "extracted/facts/timezone-2",
+        "fact",
+        "about",
+        "timezone",
+        "Matt is based in UTC+2",
+    );
+
+    check::execute_check(&conn, None, true, None).unwrap();
+    assert_eq!(report_contradiction_count(&conn), 1);
+
+    let rows: Vec<(String, String, String, String)> = conn
+        .prepare(
+            "SELECT subject, predicate, object, asserted_by
+             FROM assertions
+             ORDER BY object",
+        )
+        .unwrap()
+        .query_map([], |row| {
+            Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
+        })
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+    assert_eq!(
+        rows,
+        vec![
+            (
+                "timezone".to_string(),
+                "fact".to_string(),
+                "Matt is based in UTC+2".to_string(),
+                "extraction".to_string(),
+            ),
+            (
+                "timezone".to_string(),
+                "fact".to_string(),
+                "Matt is based in UTC+9".to_string(),
+                "extraction".to_string(),
+            ),
+        ]
+    );
+}
+
+#[test]
+fn superseded_fact_pages_are_not_mirrored_into_assertions() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let conn = open_test_db(&dir.path().join("memory.db"));
+    let head_id = insert_head_page(
+        &conn,
+        "extracted/facts/timezone-new",
+        "fact",
+        "about",
+        "timezone",
+        "Matt is based in UTC+2",
+    );
+    insert_head_page(
+        &conn,
+        "extracted/facts/timezone-old",
+        "fact",
+        "about",
+        "timezone",
+        "Matt is based in UTC+9",
+    );
+    conn.execute(
+        "UPDATE pages SET superseded_by = ?1 WHERE slug = 'extracted/facts/timezone-old'",
+        [head_id],
+    )
+    .unwrap();
+
+    check::execute_check(&conn, None, true, None).unwrap();
+
+    let assertion_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM assertions", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(
+        assertion_count, 1,
+        "only the head fact page should be mirrored"
+    );
+    assert_eq!(report_contradiction_count(&conn), 0);
+}
+
+// ── resolution surface ───────────────────────────────────────
+
+#[test]
+fn resolve_stamps_resolved_at_and_removes_row_from_check_and_stats() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let conn = open_test_db(&dir.path().join("memory.db"));
+    insert_head_page(
+        &conn,
+        "extracted/facts/timezone-1",
+        "fact",
+        "about",
+        "timezone",
+        "Matt is based in UTC+9",
+    );
+    insert_head_page(
+        &conn,
+        "extracted/facts/timezone-2",
+        "fact",
+        "about",
+        "timezone",
+        "Matt is based in UTC+2",
+    );
+    check::execute_check(&conn, None, true, None).unwrap();
+    let contradiction_id: i64 = conn
+        .query_row(
+            "SELECT id FROM contradictions WHERE resolved_at IS NULL",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+
+    let report = check::execute_resolve(&conn, contradiction_id, None).unwrap();
+    assert_eq!(report.contradiction_id, contradiction_id);
+    assert_eq!(report.kept_slug, None);
+
+    let resolved_at: Option<String> = conn
+        .query_row(
+            "SELECT resolved_at FROM contradictions WHERE id = ?1",
+            [contradiction_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(resolved_at.is_some(), "resolved_at must be stamped");
+
+    let server = QuaidServer::new(conn);
+    let check_result = server
+        .memory_check(MemoryCheckInput {
+            slug: None,
+            resolve: None,
+            keep: None,
+        })
+        .unwrap();
+    let listed: serde_json::Value = serde_json::from_str(&extract_text(&check_result)).unwrap();
+    assert_eq!(
+        listed.as_array().unwrap().len(),
+        0,
+        "resolved contradiction must not be re-detected or listed by memory_check"
+    );
+
+    let stats_result = server.memory_stats(MemoryStatsInput {}).unwrap();
+    let stats: serde_json::Value = serde_json::from_str(&extract_text(&stats_result)).unwrap();
+    assert_eq!(
+        stats["contradiction_count"], 0,
+        "stats must count only unresolved contradictions"
+    );
+}
+
+#[test]
+fn resolve_with_keep_supersedes_the_other_page() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let conn = open_test_db(&dir.path().join("memory.db"));
+    let keeper_id = insert_head_page(
+        &conn,
+        "extracted/facts/timezone-keep",
+        "fact",
+        "about",
+        "timezone",
+        "Matt is based in UTC+2",
+    );
+    let loser_id = insert_head_page(
+        &conn,
+        "extracted/facts/timezone-drop",
+        "fact",
+        "about",
+        "timezone",
+        "Matt is based in UTC+9",
+    );
+    check::execute_check(&conn, None, true, None).unwrap();
+    let contradiction_id: i64 = conn
+        .query_row(
+            "SELECT id FROM contradictions WHERE resolved_at IS NULL",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+
+    let report = check::execute_resolve(
+        &conn,
+        contradiction_id,
+        Some("extracted/facts/timezone-keep"),
+    )
+    .unwrap();
+    assert_eq!(
+        report.kept_slug.as_deref(),
+        Some("default::extracted/facts/timezone-keep")
+    );
+    assert_eq!(
+        report.superseded_slug.as_deref(),
+        Some("default::extracted/facts/timezone-drop")
+    );
+
+    let superseded_by: Option<i64> = conn
+        .query_row(
+            "SELECT superseded_by FROM pages WHERE id = ?1",
+            [loser_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(superseded_by, Some(keeper_id));
+
+    // The superseded page's mirrored assertion is gone, so a fresh check
+    // run does not re-detect the conflict.
+    check::execute_check(&conn, None, true, None).unwrap();
+    let open_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM contradictions WHERE resolved_at IS NULL",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(open_count, 0);
+}
+
+#[test]
+fn resolve_unknown_or_mismatched_inputs_error() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let conn = open_test_db(&dir.path().join("memory.db"));
+
+    let missing = check::execute_resolve(&conn, 4242, None).unwrap_err();
+    assert!(missing.to_string().contains("contradiction not found"));
+
+    insert_head_page(
+        &conn,
+        "extracted/facts/timezone-1",
+        "fact",
+        "about",
+        "timezone",
+        "Matt is based in UTC+9",
+    );
+    insert_head_page(
+        &conn,
+        "extracted/facts/timezone-2",
+        "fact",
+        "about",
+        "timezone",
+        "Matt is based in UTC+2",
+    );
+    insert_head_page(
+        &conn,
+        "extracted/facts/bystander",
+        "fact",
+        "about",
+        "editor",
+        "Matt uses Helix today",
+    );
+    check::execute_check(&conn, None, true, None).unwrap();
+    let contradiction_id: i64 = conn
+        .query_row(
+            "SELECT id FROM contradictions WHERE resolved_at IS NULL",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+
+    let mismatched =
+        check::execute_resolve(&conn, contradiction_id, Some("extracted/facts/bystander"))
+            .unwrap_err();
+    assert!(mismatched.to_string().contains("is not part of"));
+
+    check::execute_resolve(&conn, contradiction_id, None).unwrap();
+    let already = check::execute_resolve(&conn, contradiction_id, None).unwrap_err();
+    assert!(already.to_string().contains("already resolved"));
+}
+
+#[test]
+fn memory_check_resolve_param_resolves_contradiction() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let conn = open_test_db(&dir.path().join("memory.db"));
+    insert_head_page(
+        &conn,
+        "extracted/facts/timezone-keep",
+        "fact",
+        "about",
+        "timezone",
+        "Matt is based in UTC+2",
+    );
+    insert_head_page(
+        &conn,
+        "extracted/facts/timezone-drop",
+        "fact",
+        "about",
+        "timezone",
+        "Matt is based in UTC+9",
+    );
+    check::execute_check(&conn, None, true, None).unwrap();
+    let contradiction_id: i64 = conn
+        .query_row(
+            "SELECT id FROM contradictions WHERE resolved_at IS NULL",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+
+    let server = QuaidServer::new(conn);
+    let resolve_result = server
+        .memory_check(MemoryCheckInput {
+            slug: None,
+            resolve: Some(contradiction_id),
+            keep: Some("extracted/facts/timezone-keep".to_string()),
+        })
+        .unwrap();
+    let report: serde_json::Value = serde_json::from_str(&extract_text(&resolve_result)).unwrap();
+    assert_eq!(report["contradiction_id"], contradiction_id);
+    assert_eq!(
+        report["kept_slug"],
+        "default::extracted/facts/timezone-keep"
+    );
+    assert_eq!(
+        report["superseded_slug"],
+        "default::extracted/facts/timezone-drop"
+    );
+
+    let check_result = server
+        .memory_check(MemoryCheckInput {
+            slug: None,
+            resolve: None,
+            keep: None,
+        })
+        .unwrap();
+    let listed: serde_json::Value = serde_json::from_str(&extract_text(&check_result)).unwrap();
+    assert_eq!(listed.as_array().unwrap().len(), 0);
+}
+
+#[test]
+fn superseding_a_page_auto_resolves_open_contradictions_touching_it() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let conn = open_test_db(&dir.path().join("memory.db"));
+    let keeper_id = insert_head_page(
+        &conn,
+        "extracted/facts/timezone-new",
+        "fact",
+        "about",
+        "timezone",
+        "Matt is based in UTC+2",
+    );
+    let loser_id = insert_head_page(
+        &conn,
+        "extracted/facts/timezone-old",
+        "fact",
+        "about",
+        "timezone",
+        "Matt is based in UTC+9",
+    );
+    check::execute_check(&conn, None, true, None).unwrap();
+    assert_eq!(report_contradiction_count(&conn), 1);
+
+    quaid::core::supersede::mark_page_superseded(&conn, keeper_id, loser_id).unwrap();
+
+    assert_eq!(
+        report_contradiction_count(&conn),
+        0,
+        "supersede must auto-resolve open contradictions touching the superseded page"
+    );
+}
+
+#[test]
+fn resolve_contradiction_core_api_is_idempotent_and_404s_on_unknown_id() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let conn = open_test_db(&dir.path().join("memory.db"));
+    insert_head_page(
+        &conn,
+        "extracted/facts/timezone-1",
+        "fact",
+        "about",
+        "timezone",
+        "Matt is based in UTC+9",
+    );
+    insert_head_page(
+        &conn,
+        "extracted/facts/timezone-2",
+        "fact",
+        "about",
+        "timezone",
+        "Matt is based in UTC+2",
+    );
+    check::execute_check(&conn, None, true, None).unwrap();
+    let contradiction_id: i64 = conn
+        .query_row("SELECT id FROM contradictions", [], |row| row.get(0))
+        .unwrap();
+
+    assert!(assertions::resolve_contradiction(contradiction_id, &conn).unwrap());
+    assert!(!assertions::resolve_contradiction(contradiction_id, &conn).unwrap());
+    assert!(matches!(
+        assertions::resolve_contradiction(4242, &conn).unwrap_err(),
+        assertions::AssertionError::ContradictionNotFound { id: 4242 }
+    ));
+}
+
+fn report_contradiction_count(conn: &Connection) -> i64 {
+    conn.query_row(
+        "SELECT COUNT(*) FROM contradictions WHERE resolved_at IS NULL",
+        [],
+        |row| row.get(0),
+    )
+    .unwrap()
+}
+
+fn run_quaid(db_path: &Path, args: &[&str]) -> Output {
+    let mut command = Command::new(common::quaid_bin());
+    common_subprocess::configure_test_command(&mut command);
+    command
+        .arg("--db")
+        .arg(db_path)
+        .args(args)
+        .output()
+        .expect("run quaid")
+}
+
+#[test]
+fn cli_check_resolve_keep_flow_round_trips() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("memory.db");
+    let conn = open_test_db(&db_path);
+    insert_head_page(
+        &conn,
+        "extracted/facts/timezone-keep",
+        "fact",
+        "about",
+        "timezone",
+        "Matt is based in UTC+2",
+    );
+    insert_head_page(
+        &conn,
+        "extracted/facts/timezone-drop",
+        "fact",
+        "about",
+        "timezone",
+        "Matt is based in UTC+9",
+    );
+    drop(conn);
+
+    let check = run_quaid(&db_path, &["check", "--all", "--json"]);
+    assert!(
+        check.status.success(),
+        "check stderr: {}",
+        String::from_utf8_lossy(&check.stderr)
+    );
+    let listed: serde_json::Value = serde_json::from_slice(&check.stdout).unwrap();
+    let contradiction = &listed.as_array().unwrap()[0];
+    let contradiction_id = contradiction["id"].as_i64().unwrap();
+    assert_eq!(contradiction["type"], "assertion_conflict");
+
+    let resolve = run_quaid(
+        &db_path,
+        &[
+            "check",
+            "--resolve",
+            &contradiction_id.to_string(),
+            "--keep",
+            "extracted/facts/timezone-keep",
+            "--json",
+        ],
+    );
+    assert!(
+        resolve.status.success(),
+        "resolve stderr: {}",
+        String::from_utf8_lossy(&resolve.stderr)
+    );
+    let report: serde_json::Value = serde_json::from_slice(&resolve.stdout).unwrap();
+    assert_eq!(report["contradiction_id"], contradiction_id);
+    assert_eq!(
+        report["superseded_slug"],
+        "default::extracted/facts/timezone-drop"
+    );
+
+    let recheck = run_quaid(&db_path, &["check", "--all", "--json"]);
+    assert!(recheck.status.success());
+    let relisted: serde_json::Value = serde_json::from_slice(&recheck.stdout).unwrap();
+    assert_eq!(relisted.as_array().unwrap().len(), 0);
+}
+
+#[test]
+fn cli_check_keep_without_resolve_is_rejected() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("memory.db");
+    drop(open_test_db(&db_path));
+
+    let output = run_quaid(&db_path, &["check", "--keep", "people/alice"]);
+    assert!(
+        !output.status.success(),
+        "--keep without --resolve must be rejected by clap"
+    );
+}

--- a/tests/db_schema_migrations.rs
+++ b/tests/db_schema_migrations.rs
@@ -153,3 +153,80 @@ fn open_backfills_raw_import_content_hash_for_existing_rows() {
         quaid::core::raw_imports::content_hash_hex(b"hello")
     );
 }
+
+#[test]
+fn open_rebuilds_assertions_check_to_allow_extraction_provenance() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("test_memory.db");
+    let path_str = db_path.to_str().unwrap();
+
+    let conn = open(path_str).unwrap();
+    conn.execute(
+        "INSERT INTO pages (slug, uuid, type, title)
+         VALUES ('notes/assert-test', ?1, 'concept', 'notes/assert-test')",
+        [quaid::core::page_uuid::generate_uuid_v7()],
+    )
+    .unwrap();
+    let page_id: i64 = conn
+        .query_row(
+            "SELECT id FROM pages WHERE slug = 'notes/assert-test'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    drop(conn);
+
+    // Simulate a database created before 'extraction' was an allowed
+    // asserted_by value.
+    let conn = Connection::open(path_str).unwrap();
+    conn.execute_batch(
+        "DROP TABLE assertions;
+         CREATE TABLE assertions (
+             id              INTEGER PRIMARY KEY AUTOINCREMENT,
+             page_id         INTEGER NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
+             subject         TEXT    NOT NULL,
+             predicate       TEXT    NOT NULL,
+             object          TEXT    NOT NULL,
+             valid_from      TEXT    DEFAULT NULL,
+             valid_until     TEXT    DEFAULT NULL,
+             supersedes_id   INTEGER DEFAULT NULL REFERENCES assertions(id),
+             confidence      REAL    DEFAULT 1.0,
+             asserted_by     TEXT    NOT NULL DEFAULT 'agent',
+             source_ref      TEXT    NOT NULL DEFAULT '',
+             evidence_text   TEXT    NOT NULL DEFAULT '',
+             created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+             CHECK (valid_from IS NULL OR valid_until IS NULL OR valid_until >= valid_from),
+             CHECK (asserted_by IN ('agent', 'manual', 'import', 'enrichment'))
+         );
+         CREATE INDEX IF NOT EXISTS idx_assertions_subj ON assertions(subject);
+         CREATE INDEX IF NOT EXISTS idx_assertions_pred ON assertions(predicate);",
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO assertions (page_id, subject, predicate, object, asserted_by)
+         VALUES (?1, 'Alice', 'works_at', 'Acme Corp', 'manual')",
+        [page_id],
+    )
+    .unwrap();
+    drop(conn);
+
+    let conn = open(path_str).unwrap();
+    // Legacy rows survive the rebuild...
+    let (subject, asserted_by): (String, String) = conn
+        .query_row(
+            "SELECT subject, asserted_by FROM assertions WHERE page_id = ?1",
+            [page_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(subject, "Alice");
+    assert_eq!(asserted_by, "manual");
+
+    // ...and 'extraction' provenance is now accepted.
+    conn.execute(
+        "INSERT INTO assertions (page_id, subject, predicate, object, asserted_by)
+         VALUES (?1, 'timezone', 'fact', 'Matt is based in UTC+2', 'extraction')",
+        [page_id],
+    )
+    .unwrap();
+}

--- a/tests/db_schema_v10.rs
+++ b/tests/db_schema_v10.rs
@@ -114,6 +114,7 @@ fn fresh_v10_schema_includes_conversation_memory_artifacts_and_defaults() {
                  'extraction.idle_close_ms',
                  'extraction.retention_days',
                  'fact_resolution.dedup_cosine_min',
+                 'fact_resolution.key_match_cosine_min',
                  'fact_resolution.supersede_cosine_min'
              )
              ORDER BY key",
@@ -143,6 +144,10 @@ fn fresh_v10_schema_includes_conversation_memory_artifacts_and_defaults() {
             (
                 "fact_resolution.dedup_cosine_min".to_string(),
                 "0.92".to_string()
+            ),
+            (
+                "fact_resolution.key_match_cosine_min".to_string(),
+                "0.85".to_string()
             ),
             (
                 "fact_resolution.supersede_cosine_min".to_string(),

--- a/tests/entity_extraction.rs
+++ b/tests/entity_extraction.rs
@@ -75,6 +75,32 @@ fn count_entity_pattern_links(conn: &Connection) -> i64 {
     .unwrap()
 }
 
+/// `entities::run_for_page` with a generous extraction deadline.
+///
+/// The production 5 ms budget is load-sensitive: on a saturated CI runner the
+/// first pattern can already blow it, skipping extraction and flaking any
+/// assertion-count expectation. Routing tests pin a deterministic deadline via
+/// the explicit seam; budget behaviour itself is covered by the
+/// `extract_entities` over-budget test.
+fn run_for_page_generous(
+    conn: &Connection,
+    page_id: i64,
+    collection_id: i64,
+    page_slug: &str,
+    compiled_truth: &str,
+    patterns: &[EntityPattern],
+) -> Result<entities::RoutingSummary, entities::EntityError> {
+    entities::run_for_page_with_deadline(
+        conn,
+        page_id,
+        collection_id,
+        page_slug,
+        compiled_truth,
+        patterns,
+        Duration::from_secs(30),
+    )
+}
+
 // ── 6.x: pattern config and validation ────────────────────────
 
 #[test]
@@ -305,7 +331,7 @@ fn budget_overrun_logs_knowledge_gap() {
     assert!(outcome.over_budget);
 
     // Force the wired gap-logging via the helper for budget overrun.
-    let summary = entities::run_for_page(&conn, page_id, 1, "people/alice", "", &[]).unwrap();
+    let summary = run_for_page_generous(&conn, page_id, 1, "people/alice", "", &[]).unwrap();
     assert_eq!(summary.matches_seen, 0);
     let gap_count: i64 = conn
         .query_row("SELECT COUNT(*) FROM knowledge_gaps", [], |row| row.get(0))
@@ -323,7 +349,7 @@ fn match_with_both_resolved_inserts_assertion_no_link() {
     insert_page(&conn, "companies/brex", "Brex", "body");
 
     let patterns = entities::load_patterns_from(None, &conn).unwrap();
-    let summary = entities::run_for_page(
+    let summary = run_for_page_generous(
         &conn,
         source,
         1,
@@ -360,7 +386,7 @@ fn unresolved_match_still_inserts_assertion_no_link() {
     insert_page(&conn, "people/alice", "Alice", "body");
 
     let patterns = entities::load_patterns_from(None, &conn).unwrap();
-    let summary = entities::run_for_page(
+    let summary = run_for_page_generous(
         &conn,
         source,
         1,
@@ -387,7 +413,7 @@ fn unresolved_evidence_does_not_include_raw_capture_text() {
     insert_page(&conn, "people/alice", "Alice", "body");
 
     let patterns = entities::load_patterns_from(None, &conn).unwrap();
-    entities::run_for_page(
+    run_for_page_generous(
         &conn,
         source,
         1,
@@ -450,7 +476,7 @@ fn idempotent_reingest_does_not_duplicate_assertions() {
     let patterns = entities::load_patterns_from(None, &conn).unwrap();
 
     for _ in 0..3 {
-        entities::run_for_page(
+        run_for_page_generous(
             &conn,
             source,
             1,
@@ -475,7 +501,7 @@ fn reingest_removes_entity_assertions_no_longer_in_page_text() {
     insert_page(&conn, "companies/stripe", "Stripe", "body");
     let patterns = entities::load_patterns_from(None, &conn).unwrap();
 
-    entities::run_for_page(
+    run_for_page_generous(
         &conn,
         source,
         1,
@@ -484,7 +510,7 @@ fn reingest_removes_entity_assertions_no_longer_in_page_text() {
         &patterns,
     )
     .unwrap();
-    entities::run_for_page(
+    run_for_page_generous(
         &conn,
         source,
         1,
@@ -574,7 +600,7 @@ fn over_budget_run_for_page_logs_gap_and_preserves_existing_entity_assertions() 
     insert_page(&conn, "companies/brex", "Brex", "body");
     let patterns = entities::load_patterns_from(None, &conn).unwrap();
 
-    entities::run_for_page(
+    run_for_page_generous(
         &conn,
         source,
         1,

--- a/tests/fact_resolution.rs
+++ b/tests/fact_resolution.rs
@@ -184,7 +184,14 @@ fn resolve_coexists_when_no_head_matches_key() {
         &conn,
         1,
         "",
-        |_, _| panic!("similarity should not run when there are no matching heads"),
+        |left, right| {
+            // Fuzzy key matching compares normalized type keys; report the
+            // dissimilar key pair as well below the acceptance threshold.
+            if left == "programming-language" && right == "editor" {
+                return Ok(0.2);
+            }
+            panic!("body similarity should not run when fuzzy key match is below threshold");
+        },
     )
     .unwrap();
 

--- a/tests/mcp_server_check_timeline_tags.rs
+++ b/tests/mcp_server_check_timeline_tags.rs
@@ -33,6 +33,8 @@ fn memory_check_on_clean_page_returns_empty_array() {
     let result = server
         .memory_check(MemoryCheckInput {
             slug: Some("people/alice".to_string()),
+            resolve: None,
+            keep: None,
         })
         .unwrap();
 
@@ -54,6 +56,8 @@ fn memory_check_detects_contradiction_on_page() {
     let result = server
         .memory_check(MemoryCheckInput {
             slug: Some("people/alice".to_string()),
+            resolve: None,
+            keep: None,
         })
         .unwrap();
 
@@ -80,12 +84,16 @@ fn memory_check_filters_output_to_requested_slug() {
     server
         .memory_check(MemoryCheckInput {
             slug: Some("people/bob".to_string()),
+            resolve: None,
+            keep: None,
         })
         .unwrap();
 
     let result = server
         .memory_check(MemoryCheckInput {
             slug: Some("people/alice".to_string()),
+            resolve: None,
+            keep: None,
         })
         .unwrap();
 
@@ -118,12 +126,16 @@ fn memory_check_explicit_collection_slug_filters_to_resolved_page_when_slug_coll
     server
         .memory_check(MemoryCheckInput {
             slug: Some("default::people/alice".to_string()),
+            resolve: None,
+            keep: None,
         })
         .unwrap();
 
     let result = server
         .memory_check(MemoryCheckInput {
             slug: Some("memory::people/alice".to_string()),
+            resolve: None,
+            keep: None,
         })
         .unwrap();
 
@@ -147,7 +159,11 @@ fn memory_check_without_slug_returns_all_unresolved_contradictions() {
     );
 
     let result = server
-        .memory_check(MemoryCheckInput { slug: None })
+        .memory_check(MemoryCheckInput {
+            slug: None,
+            resolve: None,
+            keep: None,
+        })
         .unwrap();
 
     let parsed: Vec<serde_json::Value> = serde_json::from_str(&extract_text(&result)).unwrap();

--- a/website/src/content/docs/how-to/contradictions-and-gaps.mdx
+++ b/website/src/content/docs/how-to/contradictions-and-gaps.mdx
@@ -11,45 +11,62 @@ Two intelligence-layer surfaces work together: `check` finds places where the me
 ## Run a contradiction check
 
 ```bash
-quaid check people/alice --db ~/memory.db    # one page
-quaid check --all --db ~/memory.db           # every page
-quaid check --type person --db ~/memory.db   # all pages of one type
+quaid check people/alice --db ~/memory.db                 # one page
+quaid check --all --db ~/memory.db                        # every page
+quaid check --all --type assertion_conflict --db ~/memory.db  # filter by contradiction type
 ```
 
-`check` reads the `assertions` table and flags subject-predicate-object triples that disagree. Common patterns:
+`check` re-extracts the page's assertions, then flags pairs of subject-predicate-object triples about the same `(subject, predicate)` whose objects differ while their `valid_from` / `valid_until` windows overlap. Detection is exact-match over the `assertions` table — it does not infer conflicts from arbitrary prose, timelines, or unstructured frontmatter.
 
-- Two assertions about the same `(subject, predicate)` with overlapping `valid_from` / `valid_until`.
-- A timeline entry that contradicts a compiled-truth assertion.
-- A frontmatter field that disagrees with content in the body.
-
-Output is human-readable by default, JSON with `--json`. Materialized contradictions live in the `contradictions` table.
+Output is human-readable by default (each line starts with the contradiction id, e.g. `#3 [a] ↔ [b]: …`), JSON with `--json`. Materialized contradictions live in the `contradictions` table.
 
 ## Where assertions come from
 
 Assertions are populated three ways:
 
-1. **Declared in frontmatter**:
+1. **A small frontmatter allowlist** — the scalar fields `is_a`, `works_at`, and `founded`:
 
    ```yaml
    ---
    title: Alice
    type: person
-   assertions:
-     - subject: alice
-       predicate: employed_by
-       object: river-ai
-       valid_from: 2024-01-15
+   works_at: River AI
    ---
    ```
 
-2. **Parsed from `## Assertions` sections** in the body.
-3. **Inferred** by ingestion heuristics from common patterns (e.g. "Alice joined RiverAI in 2024").
+2. **Parsed from a `## Assertions` section** in the body. Three sentence patterns are recognized: `X works at Y`, `X is a Y`, and `X founded Y`. Prose outside this section is never scanned.
+
+3. **Mirrored from extracted-fact pages.** Facts the conversation pipeline writes under `extracted/` (kinds `decision`, `preference`, `fact`, `action_item`) are mirrored automatically as `(type key, kind, summary)` triples with `asserted_by = 'extraction'` — no `## Assertions` heading needed. Superseded fact pages are skipped, so resolved history doesn't conflict with current truth.
+
+You can also insert rows into `assertions` directly (`asserted_by = 'manual'`); re-running `check` preserves manual rows.
 
 ## Resolve a contradiction
 
-There's no automated resolver — contradictions are surfaced for human (or agent) review. The typical resolution:
+Each contradiction has an id (shown by `quaid check` and `memory_check`). Resolve it with:
 
-- **Wrong assertion?** Delete it from the source (frontmatter or body), re-run `put`, re-run `check`.
+```bash
+# Keep one page: the other page in the pair is superseded by it,
+# and the contradiction is stamped resolved.
+quaid check --resolve 3 --keep people/alice --db ~/memory.db
+
+# Dismiss without superseding (e.g. false positive):
+quaid check --resolve 3 --db ~/memory.db
+```
+
+Over MCP, pass `resolve` (and optionally `keep`) to `memory_check`:
+
+```bash
+quaid call memory_check '{"resolve":3,"keep":"people/alice"}' --db ~/memory.db
+```
+
+Resolution semantics:
+
+- Resolving stamps `contradictions.resolved_at`; resolved rows disappear from `quaid check`, `memory_check`, and the `memory_stats` contradiction count.
+- A resolved contradiction is a durable dismissal: the identical conflict (same pages, same description) is not re-raised on later checks. A materially different conflict (e.g. a new object value) is still detected as a new contradiction.
+- Superseding a page — via `--keep`, a `supersedes:` write, or the extraction pipeline — auto-resolves open contradictions touching the superseded page.
+
+When neither side should win outright, fix the data instead:
+
 - **Both true at different times?** Add `valid_until` to the older assertion so the intervals don't overlap.
 - **Both true now, but seem to disagree?** Edit the predicate; the contradiction was lexical, not semantic.
 


### PR DESCRIPTION
Implements **Area 13 — Contradiction detection & resolution** of the codebase review (`docs/fable-review.md` on `code-review-2`). Addresses #197 and #135.

## Changes
- **Fuzzy head matching** (`conversation/supersede.rs`): when exact `type_key` match finds no head, candidates of the same `(collection, namespace, type)` are ranked by key similarity; top-1 accepted only above new config `fact_resolution.key_match_cosine_min` (0.85) **and** with a ≥0.05 margin over the runner-up — otherwise Coexist. Never inflates `AmbiguousMatchingHeads`; falls back gracefully (log + Coexist) when embedding evidence is untrustworthy (hash shim).
- **Extraction facts → assertions**: extracted-fact pages (decision/preference/fact/action_item) are mirrored into `assertions` as `(type_key → subject, kind → predicate, summary → object, asserted_by='extraction')`, so `quaid check`/`memory_check` detect conflicts **without a literal `## Assertions` heading** (the #197 root cause). Deliberate deviation from the review's plan wording: mirroring runs in `extract_assertions` (page row must exist; the fact writer only emits a vault file pre-ingest) — the observable spec behavior is implemented and tested.
- **Resolution surface** (#135): `resolve_contradiction` stamps `resolved_at`; auto-resolved from the supersede path for conflicts touching the superseded head; exposed as `quaid check --resolve <id> --keep <slug>` and a `resolve` param on `memory_check`. Resolved conflicts are durably dismissed (identical pair/type/description not re-raised; a genuinely different conflict still produces a new row) — the pre-existing inline test asserting re-detection was rewritten accordingly.
- **Schema**: `assertions` CHECK extended with `'extraction'`; legacy DBs transparently rebuilt at open (`ensure_assertions_extraction_provenance`, data/ids/indexes preserved, migration test included).
- **Docs**: `contradictions-and-gaps.mdx` rewritten to match real behavior (drops the fictional timeline-vs-truth/frontmatter-vs-body/prose-inference claims that generated #197).

## Validation
fmt/clippy (-D warnings) clean; full `cargo test --lib` 928 passed. Integration green: contradiction_resolution (15), fact_resolution, assertions, mcp check/timeline/tags, db_schema_v10 + migrations, fact_write, supersede chains, memory_correct, extraction_worker, command_surface_coverage. The two known hash-shim-env failures in extraction_worker fail identically on origin/main (A/B verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)