### PR TITLE
fix(db): one connection factory, one transaction helper, no FS effects at open (area 7)

### DIFF
--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -19,12 +19,14 @@ pub fn run(path: &str, requested_model: &inference::ModelConfig) -> Result<()> {
     }
 
     if db_path.exists() {
-        db::init(path, &inference::resolve_model("small"))?;
+        let conn = db::init(path, &inference::resolve_model("small"))?;
+        db::provision_default_collection_root(&conn)?;
         println!("Database already exists at {path}");
         return Ok(());
     }
 
-    db::init(path, requested_model)?;
+    let conn = db::init(path, requested_model)?;
+    db::provision_default_collection_root(&conn)?;
     println!("Memory initialized at {path}");
     Ok(())
 }

--- a/src/commands/link.rs
+++ b/src/commands/link.rs
@@ -382,6 +382,13 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let db_path = dir.path().join("test_memory.db");
         let conn = db::open(db_path.to_str().unwrap()).unwrap();
+        // Configure a real root so write-target resolution never falls back
+        // to provisioning the default `~/.quaid/vault` from a unit test.
+        conn.execute(
+            "UPDATE collections SET root_path = ?1 WHERE id = 1",
+            [dir.path().display().to_string()],
+        )
+        .unwrap();
         std::mem::forget(dir);
         conn
     }

--- a/src/commands/stats.rs
+++ b/src/commands/stats.rs
@@ -192,6 +192,13 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let db_path = dir.path().join("test_memory.db");
         let conn = db::open(db_path.to_str().unwrap()).unwrap();
+        // Configure a real root: `gather_stats` only lists collections with a
+        // non-empty root, and open no longer provisions the default root.
+        conn.execute(
+            "UPDATE collections SET root_path = ?1 WHERE id = 1",
+            [dir.path().display().to_string()],
+        )
+        .unwrap();
         std::mem::forget(dir);
         conn
     }

--- a/src/commands/tags.rs
+++ b/src/commands/tags.rs
@@ -75,6 +75,13 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let db_path = dir.path().join("test_memory.db");
         let conn = db::open(db_path.to_str().unwrap()).unwrap();
+        // Configure a real root so write-target resolution never falls back
+        // to provisioning the default `~/.quaid/vault` from a unit test.
+        conn.execute(
+            "UPDATE collections SET root_path = ?1 WHERE id = 1",
+            [dir.path().display().to_string()],
+        )
+        .unwrap();
         std::mem::forget(dir);
         conn
     }

--- a/src/commands/timeline.rs
+++ b/src/commands/timeline.rs
@@ -180,7 +180,17 @@ mod tests {
     use rusqlite::Connection;
 
     fn open_test_db() -> Connection {
-        db::open(":memory:").unwrap()
+        let conn = db::open(":memory:").unwrap();
+        // Configure a real root so write-target resolution never falls back
+        // to provisioning the default `~/.quaid/vault` from a unit test.
+        let root = tempfile::TempDir::new().unwrap();
+        conn.execute(
+            "UPDATE collections SET root_path = ?1 WHERE id = 1",
+            [root.path().display().to_string()],
+        )
+        .unwrap();
+        std::mem::forget(root);
+        conn
     }
 
     fn insert_page(conn: &Connection, slug: &str) {

--- a/src/core/conversation/queue.rs
+++ b/src/core/conversation/queue.rs
@@ -17,6 +17,7 @@ use rusqlite::{params, Connection, OptionalExtension};
 use thiserror::Error;
 
 use crate::core::db;
+use crate::core::db::with_immediate_transaction;
 use crate::core::types::{ExtractionJob, ExtractionTriggerKind};
 
 /// Default cap on extraction attempts before a job is parked in
@@ -414,29 +415,6 @@ fn read_job(row: &rusqlite::Row<'_>) -> rusqlite::Result<ExtractionJob> {
                 )
             })?,
     })
-}
-
-fn with_immediate_transaction<T>(
-    conn: &Connection,
-    action: impl FnOnce(&Connection) -> Result<T, ExtractionQueueError>,
-) -> Result<T, ExtractionQueueError> {
-    conn.execute_batch("BEGIN IMMEDIATE TRANSACTION")?;
-    match action(conn) {
-        Ok(value) => match conn.execute_batch("COMMIT TRANSACTION") {
-            Ok(()) => Ok(value),
-            Err(commit_error) => {
-                // SQLITE_BUSY on COMMIT does not auto-rollback, so the transaction
-                // would otherwise stay open and wedge subsequent BEGIN IMMEDIATEs
-                // on this shared connection.
-                let _ = conn.execute_batch("ROLLBACK TRANSACTION");
-                Err(ExtractionQueueError::from(commit_error))
-            }
-        },
-        Err(error) => {
-            let _ = conn.execute_batch("ROLLBACK TRANSACTION");
-            Err(error)
-        }
-    }
 }
 
 #[cfg(test)]

--- a/src/core/conversation/supersede.rs
+++ b/src/core/conversation/supersede.rs
@@ -27,6 +27,7 @@ use thiserror::Error;
 
 use crate::core::conversation::{format, queue, turn_writer};
 use crate::core::db;
+use crate::core::db::with_immediate_transaction;
 use crate::core::inference::{embed, embedding_evidence_kind, EmbeddingEvidenceKind};
 use crate::core::types::{
     frontmatter_insert_string, ExtractionJob, Frontmatter, Page, RawFact, Turn, WindowedTurns,
@@ -884,21 +885,4 @@ fn write_markdown(
 
 fn path_to_slash(path: &Path) -> String {
     path.to_string_lossy().replace('\\', "/")
-}
-
-fn with_immediate_transaction<T>(
-    conn: &Connection,
-    action: impl FnOnce(&Connection) -> Result<T, FactResolutionError>,
-) -> Result<T, FactResolutionError> {
-    conn.execute_batch("BEGIN IMMEDIATE TRANSACTION")?;
-    match action(conn) {
-        Ok(value) => {
-            conn.execute_batch("COMMIT TRANSACTION")?;
-            Ok(value)
-        }
-        Err(error) => {
-            let _ = conn.execute_batch("ROLLBACK TRANSACTION");
-            Err(error)
-        }
-    }
 }

--- a/src/core/conversation/turn_writer.rs
+++ b/src/core/conversation/turn_writer.rs
@@ -268,6 +268,12 @@ pub fn resolve_memory_root(conn: &Connection) -> Result<MemoryRoot, TurnWriteErr
             }
         })?,
     )?;
+    // Opening a database no longer provisions the default `~/.quaid/vault`
+    // root on disk; heal the empty-root placeholder here, at the moment a
+    // write actually needs a usable write-target root.
+    db::provision_default_collection_root(conn).map_err(|error| TurnWriteError::Config {
+        message: error.to_string(),
+    })?;
     let write_target = collections::get_write_target(conn)
         .map_err(|error| TurnWriteError::Config {
             message: error.to_string(),

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -129,6 +129,81 @@ pub fn open(path: &str) -> Result<Connection, DbError> {
     open_with_model(path, &default_model()).map(|opened| opened.conn)
 }
 
+/// Opens an **already-initialized** database at `path` for runtime use:
+/// background workers, watcher callbacks, supervisor ticks, IPC handlers,
+/// and other short-lived "fresh connection" sites.
+///
+/// Unlike [`open`], this performs no DDL, no bootstrap, and no filesystem
+/// side effects — the database file must already exist and have been
+/// initialized via [`init`]/[`open`] (e.g. `quaid init`). It registers
+/// `sqlite-vec`, applies the standard 5s busy timeout, and enables
+/// `foreign_keys`, so runtime connections behave identically to [`open`]ed
+/// ones under write contention instead of failing instantly with
+/// `SQLITE_BUSY`.
+///
+/// A cheap `PRAGMA user_version` guard rejects files that were never
+/// bootstrapped (including `:memory:`, which is always a fresh empty
+/// database on a new connection and therefore never valid here).
+pub fn open_runtime<P: AsRef<Path>>(path: P) -> Result<Connection, DbError> {
+    let db_path = path.as_ref();
+    if db_path.as_os_str() != ":memory:" && !db_path.exists() {
+        return Err(DbError::PathNotFound {
+            path: db_path.display().to_string(),
+        });
+    }
+
+    ensure_sqlite_vec();
+    let conn = Connection::open(db_path)?;
+    conn.busy_timeout(Duration::from_secs(5))?;
+    conn.execute_batch("PRAGMA foreign_keys = ON;")?;
+
+    let user_version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
+    if user_version != SCHEMA_VERSION {
+        return Err(DbError::Schema {
+            message: format!(
+                "open_runtime requires an initialized database (found user_version {user_version}, expected {SCHEMA_VERSION}) at {}; run `quaid init` or open it via db::open first",
+                db_path.display()
+            ),
+        });
+    }
+
+    Ok(conn)
+}
+
+/// Runs `action` inside a `BEGIN IMMEDIATE` transaction on `conn`,
+/// committing on success and rolling back on failure.
+///
+/// `SQLITE_BUSY` on COMMIT does **not** auto-rollback, so a failed commit
+/// would otherwise leave the transaction open and wedge every subsequent
+/// `BEGIN IMMEDIATE` on a shared connection with "cannot start a
+/// transaction within a transaction". The explicit ROLLBACK on the
+/// commit-error path restores the connection to autocommit; the rollback
+/// result is intentionally ignored because the commit error is the one the
+/// caller must see (and ROLLBACK after a failed COMMIT can itself report
+/// that no transaction is active).
+pub fn with_immediate_transaction<T, E>(
+    conn: &Connection,
+    action: impl FnOnce(&Connection) -> Result<T, E>,
+) -> Result<T, E>
+where
+    E: From<rusqlite::Error>,
+{
+    conn.execute_batch("BEGIN IMMEDIATE TRANSACTION")?;
+    match action(conn) {
+        Ok(value) => match conn.execute_batch("COMMIT TRANSACTION") {
+            Ok(()) => Ok(value),
+            Err(commit_error) => {
+                let _ = conn.execute_batch("ROLLBACK TRANSACTION");
+                Err(E::from(commit_error))
+            }
+        },
+        Err(error) => {
+            let _ = conn.execute_batch("ROLLBACK TRANSACTION");
+            Err(error)
+        }
+    }
+}
+
 /// Returns the conventional `~/.quaid/memory.db` path, falling back to
 /// `memory.db` in the current directory when no home directory is available.
 pub fn default_db_path() -> std::path::PathBuf {
@@ -626,12 +701,35 @@ fn ensure_raw_import_hash_schema(conn: &Connection) -> Result<(), DbError> {
 /// All legacy INSERT INTO pages statements that omit collection_id rely on
 /// `DEFAULT 1` routing them to this collection.  Called at every
 /// `open_connection()` so test-only in-memory databases are also covered.
+///
+/// Deliberately performs **no filesystem side effects**: the row is seeded
+/// with `root_path = ''` and the on-disk default root (`~/.quaid/vault`) is
+/// only provisioned by [`provision_default_collection_root`] — called from
+/// `quaid init` and from write-target resolution — whose ON CONFLICT branch
+/// heals the empty `root_path` placeholder.
 fn ensure_default_collection(conn: &Connection) -> Result<(), DbError> {
     if has_configured_write_target(conn)? {
         return Ok(());
     }
 
+    upsert_default_collection(conn, "")
+}
+
+/// Provisions the default collection root (`~/.quaid/vault`) on disk and
+/// heals the default collection row when its `root_path` is still the
+/// empty-string placeholder seeded at open. Called by `quaid init` and by
+/// write-target resolution points just before a write needs a usable root;
+/// a no-op when a write target with a non-empty root is already configured.
+pub fn provision_default_collection_root(conn: &Connection) -> Result<(), DbError> {
+    if has_configured_write_target(conn)? {
+        return Ok(());
+    }
+
     let default_root = prepare_default_collection_root()?;
+    upsert_default_collection(conn, &default_root)
+}
+
+fn upsert_default_collection(conn: &Connection, default_root: &str) -> Result<(), DbError> {
     let tx = conn.unchecked_transaction()?;
     tx.execute(
         "UPDATE collections SET is_write_target = 0 WHERE is_write_target != 0",
@@ -666,6 +764,10 @@ fn ensure_default_collection(conn: &Connection) -> Result<(), DbError> {
     Ok(())
 }
 
+/// Returns whether a write-target collection with a usable (non-empty)
+/// root is configured — the guard both [`ensure_default_collection`] and
+/// [`provision_default_collection_root`] use to stay no-ops once a real
+/// write target exists.
 fn has_configured_write_target(conn: &Connection) -> Result<bool, DbError> {
     let count: i64 = conn.query_row(
         "SELECT COUNT(*)
@@ -800,11 +902,14 @@ fn is_bootstrap_fresh_db(conn: &Connection) -> Result<bool, DbError> {
         "assertions",
         "collection_owners",
         "contradictions",
+        "correction_sessions",
         "embedding_jobs",
+        "extraction_queue",
         "file_state",
         "import_manifest",
         "knowledge_gaps",
         "links",
+        "namespaces",
         "page_embeddings",
         "pages",
         "quarantine_exports",

--- a/src/core/reconciler.rs
+++ b/src/core/reconciler.rs
@@ -1078,7 +1078,11 @@ fn fresh_collection_dirty_status(
     collection_id: i64,
     recovery_root: &Path,
 ) -> Result<CollectionDirtyStatus, ReconcileError> {
-    let conn = Connection::open(db_path)?;
+    let conn = crate::core::db::open_runtime(db_path).map_err(|error| {
+        ReconcileError::Other(format!(
+            "fresh_collection_dirty_status: open_runtime failed: {error}"
+        ))
+    })?;
     is_collection_dirty(&conn, collection_id, recovery_root)
 }
 
@@ -3411,6 +3415,9 @@ mod tests {
         let db_path = dir.path().join("memory.db");
         let conn = rusqlite::Connection::open(&db_path).unwrap();
         conn.execute_batch(include_str!("../schema.sql")).unwrap();
+        // Stamp the schema version so fresh connections opened through
+        // `db::open_runtime` accept this fixture as initialized.
+        crate::core::db::set_version(&conn).unwrap();
         (dir, db_path, conn)
     }
 

--- a/src/core/vault_sync/embedding.rs
+++ b/src/core/vault_sync/embedding.rs
@@ -68,7 +68,7 @@ pub(crate) fn resume_orphaned_embedding_jobs(conn: &Connection) -> Result<usize,
 /// failed `run_once` calls so a transient extractor error does not
 /// hot-loop the CPU.
 pub(super) fn run_extraction_worker(db_path: String, stop: Arc<AtomicBool>, session_id: String) {
-    let conn = match Connection::open(&db_path) {
+    let conn = match crate::core::db::open_runtime(&db_path) {
         Ok(conn) => conn,
         Err(error) => {
             eprintln!(

--- a/src/core/vault_sync/error.rs
+++ b/src/core/vault_sync/error.rs
@@ -188,6 +188,11 @@ pub enum VaultSyncError {
     #[error(transparent)]
     Sqlite(#[from] rusqlite::Error),
 
+    /// Surfaces a [`crate::core::types::DbError`] from the connection
+    /// factory (`db::open_runtime`) or default-collection provisioning.
+    #[error(transparent)]
+    Db(#[from] crate::core::types::DbError),
+
     /// Surfaces a `std::io::Error` from a filesystem operation.
     #[error(transparent)]
     Io(#[from] io::Error),

--- a/src/core/vault_sync/ipc/handler.rs
+++ b/src/core/vault_sync/ipc/handler.rs
@@ -30,8 +30,6 @@ use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
-use rusqlite::Connection;
-
 use super::socket::{authorize_server_peer, peer_credentials_for_stream};
 use super::{IpcRequest, IpcResponse};
 use crate::commands::put;
@@ -157,7 +155,7 @@ fn handle_ipc_client(
                 content,
                 expected_version,
             } => {
-                let conn = Connection::open(db_path)?;
+                let conn = crate::core::db::open_runtime(db_path)?;
                 match put::put_from_string_status(&conn, &slug, &content, expected_version) {
                     Ok(status) => {
                         write_ipc_response(&mut writer, &IpcResponse::PutOk { status })?;

--- a/src/core/vault_sync/mod.rs
+++ b/src/core/vault_sync/mod.rs
@@ -72,7 +72,6 @@ use crate::commands::{get::get_page_by_key, put};
 use crate::core::collections::{self, Collection, CollectionState, OpKind, SlugResolution};
 use crate::core::conversation::idle_close;
 use crate::core::conversation::janitor;
-#[cfg(all(test, unix))]
 use crate::core::db;
 #[cfg(unix)]
 use crate::core::file_state;
@@ -389,7 +388,7 @@ impl Drop for ServeRuntime {
         // on its way out, so do it from Drop. Best-effort: a stuck SQLite
         // open here would just leak the row to the next sweep.
         if let Some(path) = self.transport_only_db_path.take() {
-            if let Ok(conn) = Connection::open(&path) {
+            if let Ok(conn) = db::open_runtime(&path) {
                 let _ = unregister_session(&conn, &self.session_id);
             }
         }
@@ -1002,8 +1001,7 @@ pub fn mark_collection_needs_full_sync_via_fresh_connection(
     collection_id: i64,
 ) -> Result<(), VaultSyncError> {
     let db_path = database_path(conn)?;
-    let fresh = Connection::open(db_path)?;
-    fresh.busy_timeout(Duration::from_millis(0))?;
+    let fresh = db::open_runtime(&db_path)?;
     mark_collection_needs_full_sync(&fresh, collection_id)
 }
 
@@ -1986,6 +1984,12 @@ pub fn resolve_slug_for_op(
     input: &str,
     op_kind: OpKind,
 ) -> Result<ResolvedSlug, VaultSyncError> {
+    // Write resolution may fall back to the write-target collection, whose
+    // default root is no longer provisioned at open; heal the empty-root
+    // placeholder on demand before resolving.
+    if !matches!(op_kind, OpKind::Read) {
+        db::provision_default_collection_root(conn)?;
+    }
     match collections::parse_slug(conn, input, op_kind)? {
         SlugResolution::Resolved {
             collection_id,
@@ -2721,7 +2725,7 @@ pub fn run_rcrt_pass(
 /// database without double-spawning the runtime.
 pub fn start_serve_runtime(db_path: String) -> Result<ServeRuntime, VaultSyncError> {
     init_process_registries()?;
-    let conn = Connection::open(&db_path)?;
+    let conn = db::open_runtime(&db_path)?;
     sweep_stale_sessions(&conn)?;
     let session_id = register_session(&conn, SessionType::Serve)?;
 
@@ -2754,7 +2758,7 @@ pub fn start_serve_runtime(db_path: String) -> Result<ServeRuntime, VaultSyncErr
 /// per [`start_serve_runtime`].
 pub fn start_daemon_runtime(db_path: String) -> Result<ServeRuntime, VaultSyncError> {
     init_process_registries()?;
-    let conn = Connection::open(&db_path)?;
+    let conn = db::open_runtime(&db_path)?;
     sweep_stale_sessions(&conn)?;
 
     if let Some(existing) = find_active_daemon_session(&conn)? {
@@ -2894,7 +2898,7 @@ fn run_supervisor_loop(
     let mut last_embedding_drain =
         Instant::now() - Duration::from_secs(embedding::drain_interval_secs());
     while !stop_signal.load(Ordering::SeqCst) {
-        if let Ok(conn) = Connection::open(&db_path) {
+        if let Ok(conn) = db::open_runtime(&db_path) {
             if last_heartbeat.elapsed() >= Duration::from_secs(HEARTBEAT_INTERVAL_SECS) {
                 let _ = sweep_stale_sessions(&conn);
                 let _ = heartbeat_session(&conn, &session_id_for_thread);
@@ -3030,7 +3034,7 @@ fn run_supervisor_loop(
         }
         thread::sleep(Duration::from_millis(DEFERRED_RETRY_SECS * 200));
     }
-    if let Ok(conn) = Connection::open(&db_path) {
+    if let Ok(conn) = db::open_runtime(&db_path) {
         #[cfg(unix)]
         let _ = cleanup_published_ipc_socket(&conn, &session_id_for_thread, &published_ipc.path);
         let _ = clear_supervisor_handles_for_session(&session_id_for_thread);
@@ -3075,7 +3079,7 @@ struct LeaseGuard {
 impl Drop for LeaseGuard {
     fn drop(&mut self) {
         if let Some(db_path) = self.db_path.as_deref() {
-            if let Ok(conn) = Connection::open(db_path) {
+            if let Ok(conn) = db::open_runtime(db_path) {
                 let _ = unregister_session(&conn, &self.session_id);
             }
         }
@@ -3145,7 +3149,7 @@ fn start_short_lived_owner_leases_with_interval(
             if stop_signal.load(Ordering::SeqCst) {
                 break;
             }
-            if let Ok(conn) = Connection::open(&db_path_for_thread) {
+            if let Ok(conn) = db::open_runtime(&db_path_for_thread) {
                 let _ = heartbeat_session(&conn, &session_id_for_thread);
             }
         }

--- a/src/core/vault_sync/watcher.rs
+++ b/src/core/vault_sync/watcher.rs
@@ -54,8 +54,6 @@ use notify::{
     RecommendedWatcher,
 };
 #[cfg(unix)]
-use rusqlite::Connection;
-#[cfg(unix)]
 use tokio::sync::mpsc;
 
 #[cfg(unix)]
@@ -369,7 +367,7 @@ pub(super) fn watch_callback(
             match sender.try_send(action) {
                 Ok(()) => {}
                 Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
-                    if let Ok(conn) = Connection::open(&db_path) {
+                    if let Ok(conn) = crate::core::db::open_runtime(&db_path) {
                         let _ = super::mark_collection_needs_full_sync(&conn, collection_id);
                     }
                     eprintln!(

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -51,6 +51,12 @@ pub(crate) fn resolve_slug_for_mcp(
     input: &str,
     op_kind: OpKind,
 ) -> Result<vault_sync::ResolvedSlug, rmcp::Error> {
+    // Write resolution may fall back to the write-target collection, whose
+    // default root is no longer provisioned at open; heal the empty-root
+    // placeholder on demand before resolving.
+    if !matches!(op_kind, OpKind::Read) {
+        db::provision_default_collection_root(db).map_err(map_config_error)?;
+    }
     match collections::parse_slug(db, input, op_kind).map_err(map_collection_error)? {
         SlugResolution::Resolved {
             collection_id,

--- a/tests/db_connection_hygiene.rs
+++ b/tests/db_connection_hygiene.rs
@@ -1,0 +1,390 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::print_stdout,
+    reason = "test fixtures legitimately panic on setup failure and print diagnostics; per-site #[expect] would generate noise across thousands of test sites"
+)]
+
+//! Integration tests for SQLite connection & transaction hygiene:
+//!
+//! - `db::open_runtime` — the runtime connection factory used by background
+//!   workers, watcher callbacks, supervisor ticks, and IPC handlers. Must
+//!   apply the standard 5s busy timeout (so writes wait out contention
+//!   instead of failing instantly with `SQLITE_BUSY`) and must refuse
+//!   uninitialized databases without creating files.
+//! - `db::with_immediate_transaction` — the shared `BEGIN IMMEDIATE` helper.
+//!   A failed COMMIT must roll back so the shared connection is not wedged
+//!   ("cannot start a transaction within a transaction"), both through the
+//!   helper directly and through the extractor-worker supersede path that
+//!   previously had its own rollback-free copy.
+//! - `db::open` — must perform no filesystem side effects: the default
+//!   collection row is seeded with an empty `root_path` placeholder and the
+//!   on-disk `~/.quaid/vault` root is only provisioned by `quaid init` or
+//!   write-target resolution.
+//! - crash-partial fresh-bootstrap recovery — must refuse to reclaim a
+//!   database with rows in `extraction_queue`, `correction_sessions`, or
+//!   `namespaces`.
+
+mod common;
+#[path = "common/subprocess.rs"]
+mod common_subprocess;
+
+use std::fs;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use quaid::core::conversation::queue;
+use quaid::core::conversation::supersede::{resolve_and_write_fact_in_context, FactWriteContext};
+use quaid::core::db;
+use quaid::core::types::{DbError, ExtractionTriggerKind, RawFact};
+use tempfile::TempDir;
+
+// ── open_runtime ──────────────────────────────────────────────
+
+#[test]
+fn open_runtime_write_waits_for_competing_immediate_transaction() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("memory.db");
+    let path = db_path.to_str().unwrap().to_owned();
+
+    let holder = db::open(&path).unwrap();
+    holder.execute_batch("BEGIN IMMEDIATE TRANSACTION").unwrap();
+    holder
+        .execute("INSERT INTO namespaces (id) VALUES ('holder')", [])
+        .unwrap();
+
+    let (started_tx, started_rx) = std::sync::mpsc::channel::<()>();
+    let writer_path = path;
+    let contender = std::thread::spawn(move || {
+        let conn = db::open_runtime(&writer_path).expect("open_runtime on initialized db");
+        started_tx.send(()).unwrap();
+        let start = Instant::now();
+        let result = conn.execute("INSERT INTO namespaces (id) VALUES ('contender')", []);
+        (result, start.elapsed())
+    });
+
+    // Keep the write lock held well past the contender's first attempt, then
+    // release it. With the default busy_timeout of 0 the contender would fail
+    // instantly; with open_runtime's 5s budget it must wait and succeed.
+    started_rx.recv().unwrap();
+    std::thread::sleep(Duration::from_millis(750));
+    holder.execute_batch("COMMIT TRANSACTION").unwrap();
+
+    let (result, waited) = contender.join().unwrap();
+    result.expect("open_runtime write must wait out the held lock and succeed");
+    assert!(
+        waited >= Duration::from_millis(250),
+        "write should have been blocked by the held IMMEDIATE transaction, waited {waited:?}"
+    );
+    assert!(
+        waited < Duration::from_secs(5),
+        "write must succeed within the 5s busy budget, waited {waited:?}"
+    );
+
+    let count: i64 = holder
+        .query_row("SELECT COUNT(*) FROM namespaces", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(count, 2, "both writers' rows must be present");
+}
+
+#[test]
+fn open_runtime_rejects_missing_database_file() {
+    let dir = TempDir::new().unwrap();
+    let missing = dir.path().join("missing.db");
+
+    let err = db::open_runtime(&missing).expect_err("missing file must be rejected");
+    assert!(
+        matches!(err, DbError::PathNotFound { .. }),
+        "expected DbError::PathNotFound, got: {err:?}"
+    );
+    assert!(
+        !missing.exists(),
+        "open_runtime must not create the database file"
+    );
+}
+
+#[test]
+fn open_runtime_rejects_uninitialized_database() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("foreign.db");
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute_batch("CREATE TABLE t (x INTEGER);").unwrap();
+    }
+
+    let err = db::open_runtime(&db_path).expect_err("uninitialized db must be rejected");
+    assert!(
+        matches!(err, DbError::Schema { .. }),
+        "expected DbError::Schema, got: {err:?}"
+    );
+}
+
+// ── with_immediate_transaction ────────────────────────────────
+
+#[test]
+fn shared_immediate_transaction_helper_recovers_after_aborted_commit() {
+    // Force the next COMMIT to fail by registering a commit_hook that
+    // returns true (aborts the commit, surfacing as a SQLite error).
+    let conn = db::open(":memory:").unwrap();
+    conn.commit_hook(Some(|| true));
+
+    let aborted = db::with_immediate_transaction(&conn, |conn| {
+        conn.execute("INSERT INTO namespaces (id) VALUES ('wedge')", [])?;
+        Ok::<_, rusqlite::Error>(())
+    });
+    assert!(
+        aborted.is_err(),
+        "commit_hook abort must surface as an error"
+    );
+
+    // Clear the hook so the recovery transaction can commit normally. If the
+    // helper failed to roll back after the aborted commit, the next
+    // BEGIN IMMEDIATE would fail with "cannot start a transaction within a
+    // transaction".
+    conn.commit_hook::<fn() -> bool>(None);
+
+    db::with_immediate_transaction(&conn, |conn| {
+        conn.execute("INSERT INTO namespaces (id) VALUES ('recovered')", [])?;
+        Ok::<_, rusqlite::Error>(())
+    })
+    .expect("follow-up transaction must succeed; connection must not be wedged");
+
+    let rows: Vec<String> = conn
+        .prepare("SELECT id FROM namespaces ORDER BY id")
+        .unwrap()
+        .query_map([], |row| row.get(0))
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+    assert_eq!(
+        rows,
+        vec!["recovered".to_owned()],
+        "aborted commit must roll back its insert; recovery insert must land"
+    );
+}
+
+#[test]
+fn fact_write_transaction_recovers_after_aborted_commit() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("memory.db");
+    let conn = db::open(db_path.to_str().unwrap()).unwrap();
+    conn.execute(
+        "UPDATE collections
+         SET root_path = ?1,
+             state = 'active'
+         WHERE id = 1",
+        [dir.path().display().to_string()],
+    )
+    .unwrap();
+
+    let context = FactWriteContext {
+        collection_id: 1,
+        root_path: dir.path().to_path_buf(),
+        namespace: String::new(),
+        session_id: "session-1".to_owned(),
+        source_turns: vec!["1".to_owned()],
+        extracted_at: "2026-06-12T09:00:00Z".to_owned(),
+        extracted_by: "test-extractor".to_owned(),
+    };
+    let fact = RawFact::Preference {
+        about: "programming-language".to_owned(),
+        strength: None,
+        summary: "Prefers Rust".to_owned(),
+    };
+
+    // Abort the COMMIT inside resolve_and_write_fact_in_context's IMMEDIATE
+    // transaction. The supersede module's former private helper propagated
+    // the commit error without rolling back, wedging the shared extraction
+    // worker connection until restart.
+    conn.commit_hook(Some(|| true));
+    let aborted = resolve_and_write_fact_in_context(&fact, &conn, &context);
+    assert!(
+        aborted.is_err(),
+        "aborted commit must surface as an error, got: {aborted:?}"
+    );
+
+    conn.commit_hook::<fn() -> bool>(None);
+
+    // The next operations on the same connection must succeed — no
+    // "cannot start a transaction within a transaction".
+    let written = resolve_and_write_fact_in_context(&fact, &conn, &context)
+        .expect("fact write must succeed after the aborted commit");
+    assert!(
+        written.slug.is_some(),
+        "recovered fact write must allocate a slug"
+    );
+
+    // The extraction queue shares the worker connection in production; its
+    // own IMMEDIATE transaction must also go through.
+    queue::enqueue(
+        &conn,
+        "session-1",
+        "conversations/2026-06-12/session-1.md",
+        ExtractionTriggerKind::Debounce,
+        "2026-06-12T09:00:00Z",
+    )
+    .expect("enqueue must succeed on the shared connection after recovery");
+}
+
+// ── open: no filesystem side effects ──────────────────────────
+
+#[test]
+fn open_seeds_default_collection_with_empty_root_placeholder() {
+    let conn = db::open(":memory:").unwrap();
+
+    let (root_path, writable, is_write_target): (String, i64, i64) = conn
+        .query_row(
+            "SELECT root_path, writable, is_write_target
+             FROM collections
+             WHERE id = 1 AND name = 'default'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap();
+
+    assert_eq!(
+        root_path, "",
+        "open must seed the default collection with an empty root placeholder \
+         instead of provisioning ~/.quaid/vault"
+    );
+    assert_eq!(writable, 1);
+    assert_eq!(is_write_target, 1);
+}
+
+#[test]
+fn in_memory_open_succeeds_when_home_is_not_writable() {
+    // HOME points at a *file*, so any attempt to create `$HOME/.quaid/...`
+    // fails even when the test runs as root (where read-only directory
+    // permissions would not bind). Opening `:memory:` must not touch HOME.
+    let dir = TempDir::new().unwrap();
+    let home_file = dir.path().join("not-a-directory");
+    fs::write(&home_file, "not a directory").unwrap();
+
+    let mut command = Command::new(common::quaid_bin());
+    common_subprocess::configure_test_command(&mut command);
+    let output = command
+        .env("HOME", &home_file)
+        .env("USERPROFILE", &home_file)
+        .args(["--db", ":memory:", "stats"])
+        .output()
+        .expect("run quaid");
+
+    assert!(
+        output.status.success(),
+        "db::open(\":memory:\") must succeed without a writable HOME\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn in_memory_open_creates_no_directories_under_home() {
+    let dir = TempDir::new().unwrap();
+    let home = dir.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&home, fs::Permissions::from_mode(0o555)).unwrap();
+    }
+
+    let mut command = Command::new(common::quaid_bin());
+    common_subprocess::configure_test_command(&mut command);
+    let output = command
+        .env("HOME", &home)
+        .env("USERPROFILE", &home)
+        .args(["--db", ":memory:", "stats"])
+        .output()
+        .expect("run quaid");
+
+    let leftover: Vec<_> = fs::read_dir(&home)
+        .unwrap()
+        .map(|entry| entry.unwrap().file_name())
+        .collect();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&home, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    assert!(
+        output.status.success(),
+        "db::open(\":memory:\") must succeed with a read-only HOME\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        leftover.is_empty(),
+        "open must create no directories under HOME, found: {leftover:?}"
+    );
+}
+
+// ── crash-partial fresh-bootstrap recovery ────────────────────
+
+/// Builds a crash-partial database: fully bootstrapped, then `quaid_config`
+/// emptied (as if the process died between schema DDL and the config write),
+/// with optional activity rows seeded.
+fn crash_partial_db_with(seed_sql: Option<&str>) -> (TempDir, String) {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("memory.db");
+    let path = db_path.to_str().unwrap().to_owned();
+    {
+        let conn = db::open(&path).unwrap();
+        conn.execute("DELETE FROM quaid_config", []).unwrap();
+        if let Some(sql) = seed_sql {
+            conn.execute_batch(sql).unwrap();
+        }
+    }
+    (dir, path)
+}
+
+#[test]
+fn crash_partial_recovery_reclaims_truly_fresh_db() {
+    let (_dir, path) = crash_partial_db_with(None);
+    db::open(&path).expect("fresh-bootstrap recovery must reclaim an activity-free db");
+}
+
+#[test]
+fn crash_partial_recovery_rejects_seeded_extraction_queue() {
+    let (_dir, path) = crash_partial_db_with(Some(
+        "INSERT INTO extraction_queue
+             (session_id, conversation_path, trigger_kind, enqueued_at, scheduled_for, status)
+         VALUES
+             ('s1', 'conversations/2026-06-12/s1.md', 'debounce',
+              '2026-06-12T00:00:00Z', '2026-06-12T00:00:05Z', 'pending');",
+    ));
+
+    let err = db::open(&path).expect_err("queued extraction jobs must block recovery");
+    assert!(
+        matches!(err, DbError::Schema { .. }),
+        "expected DbError::Schema, got: {err:?}"
+    );
+}
+
+#[test]
+fn crash_partial_recovery_rejects_seeded_correction_sessions() {
+    let (_dir, path) = crash_partial_db_with(Some(
+        "INSERT INTO correction_sessions
+             (correction_id, fact_slug, exchange_log)
+         VALUES
+             ('correction-1', 'facts/example', '[]');",
+    ));
+
+    let err = db::open(&path).expect_err("open correction sessions must block recovery");
+    assert!(
+        matches!(err, DbError::Schema { .. }),
+        "expected DbError::Schema, got: {err:?}"
+    );
+}
+
+#[test]
+fn crash_partial_recovery_rejects_seeded_namespaces() {
+    let (_dir, path) = crash_partial_db_with(Some("INSERT INTO namespaces (id) VALUES ('alpha');"));
+
+    let err = db::open(&path).expect_err("registered namespaces must block recovery");
+    assert!(
+        matches!(err, DbError::Schema { .. }),
+        "expected DbError::Schema, got: {err:?}"
+    );
+}

--- a/tests/mcp_server_misc.rs
+++ b/tests/mcp_server_misc.rs
@@ -106,8 +106,11 @@ fn memory_add_turn_returns_conflict_error_for_closed_session() {
 
 #[test]
 fn memory_add_turn_returns_config_error_for_missing_writable_root() {
+    // An empty root_path would be healed on demand by write-target
+    // provisioning, so simulate the unusable write target by marking the
+    // configured collection non-writable instead.
     let (_dir, conn) = open_test_db();
-    conn.execute("UPDATE collections SET root_path = '' WHERE id = 1", [])
+    conn.execute("UPDATE collections SET writable = 0 WHERE id = 1", [])
         .unwrap();
     let server = QuaidServer::new(conn);
 


### PR DESCRIPTION
Implements **Area 7 — SQLite connection & transaction hygiene** of the codebase review (`docs/fable-review.md` on `code-review-2`).

## Why
`db::open` guarantees a 5s busy_timeout, but ~12 daemon hot paths opened raw `Connection::open`s with busy_timeout=0 — so writes failed instantly under any MCP contention, burning extraction retries and stranding jobs for the 300s lease. Worse, `supersede.rs`'s copy of `with_immediate_transaction` lacked the ROLLBACK-on-COMMIT-failure fix its `queue.rs` sibling had, so one busy COMMIT wedged the shared worker connection until restart. And every `db::open` (including `:memory:`) did filesystem writes to `~/.quaid/vault`.

## Changes
- **`db::open_runtime(path)`**: sqlite-vec + 5s busy_timeout + foreign_keys, no DDL/bootstrap/FS effects, `user_version` sanity guard. All 12 raw production open sites routed through it (re-grepped; remaining raw opens are inside pre-existing `#[cfg(test)]` modules). The explicit 0ms override deleted.
- **One `with_immediate_transaction`** hoisted into `core/db.rs`, generic over `E: From<rusqlite::Error>`, with the COMMIT-failure ROLLBACK handling; both per-module copies deleted (the supersede copy was the wedge-prone one).
- **No FS at open**: `ensure_default_collection` seeds `root_path=''` only; new `db::provision_default_collection_root` runs at `quaid init` and every write-target resolution point (CLI write ops, `memory_put`, turn writer) — read paths never provision.
- **Bootstrap-fresh detection** now includes `extraction_queue`, `correction_sessions`, `namespaces` (crash recovery can no longer re-persist over real activity in those tables).

## Validation
fmt/clippy (-D warnings) clean; full `cargo test --lib` 928 passed. New `tests/db_connection_hygiene.rs` 12/12: contention (held BEGIN IMMEDIATE → open_runtime write waits and succeeds), commit-wedge regression on the shared helper **plus the supersede-path variant** (aborted COMMIT → next write succeeds, no "transaction within a transaction"), `:memory:` with HOME at a read-only dir creates nothing, per-table recovery refusal. ~20 targeted integration suites green (list in branch commit).

## Notes
- Watcher-callback connections now wait up to 5s under contention instead of failing at 0ms (spec'd; supervisor tick stays best-effort).
- Five test fixtures that relied on open-time provisioning now configure temp roots (they also stop touching the real `~/.quaid/vault`).
- `drain_embedding_queue` parallel workers already used `db::open` — flagged for Area 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)