### PR TITLE
fix(core): quarantine leaks, YAML fidelity, export keying, budgets, novelty scope, cycle guard (areas 12, 16.1)

### DIFF
--- a/src/commands/ingest.rs
+++ b/src/commands/ingest.rs
@@ -45,9 +45,14 @@ pub fn run(db: &Connection, path: &str, force: bool) -> Result<()> {
             return Ok(());
         }
 
-        // Novelty check: skip near-duplicate content unless --force
+        // Novelty check: skip near-duplicate content unless --force.
+        // Compare only against the page this ingest would overwrite —
+        // collection 1 / global namespace, where ingest writes — never a
+        // same-slug page from another collection (#75).
         if !force {
-            if let Ok(existing_page) = crate::commands::get::get_page(db, &slug) {
+            if let Ok(existing_page) =
+                crate::commands::get::get_page_by_key_with_namespace(db, 1, &slug, Some(""))
+            {
                 match novelty::check_novelty(&compiled_truth, &existing_page, db) {
                     Ok(false) => {
                         eprintln!("Skipping ingest: content not novel (slug: {slug})");

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -100,29 +100,36 @@ pub async fn run(
     Ok(())
 }
 
+/// Trim `results` to at most `limit` entries fitting `token_budget`.
+///
+/// Token accounting mirrors `core::progressive`: one token ≈ four characters
+/// of rendered output (`<slug>: <summary>` per line). Costs and the final
+/// truncation are both measured in characters (not bytes), so multibyte
+/// summaries are budgeted consistently and never split mid-character.
 fn budget_results(
     results: Vec<SearchResult>,
     limit: usize,
     token_budget: usize,
 ) -> Vec<SearchResult> {
-    let mut remaining = token_budget;
+    let mut remaining_chars = token_budget.saturating_mul(4);
     let mut budgeted = Vec::new();
 
     for result in results.into_iter().take(limit) {
-        let line_prefix = format!("{}: ", result.slug);
-        let full_line_len = line_prefix.len() + result.summary.len();
+        // "<slug>: " prefix
+        let prefix_chars = result.slug.chars().count() + 2;
+        let full_line_chars = prefix_chars + result.summary.chars().count();
 
-        if full_line_len <= remaining {
-            remaining = remaining.saturating_sub(full_line_len);
+        if full_line_chars <= remaining_chars {
+            remaining_chars -= full_line_chars;
             budgeted.push(result);
             continue;
         }
 
-        if remaining <= line_prefix.len() {
+        if remaining_chars <= prefix_chars {
             break;
         }
 
-        let summary_budget = remaining - line_prefix.len();
+        let summary_budget = remaining_chars - prefix_chars;
         let mut truncated = result;
         truncated.summary = truncated.summary.chars().take(summary_budget).collect();
         budgeted.push(truncated);
@@ -164,18 +171,32 @@ mod tests {
     #[test]
     fn budget_results_truncates_summary_to_fit_remaining_budget() {
         let results = vec![result("people/alice", "abcdefghijklmnopqrstuvwxyz")];
-        let prefix_len = "people/alice: ".len();
 
-        let budgeted = budget_results(results, 10, prefix_len + 5);
+        // 5 tokens = 20 chars; prefix "people/alice: " = 14 chars → 6 summary chars.
+        let budgeted = budget_results(results, 10, 5);
 
         assert_eq!(budgeted.len(), 1);
-        assert_eq!(budgeted[0].summary, "abcde");
+        assert_eq!(budgeted[0].summary, "abcdef");
+    }
+
+    #[test]
+    fn budget_results_counts_multibyte_summaries_in_chars_not_bytes() {
+        // 100 three-byte chars: a byte-based budget would overcount this
+        // summary threefold and a byte-based truncation could split a char.
+        let results = vec![result("people/alice", &"あ".repeat(100))];
+
+        // 10 tokens = 40 chars; prefix = 14 chars → 26 summary chars.
+        let budgeted = budget_results(results, 10, 10);
+
+        assert_eq!(budgeted.len(), 1);
+        assert_eq!(budgeted[0].summary.chars().count(), 26);
+        assert!(budgeted[0].summary.chars().all(|ch| ch == 'あ'));
     }
 
     #[test]
     fn budget_results_zero_budget_breaks_immediately() {
         let results = vec![result("people/alice", "anything")];
-        // prefix len ("people/alice: ") = 14, budget = 0 → 0 <= 14 → break
+        // prefix chars ("people/alice: ") = 14, budget = 0 → 0 <= 14 → break
         let budgeted = budget_results(results, 10, 0);
         assert!(budgeted.is_empty());
     }

--- a/src/core/markdown.rs
+++ b/src/core/markdown.rs
@@ -39,7 +39,12 @@ pub fn parse_frontmatter(raw: &str) -> (Frontmatter, String) {
     };
 
     let yaml_str = &raw[frontmatter_start..frontmatter_end];
-    let map = parse_yaml_to_map(yaml_str);
+    let Ok(map) = parse_yaml_to_map(yaml_str) else {
+        // Unparseable YAML: treat the whole input as body so the raw
+        // frontmatter block survives verbatim instead of being silently
+        // dropped on the next render.
+        return (Frontmatter::new(), raw.to_string());
+    };
     let body = &raw[body_start.unwrap_or(raw.len())..];
     (map, body.to_string())
 }
@@ -160,6 +165,13 @@ pub fn render_page(page: &Page) -> String {
         for key in keys {
             if let Some(value) = rendered_frontmatter.get(key) {
                 out.push_str(key);
+                if let JsonValue::String(scalar) = value {
+                    match yaml_scalar(scalar) {
+                        Some(rendered) => push_scalar_value(&mut out, &rendered),
+                        None => out.push_str(": null\n"),
+                    }
+                    continue;
+                }
                 match render_yaml_value(value) {
                     Some(rendered) => {
                         let force_block =
@@ -216,23 +228,23 @@ fn next_line(s: &str, start: usize) -> (&str, usize) {
 
 /// Parse a YAML string into frontmatter values.
 ///
-/// Non-string keys are silently skipped. Returns an empty map on any parse failure.
-fn parse_yaml_to_map(yaml_str: &str) -> Frontmatter {
+/// Non-string keys are silently skipped. Returns `Err` on any parse failure
+/// so callers can preserve the raw block instead of dropping it.
+fn parse_yaml_to_map(yaml_str: &str) -> Result<Frontmatter, serde_yaml::Error> {
     if yaml_str.trim().is_empty() {
-        return Frontmatter::new();
+        return Ok(Frontmatter::new());
     }
 
-    let Ok(map) = serde_yaml::from_str::<serde_yaml::Mapping>(yaml_str) else {
-        return Frontmatter::new();
-    };
+    let map = serde_yaml::from_str::<serde_yaml::Mapping>(yaml_str)?;
 
-    map.into_iter()
+    Ok(map
+        .into_iter()
         .filter_map(|(k, v)| {
             let key = k.as_str()?.to_string();
             let value = serde_json::to_value(v).ok()?;
             Some((key, value))
         })
-        .collect()
+        .collect())
 }
 
 fn render_yaml_value(value: &JsonValue) -> Option<String> {
@@ -240,7 +252,9 @@ fn render_yaml_value(value: &JsonValue) -> Option<String> {
         JsonValue::Null => Some("null".to_string()),
         JsonValue::Bool(value) => Some(value.to_string()),
         JsonValue::Number(value) => Some(value.to_string()),
-        JsonValue::String(value) => Some(yaml_scalar(value)),
+        // Strings are handled by `yaml_scalar` + `push_scalar_value` in
+        // `render_page`; this fallback keeps the function total.
+        JsonValue::String(value) => yaml_scalar(value).map(|s| s.trim_end_matches('\n').to_owned()),
         JsonValue::Array(_) | JsonValue::Object(_) => {
             let rendered = serde_yaml::to_string(value).ok()?;
             Some(strip_yaml_document(&rendered))
@@ -256,23 +270,39 @@ fn strip_yaml_document(rendered: &str) -> String {
         .to_string()
 }
 
-fn yaml_scalar(value: &str) -> String {
-    if value.is_empty()
-        || value == "null"
-        || value.starts_with(' ')
-        || value.ends_with(' ')
-        || value.contains(':')
-        || value.contains('#')
-        || value.contains('[')
-        || value.contains(']')
-        || value.contains('{')
-        || value.contains('}')
-        || value.contains('"')
-        || value.contains('\'')
-    {
-        format!("'{}'", value.replace('\'', "''"))
-    } else {
-        value.to_string()
+/// Serialize a string scalar with serde_yaml so quoting decisions match the
+/// parser exactly: scalars that would re-resolve to another YAML type
+/// (`"true"`, `"007"`, `"2024"`) are quoted, scalars that would break the
+/// document (`"- item"`) are quoted, and multiline strings come back as
+/// block scalars. The returned string keeps serde_yaml's own layout,
+/// including the trailing newline and block-scalar content indentation.
+fn yaml_scalar(value: &str) -> Option<String> {
+    let rendered = serde_yaml::to_string(value).ok()?;
+    Some(
+        rendered
+            .strip_prefix("---\n")
+            .unwrap_or(&rendered)
+            .to_string(),
+    )
+}
+
+/// Append a serde_yaml-rendered scalar after `<key>`, preserving the
+/// emitter's layout byte-for-byte. Single-line scalars become
+/// `key: <scalar>\n`; block scalars keep their header on the key line
+/// (`key: |-`) with the content lines — already indented two spaces by
+/// serde_yaml — emitted verbatim so chomping-indicator newlines survive.
+fn push_scalar_value(out: &mut String, rendered: &str) {
+    out.push_str(": ");
+    match rendered.split_once('\n') {
+        Some((first, rest)) => {
+            out.push_str(first);
+            out.push('\n');
+            out.push_str(rest);
+        }
+        None => {
+            out.push_str(rendered);
+            out.push('\n');
+        }
     }
 }
 

--- a/src/core/migrate.rs
+++ b/src/core/migrate.rs
@@ -1,20 +1,60 @@
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use rusqlite::Connection;
 
 use crate::core::markdown;
-use crate::core::page_uuid;
 use crate::core::types::Frontmatter;
 
-/// Export all pages as markdown files to the given output directory.
-pub fn export_dir(db: &Connection, output_path: &Path) -> Result<usize> {
-    let pages = all_pages(db)?;
+/// One exported page together with the collection/namespace key that
+/// disambiguates same-slug pages across collections and namespaces.
+struct ExportEntry {
+    collection: String,
+    namespace: String,
+    page: crate::core::types::Page,
+}
 
-    for page in &pages {
-        let rendered = markdown::render_page(page);
-        let file_path = output_path.join(format!("{}.md", page.slug));
+/// Relative export path for a page.
+///
+/// When `flat` is set (single collection, no namespaces) the legacy
+/// `<slug>.md` layout is preserved for compatibility with existing
+/// re-ingest scripts; otherwise pages are keyed as
+/// `<collection>/<namespace?>/<slug>.md`.
+fn export_relative_path(flat: bool, entry: &ExportEntry) -> PathBuf {
+    if flat {
+        return PathBuf::from(format!("{}.md", entry.page.slug));
+    }
+    let mut path = PathBuf::from(&entry.collection);
+    if !entry.namespace.is_empty() {
+        path.push(&entry.namespace);
+    }
+    path.push(format!("{}.md", entry.page.slug));
+    path
+}
+
+/// Whether the export set can use the legacy flat `<slug>.md` layout:
+/// every page lives in the same collection and the global namespace, so
+/// slugs alone are collision-free.
+fn flat_layout(entries: &[ExportEntry]) -> bool {
+    entries
+        .iter()
+        .all(|entry| entry.namespace.is_empty() && entry.collection == entries[0].collection)
+}
+
+/// Export all pages as markdown files to the given output directory.
+///
+/// Pages are keyed by `(collection, namespace, slug)`; the flat `<slug>.md`
+/// layout is kept when only a single collection with no namespaces exists.
+/// Pages without a persisted UUID are skipped with a warning instead of
+/// aborting the whole export.
+pub fn export_dir(db: &Connection, output_path: &Path) -> Result<usize> {
+    let entries = all_pages(db)?;
+    let flat = flat_layout(&entries);
+
+    for entry in &entries {
+        let rendered = markdown::render_page(&entry.page);
+        let file_path = output_path.join(export_relative_path(flat, entry));
 
         if let Some(parent) = file_path.parent() {
             fs::create_dir_all(parent)?;
@@ -22,18 +62,20 @@ pub fn export_dir(db: &Connection, output_path: &Path) -> Result<usize> {
         fs::write(&file_path, &rendered)?;
     }
 
-    Ok(pages.len())
+    Ok(entries.len())
 }
 
 /// Validate round-trip fidelity: export then re-parse and compare.
 /// Used only in tests.
 #[cfg(test)]
 fn validate_roundtrip(db: &Connection, output_path: &Path) -> Result<()> {
-    let pages = all_pages(db)?;
+    let entries = all_pages(db)?;
+    let flat = flat_layout(&entries);
 
-    for page in &pages {
+    for entry in &entries {
+        let page = &entry.page;
         let rendered = markdown::render_page(page);
-        let file_path = output_path.join(format!("{}.md", page.slug));
+        let file_path = output_path.join(export_relative_path(flat, entry));
 
         if let Some(parent) = file_path.parent() {
             fs::create_dir_all(parent)?;
@@ -69,12 +111,15 @@ fn validate_roundtrip(db: &Connection, output_path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn all_pages(db: &Connection) -> Result<Vec<crate::core::types::Page>> {
+fn all_pages(db: &Connection) -> Result<Vec<ExportEntry>> {
     let mut stmt = db.prepare(
-        "SELECT slug, type, title, summary, compiled_truth, timeline, \
-                uuid, frontmatter, wing, room, superseded_by, version, created_at, updated_at, \
-                truth_updated_at, timeline_updated_at, id \
-         FROM pages ORDER BY slug",
+        "SELECT p.slug, p.type, p.title, p.summary, p.compiled_truth, p.timeline, \
+                p.uuid, p.frontmatter, p.wing, p.room, p.superseded_by, p.version, \
+                p.created_at, p.updated_at, \
+                p.truth_updated_at, p.timeline_updated_at, p.id, c.name, p.namespace \
+         FROM pages p \
+         JOIN collections c ON c.id = p.collection_id \
+         ORDER BY c.name, p.namespace, p.slug",
     )?;
 
     let rows = stmt.query_map([], |row| {
@@ -83,15 +128,12 @@ fn all_pages(db: &Connection) -> Result<Vec<crate::core::types::Page>> {
 
         Ok((
             row.get::<_, i64>(16)?,
+            row.get::<_, String>(17)?,
+            row.get::<_, String>(18)?,
+            row.get::<_, Option<String>>(6)?,
             crate::core::types::Page {
                 slug: row.get(0)?,
-                uuid: row.get::<_, Option<String>>(6)?.ok_or_else(|| {
-                    rusqlite::Error::FromSqlConversionFailure(
-                        6,
-                        rusqlite::types::Type::Null,
-                        Box::new(page_uuid::PageUuidError::EmptyFrontmatterUuid),
-                    )
-                })?,
+                uuid: String::new(),
                 page_type: row.get(1)?,
                 superseded_by: row.get(10)?,
                 title: row.get(2)?,
@@ -110,9 +152,19 @@ fn all_pages(db: &Connection) -> Result<Vec<crate::core::types::Page>> {
         ))
     })?;
 
-    let mut pages = Vec::new();
+    let mut entries = Vec::new();
     for row in rows {
-        let (page_id, mut page) = row?;
+        let (page_id, collection, namespace, uuid, mut page) = row?;
+        // Skip-and-warn instead of aborting the entire export: a single
+        // legacy row without a UUID must not block exporting everything else.
+        let Some(uuid) = uuid else {
+            eprintln!(
+                "Warning: skipping export of page '{}::{}' (id {page_id}): missing uuid",
+                collection, page.slug
+            );
+            continue;
+        };
+        page.uuid = uuid;
         if !page.frontmatter.contains_key("supersedes") {
             if let Ok(predecessor_slug) = db.query_row(
                 "SELECT slug FROM pages WHERE superseded_by = ?1 LIMIT 1",
@@ -125,9 +177,13 @@ fn all_pages(db: &Connection) -> Result<Vec<crate::core::types::Page>> {
                 );
             }
         }
-        pages.push(page);
+        entries.push(ExportEntry {
+            collection,
+            namespace,
+            page,
+        });
     }
-    Ok(pages)
+    Ok(entries)
 }
 
 #[cfg(test)]

--- a/src/core/novelty.rs
+++ b/src/core/novelty.rs
@@ -3,10 +3,6 @@
 //! Phase 1 treats novelty as a conservative duplicate filter:
 //! - lexical overlap is measured with lowercased whitespace-token Jaccard
 //! - stored embeddings are consulted when present for a near-duplicate check
-//!
-//! The current embedding backend is a deterministic SHA-256 placeholder, not a
-//! semantic model, so tests intentionally only lock down duplicate-vs-different
-//! behavior and avoid paraphrase expectations.
 
 use std::collections::HashSet;
 
@@ -48,17 +44,20 @@ pub fn check_novelty(
     })?;
     let query_blob = embedding_to_blob(&query_embedding);
 
+    // Scope strictly to the page being compared against (by its unique
+    // UUID), not to every same-slug page across all collections — a slug
+    // can exist independently in several collections (#75).
     let sql = format!(
         "SELECT MAX(1.0 - vec_distance_cosine(pev.embedding, ?1)) \
          FROM {vec_table} pev \
          JOIN page_embeddings pe ON pev.rowid = pe.vec_rowid \
          JOIN pages p ON p.id = pe.page_id \
-         WHERE pe.model = ?2 AND p.slug = ?3"
+         WHERE pe.model = ?2 AND p.uuid = ?3"
     );
 
     let max_similarity = conn.query_row(
         &sql,
-        params![query_blob, model_name, existing_page.slug.as_str()],
+        params![query_blob, model_name, existing_page.uuid.as_str()],
         |row| row.get::<_, Option<f64>>(0),
     )?;
 

--- a/src/core/progressive.rs
+++ b/src/core/progressive.rs
@@ -11,7 +11,7 @@ const MAX_DEPTH: u32 = 3;
 /// Expand an initial result set by following outbound links until the token
 /// budget is exhausted or the depth cap is reached.
 ///
-/// Token count is approximated as `len(compiled_truth) / 4`.
+/// Token count is approximated as `(len(compiled_truth) + len(timeline)) / 4`.
 /// Results are deduplicated by slug. Initial results appear first, followed
 /// by expansion results ordered by link distance.
 ///
@@ -64,11 +64,16 @@ pub fn progressive_retrieve_with_namespace(
     let mut results: Vec<SearchResult> = Vec::new();
     let mut tokens_used: usize = 0;
 
-    // Consume initial results, tracking budget
+    // Consume initial results, tracking budget. Entries that do not fit are
+    // skipped (not `break`) so one oversized page cannot starve later
+    // results — the same policy the expansion loop below applies. Entries
+    // whose slug cannot be costed are skipped rather than riding for free.
     for r in &initial {
-        let cost = token_cost(&r.slug, conn);
+        let Some(cost) = token_cost(&r.slug, conn) else {
+            continue;
+        };
         if tokens_used + cost > budget {
-            break;
+            continue;
         }
         seen.insert(r.slug.clone());
         tokens_used += cost;
@@ -98,7 +103,9 @@ pub fn progressive_retrieve_with_namespace(
                     continue;
                 }
 
-                let cost = token_cost(&neighbour.slug, conn);
+                let Some(cost) = token_cost(&neighbour.slug, conn) else {
+                    continue;
+                };
                 if tokens_used + cost > budget {
                     continue;
                 }
@@ -115,19 +122,21 @@ pub fn progressive_retrieve_with_namespace(
     Ok(results)
 }
 
-/// Approximate token cost of a page: `len(compiled_truth) / 4`.
-fn token_cost(slug: &str, conn: &Connection) -> usize {
-    let Some((collection_id, resolved_slug)) = resolve_slug_key(conn, slug) else {
-        return 0;
-    };
+/// Approximate token cost of a page: `(len(compiled_truth) + len(timeline)) / 4`.
+///
+/// Returns `None` when the slug cannot be resolved or the page row is
+/// missing, so callers can skip the entry instead of treating it as free.
+fn token_cost(slug: &str, conn: &Connection) -> Option<usize> {
+    let (collection_id, resolved_slug) = resolve_slug_key(conn, slug)?;
 
     conn.query_row(
-        "SELECT LENGTH(compiled_truth) FROM pages WHERE collection_id = ?1 AND slug = ?2",
+        "SELECT LENGTH(compiled_truth) + LENGTH(timeline) \
+         FROM pages WHERE collection_id = ?1 AND slug = ?2",
         rusqlite::params![collection_id, resolved_slug],
         |row| row.get::<_, i64>(0),
     )
+    .ok()
     .map(|len| (len as usize) / 4)
-    .unwrap_or(0)
 }
 
 fn page_is_head(slug: &str, conn: &Connection) -> bool {
@@ -148,6 +157,10 @@ fn page_is_head(slug: &str, conn: &Connection) -> bool {
 /// When `collection_filter` is `Some(id)`, only target pages belonging to that
 /// collection are returned, enforcing the MCP read-filter contract during
 /// `depth="auto"` expansion.
+///
+/// Quarantined targets are always excluded — retrieval never surfaces
+/// quarantined pages; they remain reachable only via explicit access paths
+/// such as `memory_get` and raw imports.
 fn outbound_neighbours(
     slug: &str,
     collection_filter: Option<i64>,
@@ -176,6 +189,7 @@ fn outbound_neighbours(
          JOIN pages p1 ON l.from_page_id = p1.id \
          JOIN pages p2 ON l.to_page_id = p2.id{collection_join} \
          WHERE p1.collection_id = ?1 AND p1.slug = ?2 \
+           AND p2.quarantined_at IS NULL \
            AND (l.valid_from IS NULL OR l.valid_from <= date('now')) \
            AND (l.valid_until IS NULL OR l.valid_until >= date('now')) \
            AND (?3 IS NULL OR p2.collection_id = ?3) \

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -48,6 +48,9 @@ use super::types::{SearchError, SearchMergeStrategy, SearchResult};
 ///   the `foo` namespace and the global `""` namespace.
 /// - `include_superseded`: when `false`, hides pages with non-NULL
 ///   `superseded_by`.
+/// - `include_quarantined`: when `false`, hides pages with non-NULL
+///   `quarantined_at`. Quarantined pages must be fetched explicitly (e.g.
+///   `memory_get`/raw access), never surfaced by retrieval.
 /// - `canonical`: when `true`, results return slugs in
 ///   `<collection>::<slug>` form.
 /// - `limit`: maximum number of rows to return after merge.
@@ -63,6 +66,8 @@ pub struct HybridSearch<'a> {
     pub namespace: Option<&'a str>,
     /// When `false`, hides pages whose `superseded_by` is non-NULL.
     pub include_superseded: bool,
+    /// When `false`, hides pages whose `quarantined_at` is non-NULL.
+    pub include_quarantined: bool,
     /// When `true`, results return slugs in `<collection>::<slug>` form.
     pub canonical: bool,
     /// Maximum number of rows to return after the merge step.
@@ -94,6 +99,7 @@ pub fn hybrid_search(
             q.collection,
             q.namespace,
             q.include_superseded,
+            q.include_quarantined,
             conn,
             q.canonical,
         )? {
@@ -311,6 +317,7 @@ pub fn expand_graph(
          JOIN pages p2 ON l.to_page_id = p2.id{collection_join} \
          WHERE p1.collection_id = ?1 AND p1.slug = ?2 \
            AND p2.superseded_by IS NULL \
+           AND p2.quarantined_at IS NULL \
            AND (l.valid_from IS NULL OR l.valid_from <= date('now')) \
            AND (l.valid_until IS NULL OR l.valid_until >= date('now'))\
            {collection_clause}"
@@ -456,17 +463,23 @@ fn exact_slug_result(
         collection_filter,
         None,
         include_superseded,
+        false,
         conn,
         canonical_slug,
     )
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "internal exact-slug helper threads the full HybridSearch filter set; a struct here would duplicate HybridSearch"
+)]
 fn exact_slug_result_with_namespace(
     slug: &str,
     wing: Option<&str>,
     collection_filter: Option<i64>,
     namespace_filter: Option<&str>,
     include_superseded: bool,
+    include_quarantined: bool,
     conn: &Connection,
     canonical_slug: bool,
 ) -> Result<Option<SearchResult>, SearchError> {
@@ -477,6 +490,7 @@ fn exact_slug_result_with_namespace(
             collection_filter,
             namespace_filter,
             include_superseded,
+            include_quarantined,
             conn,
         );
     }
@@ -508,6 +522,9 @@ fn exact_slug_result_with_namespace(
     }
     if !include_superseded {
         query.push_str(" AND superseded_by IS NULL");
+    }
+    if !include_quarantined {
+        query.push_str(" AND quarantined_at IS NULL");
     }
     if let Some(namespace) = namespace_filter.filter(|namespace| !namespace.is_empty()) {
         query.push_str(" ORDER BY CASE WHEN namespace = ?");
@@ -549,6 +566,7 @@ fn exact_slug_result_canonical(
         collection_filter,
         None,
         include_superseded,
+        false,
         conn,
     )
 }
@@ -559,6 +577,7 @@ fn exact_slug_result_canonical_with_namespace(
     collection_filter: Option<i64>,
     namespace_filter: Option<&str>,
     include_superseded: bool,
+    include_quarantined: bool,
     conn: &Connection,
 ) -> Result<Option<SearchResult>, SearchError> {
     if let Some(collection_id) = collection_filter {
@@ -568,6 +587,7 @@ fn exact_slug_result_canonical_with_namespace(
             collection_id,
             namespace_filter,
             include_superseded,
+            include_quarantined,
             conn,
         );
     }
@@ -601,6 +621,7 @@ fn exact_slug_result_canonical_with_namespace(
         resolved.0,
         namespace_filter,
         include_superseded,
+        include_quarantined,
         conn,
     );
 
@@ -625,6 +646,7 @@ fn exact_slug_result_canonical_for_collection(
         collection_id,
         None,
         include_superseded,
+        false,
         conn,
     )
 }
@@ -635,6 +657,7 @@ fn exact_slug_result_canonical_for_collection_with_namespace(
     collection_id: i64,
     namespace_filter: Option<&str>,
     include_superseded: bool,
+    include_quarantined: bool,
     conn: &Connection,
 ) -> Result<Option<SearchResult>, SearchError> {
     let stripped_slug = if let Some((collection_name, relative_slug)) = slug.split_once("::") {
@@ -654,6 +677,7 @@ fn exact_slug_result_canonical_for_collection_with_namespace(
         collection_id,
         namespace_filter,
         include_superseded,
+        include_quarantined,
         conn,
     );
 
@@ -670,6 +694,7 @@ fn query_exact_slug_canonical(
     collection_id: i64,
     namespace_filter: Option<&str>,
     include_superseded: bool,
+    include_quarantined: bool,
     conn: &Connection,
 ) -> Result<SearchResult, rusqlite::Error> {
     let mut query = String::from(
@@ -700,6 +725,9 @@ fn query_exact_slug_canonical(
     }
     if !include_superseded {
         query.push_str(" AND p.superseded_by IS NULL");
+    }
+    if !include_quarantined {
+        query.push_str(" AND p.quarantined_at IS NULL");
     }
     if let Some(namespace) = namespace_filter.filter(|namespace| !namespace.is_empty()) {
         query.push_str(" ORDER BY CASE WHEN p.namespace = ?");

--- a/src/core/supersede.rs
+++ b/src/core/supersede.rs
@@ -46,6 +46,17 @@ pub enum SupersedeError {
         slug: String,
     },
 
+    /// The writing page is itself already superseded — establishing a new
+    /// supersede pointer from a non-head page would create a chain cycle
+    /// invisible to head-only retrieval.
+    #[error("SupersedeConflictError: page `{slug}` is already superseded by `{successor_slug}` and cannot supersede another page")]
+    NonHeadWriter {
+        /// Slug of the non-head page that attempted the supersede.
+        slug: String,
+        /// Slug of the successor that already supersedes the writing page.
+        successor_slug: String,
+    },
+
     /// Target lives in a different collection from the new revision.
     #[error("SupersedeConflictError: supersede target `{slug}` must stay in the same collection")]
     CrossCollection {
@@ -221,6 +232,32 @@ fn ensure_target_is_valid(
                 slug: target.canonical_slug.clone(),
                 successor_slug: canonical_slug_by_page_id(conn, successor_id)?,
             });
+        }
+    }
+
+    // Cycle guard: a page that is itself superseded may not establish a NEW
+    // supersede pointer — writing chain-tail A with `supersedes: B` would
+    // produce a headless A<->B cycle invisible to head-only retrieval
+    // (mirrors the non-head writer rejection in conversation/file_edit.rs).
+    // Re-asserting an existing predecessor link (the target already points
+    // at the writer, i.e. `current_successor == current_page_id`) stays
+    // allowed so idempotent re-ingest of exported chains keeps working.
+    if let Some(page_id) = current_page_id {
+        if current_successor != Some(page_id) {
+            let writer_successor: Option<i64> = conn
+                .query_row(
+                    "SELECT superseded_by FROM pages WHERE id = ?1",
+                    [page_id],
+                    |row| row.get(0),
+                )
+                .optional()?
+                .flatten();
+            if let Some(successor_id) = writer_successor {
+                return Err(SupersedeError::NonHeadWriter {
+                    slug: page_slug.to_owned(),
+                    successor_slug: canonical_slug_by_page_id(conn, successor_id)?,
+                });
+            }
         }
     }
 

--- a/src/mcp/tools/search.rs
+++ b/src/mcp/tools/search.rs
@@ -49,6 +49,7 @@ impl QuaidServer {
                 collection: collection_filter.as_ref().map(|collection| collection.id),
                 namespace: namespace_filter,
                 include_superseded,
+                include_quarantined: false,
                 canonical: true,
                 limit,
                 hops: None,

--- a/tests/export_collections.rs
+++ b/tests/export_collections.rs
@@ -1,0 +1,169 @@
+//! Export keying regressions: `export_dir` used to be collection/namespace
+//! blind (same-slug pages overwrote each other) and aborted the entire
+//! export when a single row had a NULL uuid. Exports are now keyed by
+//! `(collection, namespace, slug)` while the flat `<slug>.md` layout is
+//! preserved for the common single-collection vault.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::print_stdout,
+    reason = "test fixtures legitimately panic on setup failure and print diagnostics; per-site #[expect] would generate noise across thousands of test sites"
+)]
+
+use quaid::core::db;
+use quaid::core::migrate::export_dir;
+use rusqlite::Connection;
+
+fn open_test_db() -> Connection {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("memory.db");
+    let conn = db::open(db_path.to_str().unwrap()).unwrap();
+    std::mem::forget(dir);
+    conn
+}
+
+fn insert_collection(conn: &Connection, name: &str) -> i64 {
+    conn.execute(
+        "INSERT INTO collections (name, root_path, state, writable, is_write_target)
+         VALUES (?1, ?2, 'active', 1, 0)",
+        rusqlite::params![name, format!("/{name}")],
+    )
+    .unwrap();
+    conn.last_insert_rowid()
+}
+
+fn insert_page(
+    conn: &Connection,
+    collection_id: i64,
+    namespace: &str,
+    slug: &str,
+    uuid: Option<&str>,
+    truth: &str,
+) {
+    conn.execute(
+        "INSERT INTO pages (collection_id, namespace, slug, uuid, type, title, summary, \
+                            compiled_truth, timeline, frontmatter, wing, room, version) \
+         VALUES (?1, ?2, ?3, ?4, 'concept', ?3, '', ?5, '', '{}', 'notes', '', 1)",
+        rusqlite::params![collection_id, namespace, slug, uuid, truth],
+    )
+    .unwrap();
+}
+
+#[test]
+fn export_keys_same_slug_pages_by_collection_and_skips_null_uuid_rows() {
+    let conn = open_test_db();
+    let work_id = insert_collection(&conn, "work");
+    insert_page(
+        &conn,
+        1,
+        "",
+        "people/alice",
+        Some("01969f11-9448-7d79-8d3f-c68f54761234"),
+        "Alice in the default collection.",
+    );
+    insert_page(
+        &conn,
+        work_id,
+        "",
+        "people/alice",
+        Some("01969f11-9448-7d79-8d3f-c68f54761235"),
+        "Alice in the work collection.",
+    );
+    insert_page(&conn, 1, "", "people/legacy", None, "Row without a uuid.");
+
+    let out = tempfile::TempDir::new().unwrap();
+    let count = export_dir(&conn, out.path()).unwrap();
+
+    assert_eq!(count, 2, "two exportable pages, one NULL-uuid row skipped");
+
+    let default_file = out.path().join("default/people/alice.md");
+    let work_file = out.path().join("work/people/alice.md");
+    assert!(
+        default_file.exists() && work_file.exists(),
+        "same-slug pages must export to per-collection paths"
+    );
+    assert!(
+        !out.path().join("people/alice.md").exists(),
+        "flat layout must not be used when several collections exist"
+    );
+    assert!(
+        std::fs::read_to_string(&default_file)
+            .unwrap()
+            .contains("Alice in the default collection."),
+        "default-collection content must not be overwritten by the work page"
+    );
+    assert!(std::fs::read_to_string(&work_file)
+        .unwrap()
+        .contains("Alice in the work collection."));
+    assert!(
+        !out.path().join("default/people/legacy.md").exists(),
+        "NULL-uuid rows are skipped, not exported"
+    );
+}
+
+#[test]
+fn export_preserves_flat_layout_for_single_collection_without_namespaces() {
+    let conn = open_test_db();
+    insert_page(
+        &conn,
+        1,
+        "",
+        "people/alice",
+        Some("01969f11-9448-7d79-8d3f-c68f54761234"),
+        "Alice content.",
+    );
+    insert_page(
+        &conn,
+        1,
+        "",
+        "notes/today",
+        Some("01969f11-9448-7d79-8d3f-c68f54761235"),
+        "Today content.",
+    );
+
+    let out = tempfile::TempDir::new().unwrap();
+    let count = export_dir(&conn, out.path()).unwrap();
+
+    assert_eq!(count, 2);
+    assert!(
+        out.path().join("people/alice.md").exists() && out.path().join("notes/today.md").exists(),
+        "single default collection keeps the legacy flat <slug>.md layout"
+    );
+    assert!(!out.path().join("default").exists());
+}
+
+#[test]
+fn export_keys_same_slug_pages_by_namespace() {
+    let conn = open_test_db();
+    insert_page(
+        &conn,
+        1,
+        "",
+        "people/alice",
+        Some("01969f11-9448-7d79-8d3f-c68f54761234"),
+        "Global-namespace Alice.",
+    );
+    insert_page(
+        &conn,
+        1,
+        "agent-a",
+        "people/alice",
+        Some("01969f11-9448-7d79-8d3f-c68f54761235"),
+        "Namespaced Alice.",
+    );
+
+    let out = tempfile::TempDir::new().unwrap();
+    let count = export_dir(&conn, out.path()).unwrap();
+
+    assert_eq!(count, 2);
+    assert!(
+        out.path().join("default/people/alice.md").exists(),
+        "global-namespace page exports under the collection directory"
+    );
+    assert!(
+        out.path().join("default/agent-a/people/alice.md").exists(),
+        "namespaced page exports under <collection>/<namespace>/"
+    );
+}

--- a/tests/ingest_novelty_scope.rs
+++ b/tests/ingest_novelty_scope.rs
@@ -1,0 +1,113 @@
+//! Novelty-scope regression (#75): the ingest novelty check used to compare
+//! the incoming content against a same-slug page from ANY collection, so an
+//! ingest into the default collection was silently dropped whenever another
+//! collection already held identical content under the same slug.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::print_stdout,
+    reason = "test fixtures legitimately panic on setup failure and print diagnostics; per-site #[expect] would generate noise across thousands of test sites"
+)]
+
+use quaid::commands::ingest;
+use quaid::core::db;
+use rusqlite::Connection;
+
+fn open_test_db() -> (tempfile::TempDir, Connection) {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("memory.db");
+    let conn = db::open(db_path.to_str().unwrap()).unwrap();
+    (dir, conn)
+}
+
+#[test]
+fn ingest_is_not_skipped_by_same_slug_page_in_another_collection() {
+    let (dir, conn) = open_test_db();
+
+    conn.execute(
+        "INSERT INTO collections (name, root_path, state, writable, is_write_target)
+         VALUES ('work', '/work', 'active', 1, 0)",
+        [],
+    )
+    .unwrap();
+    let work_id = conn.last_insert_rowid();
+
+    let body = "Alice works at Acme and invests in climate software.";
+    conn.execute(
+        "INSERT INTO pages (collection_id, namespace, slug, uuid, type, title, summary, \
+                            compiled_truth, timeline, frontmatter, wing, room, version) \
+         VALUES (?1, '', 'notes/shared', '01969f11-9448-7d79-8d3f-c68f54761234', 'concept', \
+                 'Shared', '', ?2, '', '{}', 'notes', '', 1)",
+        rusqlite::params![work_id, body],
+    )
+    .unwrap();
+
+    let file_path = dir.path().join("shared.md");
+    std::fs::write(
+        &file_path,
+        format!("---\nslug: notes/shared\ntitle: Shared\ntype: concept\n---\n{body}\n"),
+    )
+    .unwrap();
+
+    ingest::run(&conn, file_path.to_str().unwrap(), false).unwrap();
+
+    let default_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM pages WHERE collection_id = 1 AND slug = 'notes/shared'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        default_count, 1,
+        "identical content in another collection must not suppress the ingest (#75)"
+    );
+
+    let work_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM pages WHERE collection_id = ?1 AND slug = 'notes/shared'",
+            [work_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(work_count, 1, "the other collection's page is untouched");
+}
+
+#[test]
+fn ingest_still_skips_near_duplicates_within_its_own_collection() {
+    let (dir, conn) = open_test_db();
+
+    let body = "Alice works at Acme and invests in climate software.";
+    let first = dir.path().join("first.md");
+    std::fs::write(
+        &first,
+        format!("---\nslug: notes/shared\ntitle: Shared\ntype: concept\n---\n{body}\n"),
+    )
+    .unwrap();
+    ingest::run(&conn, first.to_str().unwrap(), false).unwrap();
+
+    // Different bytes (extra frontmatter key), near-identical content.
+    let second = dir.path().join("second.md");
+    std::fs::write(
+        &second,
+        format!(
+            "---\nslug: notes/shared\ntitle: Shared\ntype: concept\nwing: notes\n---\n{body}\n"
+        ),
+    )
+    .unwrap();
+    ingest::run(&conn, second.to_str().unwrap(), false).unwrap();
+
+    let version: i64 = conn
+        .query_row(
+            "SELECT version FROM pages WHERE collection_id = 1 AND slug = 'notes/shared'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        version, 1,
+        "same-collection duplicate must still be skipped by the novelty check"
+    );
+}

--- a/tests/markdown_yaml_roundtrip.rs
+++ b/tests/markdown_yaml_roundtrip.rs
@@ -1,0 +1,178 @@
+//! Frontmatter round-trip fidelity: `render_page` → `parse_frontmatter`
+//! must be an identity over adversarial string scalars. Under-quoted YAML
+//! used to flip types (`"true"` → Bool, `"2024"` → Number) or invalidate
+//! the document (`"- item"`), after which the parser silently dropped all
+//! frontmatter on the next render.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::print_stdout,
+    reason = "test fixtures legitimately panic on setup failure and print diagnostics; per-site #[expect] would generate noise across thousands of test sites"
+)]
+
+use quaid::core::markdown::{parse_frontmatter, render_page, split_content};
+use quaid::core::types::{Frontmatter, Page};
+use serde_json::{json, Value as JsonValue};
+
+const PAGE_UUID: &str = "01969f11-9448-7d79-8d3f-c68f54761234";
+
+fn make_page(frontmatter: Frontmatter, compiled_truth: &str, timeline: &str) -> Page {
+    Page {
+        slug: "notes/roundtrip".to_string(),
+        uuid: PAGE_UUID.to_string(),
+        page_type: "concept".to_string(),
+        superseded_by: None,
+        title: "Roundtrip".to_string(),
+        summary: String::new(),
+        compiled_truth: compiled_truth.to_string(),
+        timeline: timeline.to_string(),
+        frontmatter,
+        wing: "notes".to_string(),
+        room: String::new(),
+        version: 1,
+        created_at: String::new(),
+        updated_at: String::new(),
+        truth_updated_at: String::new(),
+        timeline_updated_at: String::new(),
+    }
+}
+
+/// Property-style identity check: every scalar must come back from
+/// `render_page` → `parse_frontmatter` exactly as it went in — same value,
+/// same JSON type.
+#[test]
+fn render_parse_identity_over_adversarial_string_scalars() {
+    let adversarial: &[&str] = &[
+        "true",
+        "false",
+        "yes",
+        "no",
+        "on",
+        "off",
+        "null",
+        "~",
+        "007",
+        "2024",
+        "1e5",
+        "0x1F",
+        "3.14",
+        "-42",
+        "2024-01-01",
+        "- item",
+        "? key",
+        ": value",
+        "a: b",
+        "#comment",
+        "[bracket]",
+        "{brace}",
+        "'single'",
+        "\"double\"",
+        "back\\slash",
+        "",
+        " leading space",
+        "trailing space ",
+        "line1\nline2",
+        "ends with newline\n",
+        "blank\n\nline",
+        "multi\nline\nvalue\n",
+    ];
+
+    for scalar in adversarial {
+        let mut frontmatter = Frontmatter::new();
+        frontmatter.insert("probe".to_string(), json!(scalar));
+        frontmatter.insert("title".to_string(), json!("Roundtrip"));
+        let page = make_page(frontmatter, "Body text.", "2024-01-01: entry.");
+
+        let rendered = render_page(&page);
+        let (parsed, body) = parse_frontmatter(&rendered);
+
+        assert_eq!(
+            parsed.get("probe"),
+            Some(&json!(scalar)),
+            "scalar {scalar:?} did not survive render→parse; rendered:\n{rendered}"
+        );
+        assert_eq!(
+            parsed.get("quaid_id"),
+            Some(&json!(PAGE_UUID)),
+            "quaid_id lost while round-tripping {scalar:?}"
+        );
+
+        let (truth, timeline) = split_content(&body);
+        assert_eq!(truth, "Body text.", "body corrupted by scalar {scalar:?}");
+        assert_eq!(
+            timeline, "2024-01-01: entry.",
+            "timeline corrupted by scalar {scalar:?}"
+        );
+    }
+}
+
+/// A second render of the parsed page must be byte-identical to the first
+/// render (idempotence), so vault files stop churning.
+#[test]
+fn render_is_idempotent_for_adversarial_scalars() {
+    for scalar in ["true", "007", "2024", "- item", "line1\nline2"] {
+        let mut frontmatter = Frontmatter::new();
+        frontmatter.insert("probe".to_string(), json!(scalar));
+        let page = make_page(frontmatter, "Body.", "");
+
+        let first = render_page(&page);
+        let (parsed, body) = parse_frontmatter(&first);
+        let (truth, timeline) = split_content(&body);
+
+        let mut reparsed_page = make_page(parsed, &truth, &timeline);
+        reparsed_page.uuid = PAGE_UUID.to_string();
+        let second = render_page(&reparsed_page);
+
+        assert_eq!(
+            first, second,
+            "render→parse→render not idempotent for scalar {scalar:?}"
+        );
+    }
+}
+
+/// Non-string scalar values must keep their JSON types through a round trip.
+#[test]
+fn render_parse_identity_preserves_non_string_types() {
+    let mut frontmatter = Frontmatter::new();
+    frontmatter.insert("flag".to_string(), json!(true));
+    frontmatter.insert("count".to_string(), json!(7));
+    frontmatter.insert("ratio".to_string(), json!(0.5));
+    frontmatter.insert("nothing".to_string(), JsonValue::Null);
+    frontmatter.insert("items".to_string(), json!(["a", "true", "007"]));
+    let page = make_page(frontmatter, "Body.", "");
+
+    let rendered = render_page(&page);
+    let (parsed, _) = parse_frontmatter(&rendered);
+
+    assert_eq!(parsed.get("flag"), Some(&json!(true)));
+    assert_eq!(parsed.get("count"), Some(&json!(7)));
+    assert_eq!(parsed.get("ratio"), Some(&json!(0.5)));
+    assert_eq!(parsed.get("nothing"), Some(&JsonValue::Null));
+    assert_eq!(parsed.get("items"), Some(&json!(["a", "true", "007"])));
+}
+
+/// Unparseable YAML frontmatter must be preserved verbatim as body content
+/// instead of being silently dropped on the next render.
+#[test]
+fn unparseable_frontmatter_is_preserved_as_body_not_dropped() {
+    let inputs = [
+        "---\ntitle: [unclosed\n---\nBody text.\n",
+        "---\na: 1\na: 2\n---\nBody text.\n",
+        "---\n\tindented: tab\n---\nBody text.\n",
+    ];
+
+    for input in inputs {
+        let (map, body) = parse_frontmatter(input);
+
+        assert!(
+            map.is_empty(),
+            "unparseable YAML must not yield frontmatter: {input:?}"
+        );
+        assert_eq!(
+            body, input,
+            "unparseable frontmatter block must survive in the body verbatim"
+        );
+    }
+}

--- a/tests/query_budget_multibyte.rs
+++ b/tests/query_budget_multibyte.rs
@@ -1,0 +1,61 @@
+//! Budget-unit regression: `quaid query` used to spend its token budget in
+//! bytes while truncating in chars, so multibyte summaries were overcounted
+//! and the budget semantics diverged from `core::progressive` (chars/4).
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::print_stdout,
+    reason = "test fixtures legitimately panic on setup failure and print diagnostics; per-site #[expect] would generate noise across thousands of test sites"
+)]
+
+mod common;
+#[path = "common/subprocess.rs"]
+mod common_subprocess;
+
+use std::process::Command;
+
+#[test]
+fn query_token_budget_truncates_multibyte_summaries_by_chars() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("memory.db");
+    {
+        let conn = quaid::core::db::open(db_path.to_str().unwrap()).unwrap();
+        conn.execute(
+            "INSERT INTO pages (slug, type, title, summary, compiled_truth, timeline, \
+                                frontmatter, wing, room, version) \
+             VALUES ('notes/jp', 'concept', 'JP', ?1, 'Body.', '', '{}', 'notes', '', 1)",
+            [&"あ".repeat(100)],
+        )
+        .unwrap();
+    }
+
+    let mut command = Command::new(common::quaid_bin());
+    common_subprocess::configure_test_command(&mut command);
+    let output = command
+        .arg("--db")
+        .arg(&db_path)
+        .args([
+            "query",
+            "notes/jp",
+            "--depth",
+            "none",
+            "--token-budget",
+            "10",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout)
+        .expect("query output must stay valid UTF-8 — truncation may not split a character");
+    let summary_chars = stdout.chars().filter(|ch| *ch == 'あ').count();
+    // 10 tokens = 40 chars; prefix "default::notes/jp: " = 19 chars → 21
+    // summary chars. A byte-based budget would have allowed only 7 chars.
+    assert_eq!(summary_chars, 21, "stdout: {stdout}");
+}

--- a/tests/retrieval_quarantine.rs
+++ b/tests/retrieval_quarantine.rs
@@ -1,0 +1,253 @@
+//! Quarantine-leak regressions: quarantined pages are filtered from FTS at
+//! the trigger level and from vector search, but used to leak back through
+//! the exact-slug short-circuit, `--hops` graph expansion, and `depth=auto`
+//! progressive expansion. Retrieval must never surface quarantined pages;
+//! they stay reachable only via explicit access paths (`memory_get`, raw).
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::print_stdout,
+    reason = "test fixtures legitimately panic on setup failure and print diagnostics; per-site #[expect] would generate noise across thousands of test sites"
+)]
+
+use quaid::core::db;
+use quaid::core::progressive::progressive_retrieve;
+use quaid::core::search::{hybrid_search, HybridSearch};
+use quaid::core::types::SearchResult;
+use rusqlite::Connection;
+
+fn open_test_db() -> Connection {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("memory.db");
+    let conn = db::open(db_path.to_str().unwrap()).unwrap();
+    std::mem::forget(dir);
+    conn
+}
+
+fn insert_page(conn: &Connection, slug: &str, truth: &str) {
+    conn.execute(
+        "INSERT INTO pages (slug, type, title, summary, compiled_truth, timeline, \
+                            frontmatter, wing, room, version) \
+         VALUES (?1, 'concept', ?1, ?1, ?2, '', '{}', 'notes', '', 1)",
+        rusqlite::params![slug, truth],
+    )
+    .unwrap();
+}
+
+fn quarantine_page(conn: &Connection, slug: &str) {
+    let updated = conn
+        .execute(
+            "UPDATE pages SET quarantined_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') \
+             WHERE slug = ?1",
+            [slug],
+        )
+        .unwrap();
+    assert_eq!(updated, 1, "quarantine fixture must hit exactly one page");
+}
+
+fn insert_link(conn: &Connection, from: &str, to: &str) {
+    let from_id: i64 = conn
+        .query_row("SELECT id FROM pages WHERE slug = ?1", [from], |row| {
+            row.get(0)
+        })
+        .unwrap();
+    let to_id: i64 = conn
+        .query_row("SELECT id FROM pages WHERE slug = ?1", [to], |row| {
+            row.get(0)
+        })
+        .unwrap();
+    conn.execute(
+        "INSERT INTO links (from_page_id, to_page_id, relationship, source_kind) \
+         VALUES (?1, ?2, 'related', 'programmatic')",
+        rusqlite::params![from_id, to_id],
+    )
+    .unwrap();
+}
+
+fn make_result(slug: &str) -> SearchResult {
+    SearchResult {
+        slug: slug.to_owned(),
+        title: slug.to_owned(),
+        summary: slug.to_owned(),
+        score: 1.0,
+        wing: "notes".to_owned(),
+    }
+}
+
+fn result_slugs(results: &[SearchResult]) -> Vec<String> {
+    let mut slugs: Vec<String> = results.iter().map(|result| result.slug.clone()).collect();
+    slugs.sort();
+    slugs
+}
+
+#[test]
+fn exact_slug_short_circuit_hides_quarantined_pages() {
+    let conn = open_test_db();
+    insert_page(&conn, "notes/poisoned", "Unparseable import body.");
+    quarantine_page(&conn, "notes/poisoned");
+
+    let results = hybrid_search(
+        &conn,
+        HybridSearch {
+            query: "notes/poisoned",
+            limit: 10,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert!(
+        results.is_empty(),
+        "quarantined page leaked through the exact-slug short-circuit: {results:?}",
+        results = result_slugs(&results)
+    );
+}
+
+#[test]
+fn exact_slug_short_circuit_hides_quarantined_pages_in_canonical_mode() {
+    let conn = open_test_db();
+    insert_page(&conn, "notes/poisoned", "Unparseable import body.");
+    quarantine_page(&conn, "notes/poisoned");
+
+    let results = hybrid_search(
+        &conn,
+        HybridSearch {
+            query: "notes/poisoned",
+            canonical: true,
+            limit: 10,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert!(
+        results.is_empty(),
+        "quarantined page leaked through the canonical exact-slug short-circuit: {results:?}",
+        results = result_slugs(&results)
+    );
+}
+
+#[test]
+fn include_quarantined_flag_restores_explicit_exact_slug_access() {
+    let conn = open_test_db();
+    insert_page(&conn, "notes/poisoned", "Unparseable import body.");
+    quarantine_page(&conn, "notes/poisoned");
+
+    let results = hybrid_search(
+        &conn,
+        HybridSearch {
+            query: "notes/poisoned",
+            include_quarantined: true,
+            limit: 10,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(result_slugs(&results), vec!["notes/poisoned".to_owned()]);
+}
+
+#[test]
+fn hops_graph_expansion_skips_quarantined_link_targets() {
+    let conn = open_test_db();
+    insert_page(&conn, "notes/source", "Source page body.");
+    insert_page(&conn, "notes/healthy", "Healthy neighbour body.");
+    insert_page(&conn, "notes/poisoned", "Quarantined neighbour body.");
+    insert_link(&conn, "notes/source", "notes/healthy");
+    insert_link(&conn, "notes/source", "notes/poisoned");
+    quarantine_page(&conn, "notes/poisoned");
+
+    let results = hybrid_search(
+        &conn,
+        HybridSearch {
+            query: "notes/source",
+            limit: 10,
+            hops: Some(1),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let slugs = result_slugs(&results);
+    assert!(
+        slugs.contains(&"notes/healthy".to_owned()),
+        "healthy neighbour must still arrive via graph expansion: {slugs:?}"
+    );
+    assert!(
+        !slugs.contains(&"notes/poisoned".to_owned()),
+        "quarantined page leaked through --hops graph expansion: {slugs:?}"
+    );
+}
+
+#[test]
+fn progressive_expansion_skips_quarantined_link_targets() {
+    let conn = open_test_db();
+    insert_page(&conn, "notes/source", "Source page body.");
+    insert_page(&conn, "notes/healthy", "Healthy neighbour body.");
+    insert_page(&conn, "notes/poisoned", "Quarantined neighbour body.");
+    insert_link(&conn, "notes/source", "notes/healthy");
+    insert_link(&conn, "notes/source", "notes/poisoned");
+    quarantine_page(&conn, "notes/poisoned");
+
+    let results = progressive_retrieve(
+        vec![make_result("notes/source")],
+        100_000,
+        1,
+        None,
+        false,
+        &conn,
+    )
+    .unwrap();
+
+    let slugs = result_slugs(&results);
+    assert_eq!(
+        slugs,
+        vec!["notes/healthy".to_owned(), "notes/source".to_owned()],
+        "depth=auto expansion must skip quarantined neighbours"
+    );
+}
+
+#[test]
+fn direct_get_still_fetches_quarantined_pages_explicitly() {
+    let conn = open_test_db();
+    conn.execute(
+        "INSERT INTO pages (slug, uuid, type, title, summary, compiled_truth, timeline, \
+                            frontmatter, wing, room, version) \
+         VALUES ('notes/poisoned', '01969f11-9448-7d79-8d3f-c68f54761234', 'concept', \
+                 'Poisoned', '', 'Unparseable import body.', '', '{}', 'notes', '', 1)",
+        [],
+    )
+    .unwrap();
+    quarantine_page(&conn, "notes/poisoned");
+
+    let page = quaid::commands::get::get_page(&conn, "notes/poisoned")
+        .expect("explicit get must still reach quarantined pages");
+    assert_eq!(page.slug, "notes/poisoned");
+}
+
+#[test]
+fn progressive_expansion_skips_quarantined_targets_even_with_include_superseded() {
+    let conn = open_test_db();
+    insert_page(&conn, "notes/source", "Source page body.");
+    insert_page(&conn, "notes/poisoned", "Quarantined neighbour body.");
+    insert_link(&conn, "notes/source", "notes/poisoned");
+    quarantine_page(&conn, "notes/poisoned");
+
+    let results = progressive_retrieve(
+        vec![make_result("notes/source")],
+        100_000,
+        1,
+        None,
+        true,
+        &conn,
+    )
+    .unwrap();
+
+    assert_eq!(
+        result_slugs(&results),
+        vec!["notes/source".to_owned()],
+        "include_superseded must not re-expose quarantined pages"
+    );
+}

--- a/tests/supersede_chain.rs
+++ b/tests/supersede_chain.rs
@@ -438,3 +438,129 @@ fn retrieval_defaults_to_heads_and_include_superseded_restores_history() {
         ]
     );
 }
+
+#[test]
+fn put_of_chain_tail_superseding_the_head_is_rejected_to_prevent_cycles() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("memory.db");
+    let root = dir.path().join("vault");
+    let server = QuaidServer::new(open_test_db(&db_path));
+    let conn = open_test_db(&db_path);
+    set_default_root(&conn, &root);
+
+    put_page(
+        &server,
+        "facts/a",
+        "---\ntitle: Fact A\ntype: fact\n---\ncycle guard marker\n",
+        None,
+    );
+    put_page(
+        &server,
+        "facts/b",
+        "---\ntitle: Fact B\ntype: fact\nsupersedes: facts/a\n---\ncycle guard marker\n",
+        None,
+    );
+
+    // Re-put the superseded chain tail claiming it supersedes the head.
+    // Accepting this would set b.superseded_by = a, producing a headless
+    // a<->b cycle that head-only retrieval can never surface.
+    let error = server
+        .memory_put(MemoryPutInput {
+            slug: "facts/a".to_string(),
+            content:
+                "---\ntitle: Fact A\ntype: fact\nsupersedes: facts/b\n---\ncycle guard marker\n"
+                    .to_string(),
+            expected_version: Some(1),
+            namespace: None,
+        })
+        .unwrap_err();
+    assert_eq!(error.code, ErrorCode(-32009));
+    assert!(error.message.contains("SupersedeConflictError"));
+
+    let b_id: i64 = conn
+        .query_row("SELECT id FROM pages WHERE slug = 'facts/b'", [], |row| {
+            row.get(0)
+        })
+        .unwrap();
+    let pointers: Vec<(String, Option<i64>)> = conn
+        .prepare("SELECT slug, superseded_by FROM pages WHERE slug LIKE 'facts/%' ORDER BY slug")
+        .unwrap()
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+    assert_eq!(
+        pointers,
+        vec![
+            ("facts/a".to_string(), Some(b_id)),
+            ("facts/b".to_string(), None),
+        ],
+        "the rejected put must leave the chain head intact (no cycle)"
+    );
+}
+
+#[test]
+fn reputting_superseded_page_with_its_existing_predecessor_link_stays_allowed() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("memory.db");
+    let root = dir.path().join("vault");
+    let server = QuaidServer::new(open_test_db(&db_path));
+    let conn = open_test_db(&db_path);
+    set_default_root(&conn, &root);
+
+    put_page(
+        &server,
+        "facts/a",
+        "---\ntitle: Fact A\ntype: fact\n---\nreingest marker\n",
+        None,
+    );
+    put_page(
+        &server,
+        "facts/b",
+        "---\ntitle: Fact B\ntype: fact\nsupersedes: facts/a\n---\nreingest marker\n",
+        None,
+    );
+    put_page(
+        &server,
+        "facts/c",
+        "---\ntitle: Fact C\ntype: fact\nsupersedes: facts/b\n---\nreingest marker\n",
+        None,
+    );
+
+    // Re-putting historical b while re-asserting its EXISTING predecessor
+    // link (what re-ingesting an exported chain does) is idempotent and must
+    // not trip the cycle guard.
+    put_page(
+        &server,
+        "facts/b",
+        "---\ntitle: Fact B\ntype: fact\nsupersedes: facts/a\n---\nreingest marker\n",
+        Some(1),
+    );
+
+    let b_id: i64 = conn
+        .query_row("SELECT id FROM pages WHERE slug = 'facts/b'", [], |row| {
+            row.get(0)
+        })
+        .unwrap();
+    let c_id: i64 = conn
+        .query_row("SELECT id FROM pages WHERE slug = 'facts/c'", [], |row| {
+            row.get(0)
+        })
+        .unwrap();
+    let pointers: Vec<(String, Option<i64>)> = conn
+        .prepare("SELECT slug, superseded_by FROM pages WHERE slug LIKE 'facts/%' ORDER BY slug")
+        .unwrap()
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+    assert_eq!(
+        pointers,
+        vec![
+            ("facts/a".to_string(), Some(b_id)),
+            ("facts/b".to_string(), Some(c_id)),
+            ("facts/c".to_string(), None),
+        ],
+        "idempotent re-assertion must keep the chain exactly as it was"
+    );
+}


### PR DESCRIPTION
Implements **Area 12 — misc retrieval & data-fidelity correctness** (all five fixes) plus **Area 16 step 1** (supersede cycle guard) of the codebase review (`docs/fable-review.md` on `code-review-2`).

## Changes
- **Quarantine leaks closed**: `quarantined_at IS NULL` on the exact-slug short-circuit (plain + canonical), `--hops` graph expansion, and progressive neighbor SQL; `HybridSearch` gains `include_quarantined` (default false) mirroring `include_superseded`; direct `memory_get`/raw access still reaches quarantined pages (test-proven).
- **YAML round-trip fidelity** (`markdown.rs`): string scalars rendered via serde_yaml so quoting is symmetric with the parser — `"true"`/`"007"`/`"2024"` keep string type, `- item` can't invalidate the document, multiline values emit proper block scalars; `parse_yaml_to_map` returns `Result` and a parse failure now **preserves** the raw frontmatter block instead of silently deleting all frontmatter on next render.
- **Export keying** (`migrate.rs`): exports keyed by `(collection, namespace, slug)` — same-slug pages no longer overwrite each other; NULL-uuid rows skip-and-warn instead of aborting the export; flat layout preserved for single-collection/no-namespace stores (re-ingest script compat).
- **Budget policy unified**: progressive skips (not breaks) on oversized entries; `token_cost` includes timeline and skips on resolve failure; `quaid query`'s budget now uses chars/4 token semantics with multibyte-safe truncation.
- **Novelty scope** (#75): cosine dedup pinned to the exact compared page (by uuid) and ingest's lookup pinned to its write target — same-slug pages in other collections no longer silently swallow ingests.
- **Supersede cycle guard** (Area 16.1): new `NonHeadWriter` error blocks a non-head page from asserting *new* `supersedes:` pointers (the headless A↔B cycle invisible to head-only retrieval), with a deliberate carve-out for idempotently re-asserting an existing predecessor link so exported-chain re-ingest keeps working.

## Validation
fmt/clippy (-D warnings) clean. New suites: retrieval_quarantine (7), markdown_yaml_roundtrip (4, property-style over 30+ adversarial scalars), export_collections (3), ingest_novelty_scope (2), query_budget_multibyte (1), supersede_chain +2 (cycle rejection at -32009 + idempotent re-assert allowed). High-risk neighbors green: vault_sync_remap, reconciler_classification, roundtrip_semantic + roundtrip_raw.

## User-visible behavior notes
- `quaid query`'s default 4000 budget now buys ~16k output chars (was 4000 bytes) — aligned with progressive's documented token semantics.
- Vault YAML quoting changes for ambiguous scalars (e.g. `'007'`); invalid frontmatter survives in the body instead of being stripped.
- Export nested layout activates only when >1 collection or any namespace exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)