### PR TITLE
fix(core): namespace-aware page identity — one resolver, ~17 sites, reconciler + backfill (area 4, fixes #212 root cause)

### DIFF
--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -9,6 +9,7 @@ use rusqlite::Connection;
 use crate::commands::get::get_page_by_key;
 use crate::core::assertions::{self, Contradiction};
 use crate::core::collections::OpKind;
+use crate::core::pages;
 use crate::core::vault_sync;
 
 #[derive(Debug)]
@@ -80,16 +81,18 @@ pub fn execute_check(
 fn resolve_target(db: &Connection, slug: &str) -> Result<CheckTarget> {
     let resolved = vault_sync::resolve_slug_for_op(db, slug, OpKind::WriteUpdate)
         .map_err(|err| anyhow!(err.to_string()))?;
-    let page_id = db
-        .query_row(
-            "SELECT id FROM pages WHERE collection_id = ?1 AND slug = ?2",
-            rusqlite::params![resolved.collection_id, &resolved.slug],
-            |row| row.get(0),
-        )
-        .map_err(|error| match error {
-            rusqlite::Error::QueryReturnedNoRows => anyhow!("page not found: {slug}"),
-            other => anyhow!(other),
-        })?;
+    let page_id = pages::resolve(
+        db,
+        &pages::PageKey {
+            collection_id: resolved.collection_id,
+            namespace: None,
+            slug: &resolved.slug,
+        },
+    )
+    .map_err(|error| match error {
+        rusqlite::Error::QueryReturnedNoRows => anyhow!("page not found: {slug}"),
+        other => anyhow!(other),
+    })?;
     Ok(CheckTarget { resolved, page_id })
 }
 

--- a/src/commands/embed.rs
+++ b/src/commands/embed.rs
@@ -159,10 +159,13 @@ fn page_refs_after(db: &Connection, last_page_id: i64, batch_size: usize) -> Res
 }
 
 fn page_id_by_key(db: &Connection, collection_id: i64, slug: &str) -> Result<i64> {
-    db.query_row(
-        "SELECT id FROM pages WHERE collection_id = ?1 AND slug = ?2",
-        rusqlite::params![collection_id, slug],
-        |row| row.get(0),
+    crate::core::pages::resolve(
+        db,
+        &crate::core::pages::PageKey {
+            collection_id,
+            namespace: None,
+            slug,
+        },
     )
     .map_err(|error| match error {
         rusqlite::Error::QueryReturnedNoRows => anyhow::anyhow!("page not found: {slug}"),

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -7,7 +7,7 @@ use anyhow::{bail, Result};
 use rusqlite::Connection;
 
 use crate::core::types::{frontmatter_insert_string, Frontmatter, Page};
-use crate::core::{markdown, page_uuid, vault_sync};
+use crate::core::{markdown, page_uuid, pages, vault_sync};
 
 /// Read a page by slug and print it to stdout.
 pub fn run(db: &Connection, slug: &str, namespace: Option<&str>, json: bool) -> Result<()> {
@@ -60,39 +60,37 @@ pub fn get_page_by_key_with_namespace(
 ) -> Result<Page> {
     crate::core::namespace::validate_optional_namespace(namespace)
         .map_err(|err| anyhow::anyhow!(err.to_string()))?;
-    let mut sql = String::from(
+    let Some(page_id) = pages::resolve_optional(
+        db,
+        &pages::PageKey {
+            collection_id,
+            namespace,
+            slug,
+        },
+    )?
+    else {
+        bail!("page not found: {slug}")
+    };
+    get_page_by_id(db, page_id).map_err(|err| {
+        let message = err.to_string();
+        if message.contains("page not found") {
+            anyhow::anyhow!("page not found: {slug}")
+        } else {
+            err
+        }
+    })
+}
+
+/// Load a single page from the database by its row id.
+pub fn get_page_by_id(db: &Connection, page_id: i64) -> Result<Page> {
+    let mut stmt = db.prepare(
         "SELECT slug, uuid, type, title, summary, compiled_truth, timeline, \
                 frontmatter, wing, room, superseded_by, version, created_at, updated_at, \
                 truth_updated_at, timeline_updated_at \
-           FROM pages WHERE collection_id = ?1 AND slug = ?2",
-    );
-    let mut params: Vec<Box<dyn rusqlite::types::ToSql>> =
-        vec![Box::new(collection_id), Box::new(slug.to_owned())];
+           FROM pages WHERE id = ?1",
+    )?;
 
-    if let Some(namespace) = namespace {
-        if namespace.is_empty() {
-            sql.push_str(" AND namespace = ?");
-            sql.push_str(&(params.len() + 1).to_string());
-            params.push(Box::new(String::new()));
-        } else {
-            sql.push_str(" AND (namespace = ?");
-            sql.push_str(&(params.len() + 1).to_string());
-            sql.push_str(" OR namespace = '')");
-            params.push(Box::new(namespace.to_owned()));
-        }
-    }
-    if let Some(namespace) = namespace.filter(|namespace| !namespace.is_empty()) {
-        sql.push_str(" ORDER BY CASE WHEN namespace = ?");
-        sql.push_str(&(params.len() + 1).to_string());
-        sql.push_str(" THEN 0 ELSE 1 END");
-        params.push(Box::new(namespace.to_owned()));
-    }
-    sql.push_str(" LIMIT 1");
-
-    let mut stmt = db.prepare(&sql)?;
-    let param_refs: Vec<&dyn rusqlite::types::ToSql> = params.iter().map(|p| p.as_ref()).collect();
-
-    let page = stmt.query_row(param_refs.as_slice(), |row| {
+    let page = stmt.query_row([page_id], |row| {
         let frontmatter_json: String = row.get(7)?;
         let frontmatter: Frontmatter = serde_json::from_str(&frontmatter_json).unwrap_or_default();
 
@@ -125,7 +123,7 @@ pub fn get_page_by_key_with_namespace(
     match page {
         Ok(page) => Ok(page),
         Err(rusqlite::Error::QueryReturnedNoRows) => {
-            bail!("page not found: {slug}")
+            bail!("page not found: id {page_id}")
         }
         Err(e) => Err(e.into()),
     }

--- a/src/commands/graph.rs
+++ b/src/commands/graph.rs
@@ -7,6 +7,7 @@ use rusqlite::Connection;
 
 use crate::core::entities;
 use crate::core::graph::{self, GraphError, TemporalFilter};
+use crate::core::pages;
 use crate::core::vault_sync;
 
 /// Top-level args for the `quaid graph` command.
@@ -79,18 +80,20 @@ pub fn run_to<W: Write>(
 
     let resolved = vault_sync::resolve_page_for_read(db, slug)
         .map_err(|err| anyhow::anyhow!(err.to_string()))?;
-    let page_id: i64 = db
-        .query_row(
-            "SELECT id FROM pages WHERE collection_id = ?1 AND slug = ?2",
-            rusqlite::params![resolved.collection_id, &resolved.slug],
-            |row| row.get(0),
-        )
-        .map_err(|error| match error {
-            rusqlite::Error::QueryReturnedNoRows => {
-                anyhow::anyhow!("page not found: {}", resolved.canonical_slug())
-            }
-            other => anyhow::anyhow!(other),
-        })?;
+    let page_id: i64 = pages::resolve(
+        db,
+        &pages::PageKey {
+            collection_id: resolved.collection_id,
+            namespace: None,
+            slug: &resolved.slug,
+        },
+    )
+    .map_err(|error| match error {
+        rusqlite::Error::QueryReturnedNoRows => {
+            anyhow::anyhow!("page not found: {}", resolved.canonical_slug())
+        }
+        other => anyhow::anyhow!(other),
+    })?;
 
     let root_slug = resolved.canonical_slug();
     let result = match graph::neighborhood_graph_for_page(

--- a/src/commands/ingest.rs
+++ b/src/commands/ingest.rs
@@ -115,10 +115,13 @@ pub fn run(db: &Connection, path: &str, force: bool) -> Result<()> {
                 room
             ],
         )?;
-        let page_id: i64 = db.query_row(
-            "SELECT id FROM pages WHERE collection_id = 1 AND slug = ?1",
-            [&slug],
-            |row| row.get(0),
+        let page_id: i64 = crate::core::pages::resolve(
+            db,
+            &crate::core::pages::PageKey {
+                collection_id: 1,
+                namespace: Some(""),
+                slug: &slug,
+            },
         )?;
         supersede::reconcile_supersede_chain(db, 1, "", page_id, &slug, supersedes.as_deref())
             .map_err(|error| anyhow::anyhow!(error.to_string()))?;
@@ -189,6 +192,7 @@ fn refresh_source_mapping_for_duplicate(
              FROM raw_imports ri
              JOIN pages p ON p.id = ri.page_id
              WHERE p.collection_id = 1
+               AND p.namespace = ''
                AND p.slug = ?2
                AND ri.is_active = 1
                AND ri.raw_bytes = ?4

--- a/src/commands/link.rs
+++ b/src/commands/link.rs
@@ -12,6 +12,7 @@ use rusqlite::Connection;
 use serde::Serialize;
 
 use crate::core::collections::OpKind;
+use crate::core::pages;
 use crate::core::types::Link;
 use crate::core::vault_sync;
 
@@ -23,19 +24,26 @@ struct ResolvedPage {
 }
 
 /// Resolve a slug to its integer page ID. Returns an error if the page doesn't exist.
-fn resolve_page(db: &Connection, slug: &str, op_kind: OpKind) -> Result<ResolvedPage> {
+fn resolve_page(
+    db: &Connection,
+    slug: &str,
+    op_kind: OpKind,
+    namespace: Option<&str>,
+) -> Result<ResolvedPage> {
     let resolved = vault_sync::resolve_slug_for_op(db, slug, op_kind)
         .map_err(|err| anyhow::anyhow!(err.to_string()))?;
-    let page_id = db
-        .query_row(
-            "SELECT id FROM pages WHERE collection_id = ?1 AND slug = ?2",
-            rusqlite::params![resolved.collection_id, resolved.slug],
-            |row| row.get(0),
-        )
-        .map_err(|error| match error {
-            rusqlite::Error::QueryReturnedNoRows => anyhow::anyhow!("page not found: {slug}"),
-            other => anyhow::anyhow!(other),
-        })?;
+    let page_id = pages::resolve(
+        db,
+        &pages::PageKey {
+            collection_id: resolved.collection_id,
+            namespace,
+            slug: &resolved.slug,
+        },
+    )
+    .map_err(|error| match error {
+        rusqlite::Error::QueryReturnedNoRows => anyhow::anyhow!("page not found: {slug}"),
+        other => anyhow::anyhow!(other),
+    })?;
     Ok(ResolvedPage { resolved, page_id })
 }
 
@@ -54,8 +62,8 @@ pub fn run(
     valid_from: Option<String>,
     valid_until: Option<String>,
 ) -> Result<()> {
-    let from_page = resolve_page(db, from, OpKind::WriteUpdate)?;
-    let to_page = resolve_page(db, to, OpKind::WriteUpdate)?;
+    let from_page = resolve_page(db, from, OpKind::WriteUpdate, None)?;
+    let to_page = resolve_page(db, to, OpKind::WriteUpdate, None)?;
     let closed = run_resolved(
         db,
         &from_page,
@@ -89,8 +97,24 @@ pub fn run_silent(
     valid_from: Option<String>,
     valid_until: Option<String>,
 ) -> Result<bool> {
-    let from_page = resolve_page(db, from, OpKind::WriteUpdate)?;
-    let to_page = resolve_page(db, to, OpKind::WriteUpdate)?;
+    run_silent_with_namespace(db, from, to, relationship, valid_from, valid_until, None)
+}
+
+/// Namespace-aware variant of [`run_silent`]: both endpoints resolve in
+/// `namespace` (with the documented global fallback) instead of the
+/// deterministic any-namespace ordering.
+#[allow(clippy::too_many_arguments)]
+pub fn run_silent_with_namespace(
+    db: &Connection,
+    from: &str,
+    to: &str,
+    relationship: &str,
+    valid_from: Option<String>,
+    valid_until: Option<String>,
+    namespace: Option<&str>,
+) -> Result<bool> {
+    let from_page = resolve_page(db, from, OpKind::WriteUpdate, namespace)?;
+    let to_page = resolve_page(db, to, OpKind::WriteUpdate, namespace)?;
     run_resolved(
         db,
         &from_page,
@@ -203,7 +227,7 @@ struct BacklinkRow {
 
 /// List all outbound links for a page.
 pub fn links(db: &Connection, slug: &str, _temporal: Option<String>, json: bool) -> Result<()> {
-    let resolved = resolve_page(db, slug, OpKind::Read)?;
+    let resolved = resolve_page(db, slug, OpKind::Read, None)?;
 
     let mut stmt = db.prepare(
         "SELECT l.id, c.name || '::' || p.slug, l.relationship, l.valid_from, l.valid_until \
@@ -252,8 +276,8 @@ pub fn links(db: &Connection, slug: &str, _temporal: Option<String>, json: bool)
 
 /// Remove a cross-reference entirely.
 pub fn unlink(db: &Connection, from: &str, to: &str, relationship: Option<String>) -> Result<()> {
-    let from_page = resolve_page(db, from, OpKind::WriteUpdate)?;
-    let to_page = resolve_page(db, to, OpKind::WriteUpdate)?;
+    let from_page = resolve_page(db, from, OpKind::WriteUpdate, None)?;
+    let to_page = resolve_page(db, to, OpKind::WriteUpdate, None)?;
     vault_sync::ensure_collection_write_allowed(db, from_page.resolved.collection_id)
         .map_err(|err| anyhow::anyhow!(err.to_string()))?;
     vault_sync::ensure_collection_write_allowed(db, to_page.resolved.collection_id)
@@ -291,7 +315,7 @@ pub fn unlink(db: &Connection, from: &str, to: &str, relationship: Option<String
 
 /// List backlinks (inbound links) for a page.
 pub fn backlinks(db: &Connection, slug: &str, _temporal: Option<String>, json: bool) -> Result<()> {
-    let resolved = resolve_page(db, slug, OpKind::Read)?;
+    let resolved = resolve_page(db, slug, OpKind::Read, None)?;
 
     let mut stmt = db.prepare(
         "SELECT l.id, c.name || '::' || p.slug, l.relationship, l.valid_from, l.valid_until \

--- a/src/commands/tags.rs
+++ b/src/commands/tags.rs
@@ -7,6 +7,7 @@ use anyhow::Result;
 use rusqlite::Connection;
 
 use crate::core::collections::OpKind;
+use crate::core::pages;
 use crate::core::vault_sync;
 
 /// Manage tags on a page: list, add, or remove.
@@ -47,10 +48,13 @@ pub fn run(db: &Connection, slug: &str, add: &[String], remove: &[String]) -> Re
 }
 
 fn resolve_page_id(db: &Connection, collection_id: i64, slug: &str) -> Result<i64> {
-    db.query_row(
-        "SELECT id FROM pages WHERE collection_id = ?1 AND slug = ?2",
-        rusqlite::params![collection_id, slug],
-        |row| row.get(0),
+    pages::resolve(
+        db,
+        &pages::PageKey {
+            collection_id,
+            namespace: None,
+            slug,
+        },
     )
     .map_err(|e| match e {
         rusqlite::Error::QueryReturnedNoRows => anyhow::anyhow!("page not found: {slug}"),

--- a/src/commands/timeline.rs
+++ b/src/commands/timeline.rs
@@ -8,6 +8,7 @@ use rusqlite::Connection;
 use serde::Serialize;
 
 use crate::core::collections::OpKind;
+use crate::core::pages;
 use crate::core::vault_sync;
 
 #[derive(Debug, Serialize)]
@@ -24,16 +25,18 @@ pub fn run(db: &Connection, slug: &str, limit: u32, json: bool) -> Result<()> {
     let canonical_slug = resolved.canonical_slug();
     let page = crate::commands::get::get_page_by_key(db, resolved.collection_id, &resolved.slug)?;
 
-    let page_id: i64 = db
-        .query_row(
-            "SELECT id FROM pages WHERE collection_id = ?1 AND slug = ?2",
-            rusqlite::params![resolved.collection_id, &resolved.slug],
-            |row| row.get(0),
-        )
-        .map_err(|e| match e {
-            rusqlite::Error::QueryReturnedNoRows => anyhow::anyhow!("page not found: {slug}"),
-            other => other.into(),
-        })?;
+    let page_id: i64 = pages::resolve(
+        db,
+        &pages::PageKey {
+            collection_id: resolved.collection_id,
+            namespace: None,
+            slug: &resolved.slug,
+        },
+    )
+    .map_err(|e| match e {
+        rusqlite::Error::QueryReturnedNoRows => anyhow::anyhow!("page not found: {slug}"),
+        other => other.into(),
+    })?;
 
     // Query structured timeline_entries table
     let mut stmt = db.prepare(
@@ -113,16 +116,18 @@ pub fn add(
     let canonical_slug = resolved.canonical_slug();
     vault_sync::ensure_collection_write_allowed(db, resolved.collection_id)
         .map_err(|err| anyhow::anyhow!(err.to_string()))?;
-    let page_id: i64 = db
-        .query_row(
-            "SELECT id FROM pages WHERE collection_id = ?1 AND slug = ?2",
-            rusqlite::params![resolved.collection_id, &resolved.slug],
-            |row| row.get(0),
-        )
-        .map_err(|e| match e {
-            rusqlite::Error::QueryReturnedNoRows => anyhow::anyhow!("page not found: {slug}"),
-            other => other.into(),
-        })?;
+    let page_id: i64 = pages::resolve(
+        db,
+        &pages::PageKey {
+            collection_id: resolved.collection_id,
+            namespace: None,
+            slug: &resolved.slug,
+        },
+    )
+    .map_err(|e| match e {
+        rusqlite::Error::QueryReturnedNoRows => anyhow::anyhow!("page not found: {slug}"),
+        other => other.into(),
+    })?;
 
     let summary_hash = {
         use sha2::{Digest, Sha256};

--- a/src/core/assertions.rs
+++ b/src/core/assertions.rs
@@ -215,9 +215,14 @@ pub fn check_assertions_for_page_id(
 }
 
 fn resolve_page_id(conn: &Connection, slug: &str) -> Result<i64, AssertionError> {
-    conn.query_row("SELECT id FROM pages WHERE slug = ?1", [slug], |row| {
-        row.get(0)
-    })
+    // Legacy collection-blind fallback (uuid lookup is the primary identity):
+    // prefer the global namespace, then order deterministically instead of
+    // binding to an arbitrary row when a slug exists in several namespaces.
+    conn.query_row(
+        "SELECT id FROM pages WHERE slug = ?1          ORDER BY CASE WHEN namespace = '' THEN 0 ELSE 1 END, namespace, collection_id          LIMIT 1",
+        [slug],
+        |row| row.get(0),
+    )
     .map_err(|error| match error {
         rusqlite::Error::QueryReturnedNoRows => AssertionError::PageNotFound {
             slug: slug.to_string(),

--- a/src/core/conversation/correction.rs
+++ b/src/core/conversation/correction.rs
@@ -528,14 +528,26 @@ fn resolve_target_fact(conn: &Connection, fact_slug: &str) -> Result<TargetFact,
             other => CorrectionError::VaultSync(other),
         })?;
 
+    let page_id = crate::core::pages::resolve_optional(
+        conn,
+        &crate::core::pages::PageKey {
+            collection_id: resolved.collection_id,
+            namespace: None,
+            slug: &resolved.slug,
+        },
+    )?;
+    let Some(page_id) = page_id else {
+        return Err(CorrectionError::NotFound {
+            slug: resolved.canonical_slug(),
+        });
+    };
     let row = conn
         .query_row(
             "SELECT type, frontmatter, COALESCE(NULLIF(compiled_truth, ''), summary, ''),
                     summary, superseded_by, namespace
              FROM pages
-             WHERE collection_id = ?1 AND slug = ?2
-             LIMIT 1",
-            params![resolved.collection_id, &resolved.slug],
+             WHERE id = ?1",
+            params![page_id],
             |row| {
                 Ok((
                     row.get::<_, String>(0)?,

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -288,6 +288,7 @@ fn open_connection(path: &str) -> Result<Connection, DbError> {
     ensure_serve_session_columns(&conn)?;
     ensure_collection_name_guards(&conn)?;
     ensure_raw_import_hash_schema(&conn)?;
+    ensure_pages_namespace_backfill(&conn)?;
     set_version(&conn)?;
     ensure_default_collection(&conn)?;
 
@@ -616,6 +617,80 @@ fn ensure_raw_import_hash_schema(conn: &Connection) -> Result<(), DbError> {
             )?;
         }
         tx.commit()?;
+    }
+
+    Ok(())
+}
+
+/// Backfill `pages.namespace` for rows whose `file_state` path carries a
+/// `<ns>/extracted/...` namespace prefix.
+///
+/// Before namespace-aware reingest landed, the vault watcher inserted every
+/// page into the global (`''`) namespace, including extracted facts written
+/// to `<ns>/extracted/...` (issue #212). This idempotent fixup derives the
+/// namespace strictly from the tracked file path and re-homes those rows.
+/// Rows whose target `(collection, namespace, slug)` is already occupied are
+/// skipped (and counted) rather than violating the uniqueness constraint.
+///
+/// NOTE for the migration-ladder workstream (Area 17): this is an
+/// `ensure_`-style open-time fixup by design and intentionally does NOT bump
+/// `SCHEMA_VERSION`; fold it into the versioned ladder when that lands.
+fn ensure_pages_namespace_backfill(conn: &Connection) -> Result<(), DbError> {
+    if !table_exists(conn, "pages")? || !table_exists(conn, "file_state")? {
+        return Ok(());
+    }
+
+    let candidates: Vec<(i64, String)> = conn
+        .prepare(
+            "SELECT p.id, fs.relative_path
+             FROM pages p
+             JOIN file_state fs ON fs.page_id = p.id
+             WHERE p.namespace = ''
+               AND fs.relative_path LIKE '%/extracted/%'
+             ORDER BY p.id",
+        )?
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?
+        .collect::<Result<_, _>>()?;
+
+    if candidates.is_empty() {
+        return Ok(());
+    }
+
+    let mut backfilled = 0usize;
+    let mut conflicts_skipped = 0usize;
+    let tx = conn.unchecked_transaction()?;
+    for (page_id, relative_path) in candidates {
+        let namespace = crate::core::pages::derive_namespace_from_relative_path(
+            std::path::Path::new(&relative_path),
+        );
+        if namespace.is_empty() {
+            continue;
+        }
+        let updated = tx.execute(
+            "UPDATE pages
+             SET namespace = ?1
+             WHERE id = ?2
+               AND namespace = ''
+               AND NOT EXISTS (
+                   SELECT 1 FROM pages p2
+                   WHERE p2.collection_id = pages.collection_id
+                     AND p2.namespace = ?1
+                     AND p2.slug = pages.slug
+               )",
+            params![namespace, page_id],
+        )?;
+        if updated == 1 {
+            backfilled += 1;
+        } else {
+            conflicts_skipped += 1;
+        }
+    }
+    tx.commit()?;
+
+    if backfilled > 0 || conflicts_skipped > 0 {
+        eprintln!(
+            "INFO: namespace_backfill pages_backfilled={backfilled} conflicts_skipped={conflicts_skipped}"
+        );
     }
 
     Ok(())

--- a/src/core/entities.rs
+++ b/src/core/entities.rs
@@ -403,17 +403,18 @@ fn lookup_by_slug(
     collection_id: i64,
     slug: &str,
 ) -> Result<Option<SurfaceResolution>, rusqlite::Error> {
-    conn.query_row(
-        "SELECT id, slug FROM pages WHERE collection_id = ?1 AND slug = ?2",
-        params![collection_id, slug],
-        |row| {
-            Ok(SurfaceResolution::Resolved {
-                page_id: row.get(0)?,
-                slug: row.get(1)?,
-            })
+    Ok(crate::core::pages::resolve_optional(
+        conn,
+        &crate::core::pages::PageKey {
+            collection_id,
+            namespace: None,
+            slug,
         },
-    )
-    .optional()
+    )?
+    .map(|page_id| SurfaceResolution::Resolved {
+        page_id,
+        slug: slug.to_owned(),
+    }))
 }
 
 fn lookup_by_title_ci(

--- a/src/core/graph.rs
+++ b/src/core/graph.rs
@@ -101,10 +101,15 @@ pub fn neighborhood_graph(
     filter: TemporalFilter,
     conn: &Connection,
 ) -> Result<GraphResult, GraphError> {
+    // Legacy slug-only entry: prefer the global namespace, then order
+    // deterministically instead of binding to an arbitrary row when a slug
+    // exists in several namespaces.
     let root_id: i64 = conn
-        .query_row("SELECT id FROM pages WHERE slug = ?1", [slug], |row| {
-            row.get(0)
-        })
+        .query_row(
+            "SELECT id FROM pages WHERE slug = ?1              ORDER BY CASE WHEN namespace = '' THEN 0 ELSE 1 END, namespace, collection_id              LIMIT 1",
+            [slug],
+            |row| row.get(0),
+        )
         .map_err(|e| match e {
             rusqlite::Error::QueryReturnedNoRows => GraphError::PageNotFound {
                 slug: slug.to_string(),

--- a/src/core/links.rs
+++ b/src/core/links.rs
@@ -492,10 +492,16 @@ pub fn sync_frontmatter_edges(
         DEFAULT_FRONTMATTER_EDGE_WEIGHT,
     );
     let source_slug = lookup_slug(conn, page_id)?;
+    let source_namespace = crate::core::pages::page_namespace(conn, page_id)?.unwrap_or_default();
 
     let mut keep: HashSet<(i64, String)> = HashSet::new();
     for edge in edges {
-        match resolve_target_in_collection(conn, collection_id, &edge.target)? {
+        match resolve_target_in_collection(
+            conn,
+            collection_id,
+            Some(&source_namespace),
+            &edge.target,
+        )? {
             Some(target_id) => {
                 upsert_derived_edge(
                     conn,
@@ -559,9 +565,10 @@ pub fn sync_wikilink_edges(
         }
     }
 
+    let source_namespace = crate::core::pages::page_namespace(conn, page_id)?.unwrap_or_default();
     let mut keep: HashSet<(i64, String)> = HashSet::new();
     for target in &targets {
-        match resolve_target_in_collection(conn, collection_id, target)? {
+        match resolve_target_in_collection(conn, collection_id, Some(&source_namespace), target)? {
             Some(target_id) => {
                 upsert_derived_edge(
                     conn,
@@ -626,14 +633,17 @@ fn delete_stale_derived_rows(
 fn resolve_target_in_collection(
     conn: &Connection,
     collection_id: i64,
+    namespace: Option<&str>,
     slug: &str,
 ) -> Result<Option<i64>, rusqlite::Error> {
-    conn.query_row(
-        "SELECT id FROM pages WHERE collection_id = ?1 AND slug = ?2",
-        params![collection_id, slug],
-        |row| row.get::<_, i64>(0),
+    crate::core::pages::resolve_optional(
+        conn,
+        &crate::core::pages::PageKey {
+            collection_id,
+            namespace,
+            slug,
+        },
     )
-    .optional()
 }
 
 fn lookup_slug(conn: &Connection, page_id: i64) -> Result<Option<String>, rusqlite::Error> {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -50,6 +50,9 @@ pub mod namespace;
 pub mod novelty;
 /// Stable per-page UUID derivation and lookup.
 pub mod page_uuid;
+/// Namespace-aware page identity resolution (the only sanctioned
+/// `(collection, namespace, slug)` → page-id lookup path).
+pub mod pages;
 /// Memory-palace classification: wing/room derivation and intent routing.
 pub mod palace;
 /// Token-budgeted expansion of search hits into context-window-sized payloads.

--- a/src/core/pages.rs
+++ b/src/core/pages.rs
@@ -1,0 +1,122 @@
+//! Namespace-aware page identity resolution.
+//!
+//! The schema keys pages on `UNIQUE(collection_id, namespace, slug)`, but most
+//! call sites historically resolved pages by `(collection_id, slug)` alone,
+//! binding to an arbitrary row whenever the same slug existed in more than one
+//! namespace (issue #212). This module is the single place where namespace
+//! resolution semantics are decided; every production lookup that turns a
+//! `(collection, slug)` pair into a page row id MUST go through [`resolve`] or
+//! [`resolve_optional`]. A source-audit test (`tests/namespace_source_audit.rs`)
+//! enforces this.
+//!
+//! Resolution semantics, ported from the documented global-fallback behaviour
+//! of `commands::get::get_page_by_key_with_namespace`:
+//!
+//! - `namespace: Some("")` — match the global (empty) namespace only.
+//! - `namespace: Some(ns)` — prefer the page in `ns`, fall back to the global
+//!   (`''`) namespace; pages in *other* namespaces never match.
+//! - `namespace: None` — match any namespace, preferring the global namespace,
+//!   then the lexicographically smallest namespace. This keeps legacy
+//!   slug-only callers working while making multi-namespace resolution
+//!   deterministic instead of row-order dependent.
+
+use std::path::Path;
+
+use rusqlite::{Connection, OptionalExtension};
+
+use super::namespace;
+
+/// Identity key for a page: collection, optional namespace filter, and slug.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PageKey<'a> {
+    /// Collection the page belongs to.
+    pub collection_id: i64,
+    /// Namespace filter. See the module docs for the exact semantics of
+    /// `None`, `Some("")`, and `Some(ns)`.
+    pub namespace: Option<&'a str>,
+    /// Page slug within the collection.
+    pub slug: &'a str,
+}
+
+/// Resolve a [`PageKey`] to its page row id.
+///
+/// Returns [`rusqlite::Error::QueryReturnedNoRows`] when no page matches, so
+/// existing call sites can keep their `QueryReturnedNoRows` → "page not
+/// found" mappings unchanged.
+pub fn resolve(conn: &Connection, key: &PageKey) -> Result<i64, rusqlite::Error> {
+    resolve_optional(conn, key)?.ok_or(rusqlite::Error::QueryReturnedNoRows)
+}
+
+/// Resolve a [`PageKey`] to its page row id, returning `Ok(None)` when no
+/// page matches.
+pub fn resolve_optional(conn: &Connection, key: &PageKey) -> Result<Option<i64>, rusqlite::Error> {
+    match key.namespace {
+        Some("") => conn
+            .query_row(
+                "SELECT id FROM pages \
+                 WHERE collection_id = ?1 AND slug = ?2 AND namespace = '' \
+                 LIMIT 1",
+                rusqlite::params![key.collection_id, key.slug],
+                |row| row.get(0),
+            )
+            .optional(),
+        Some(ns) => conn
+            .query_row(
+                "SELECT id FROM pages \
+                 WHERE collection_id = ?1 AND slug = ?2 \
+                   AND (namespace = ?3 OR namespace = '') \
+                 ORDER BY CASE WHEN namespace = ?3 THEN 0 ELSE 1 END \
+                 LIMIT 1",
+                rusqlite::params![key.collection_id, key.slug, ns],
+                |row| row.get(0),
+            )
+            .optional(),
+        None => conn
+            .query_row(
+                "SELECT id FROM pages \
+                 WHERE collection_id = ?1 AND slug = ?2 \
+                 ORDER BY CASE WHEN namespace = '' THEN 0 ELSE 1 END, namespace \
+                 LIMIT 1",
+                rusqlite::params![key.collection_id, key.slug],
+                |row| row.get(0),
+            )
+            .optional(),
+    }
+}
+
+/// Look up the namespace of an already-resolved page row.
+///
+/// Used by derived-edge sync and other id-keyed paths that need to thread the
+/// source page's namespace into target resolution.
+pub fn page_namespace(conn: &Connection, page_id: i64) -> Result<Option<String>, rusqlite::Error> {
+    conn.query_row(
+        "SELECT namespace FROM pages WHERE id = ?1",
+        [page_id],
+        |row| row.get(0),
+    )
+    .optional()
+}
+
+/// Derive the namespace encoded in a vault-relative file path.
+///
+/// The only established namespace-carrying path layout is the extraction
+/// tree: `extracted/<kind>/...` lives in the global namespace while
+/// `<ns>/extracted/<kind>/...` lives in namespace `<ns>` (see
+/// `conversation::supersede::relative_fact_path` and
+/// `conversation::file_edit::is_extracted_path`). Every other path shape maps
+/// to the global (empty) namespace. Prefixes that fail namespace-id
+/// validation are treated as plain directories, i.e. global namespace.
+pub fn derive_namespace_from_relative_path(relative_path: &Path) -> String {
+    let parts: Vec<String> = relative_path
+        .components()
+        .map(|component| component.as_os_str().to_string_lossy().into_owned())
+        .collect();
+    match parts.as_slice() {
+        [ns, second, ..]
+            if second == "extracted" && namespace::validate_namespace_id(ns).is_ok() =>
+        {
+            ns.clone()
+        }
+        _ => String::new(),
+    }
+}

--- a/src/core/pages.rs
+++ b/src/core/pages.rs
@@ -5,9 +5,10 @@
 //! binding to an arbitrary row whenever the same slug existed in more than one
 //! namespace (issue #212). This module is the single place where namespace
 //! resolution semantics are decided; every production lookup that turns a
-//! `(collection, slug)` pair into a page row id MUST go through [`resolve`] or
-//! [`resolve_optional`]. A source-audit test (`tests/namespace_source_audit.rs`)
-//! enforces this.
+//! `(collection, slug)` pair into a page row id MUST go through
+//! [`resolve`](crate::core::pages::resolve) or
+//! [`resolve_optional`](crate::core::pages::resolve_optional).
+//! A source-audit test (`tests/namespace_source_audit.rs`) enforces this.
 //!
 //! Resolution semantics, ported from the documented global-fallback behaviour
 //! of `commands::get::get_page_by_key_with_namespace`:

--- a/src/core/progressive.rs
+++ b/src/core/progressive.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 use rusqlite::Connection;
 
 use super::collections::{self, OpKind, SlugResolution};
+use super::pages::{self, PageKey};
 use super::types::{SearchError, SearchResult};
 
 /// Hard safety cap on expansion depth regardless of caller-supplied value.
@@ -51,7 +52,7 @@ pub fn progressive_retrieve_with_namespace(
     } else {
         initial
             .into_iter()
-            .filter(|result| page_is_head(&result.slug, conn))
+            .filter(|result| page_is_head(&result.slug, namespace_filter, conn))
             .collect()
     };
     if initial.is_empty() || depth == 0 {
@@ -66,7 +67,7 @@ pub fn progressive_retrieve_with_namespace(
 
     // Consume initial results, tracking budget
     for r in &initial {
-        let cost = token_cost(&r.slug, conn);
+        let cost = token_cost(&r.slug, namespace_filter, conn);
         if tokens_used + cost > budget {
             break;
         }
@@ -98,7 +99,7 @@ pub fn progressive_retrieve_with_namespace(
                     continue;
                 }
 
-                let cost = token_cost(&neighbour.slug, conn);
+                let cost = token_cost(&neighbour.slug, namespace_filter, conn);
                 if tokens_used + cost > budget {
                     continue;
                 }
@@ -116,31 +117,45 @@ pub fn progressive_retrieve_with_namespace(
 }
 
 /// Approximate token cost of a page: `len(compiled_truth) / 4`.
-fn token_cost(slug: &str, conn: &Connection) -> usize {
-    let Some((collection_id, resolved_slug)) = resolve_slug_key(conn, slug) else {
+fn token_cost(slug: &str, namespace_filter: Option<&str>, conn: &Connection) -> usize {
+    let Some(page_id) = resolve_page_id(conn, slug, namespace_filter) else {
         return 0;
     };
 
     conn.query_row(
-        "SELECT LENGTH(compiled_truth) FROM pages WHERE collection_id = ?1 AND slug = ?2",
-        rusqlite::params![collection_id, resolved_slug],
+        "SELECT LENGTH(compiled_truth) FROM pages WHERE id = ?1",
+        [page_id],
         |row| row.get::<_, i64>(0),
     )
     .map(|len| (len as usize) / 4)
     .unwrap_or(0)
 }
 
-fn page_is_head(slug: &str, conn: &Connection) -> bool {
-    let Some((collection_id, resolved_slug)) = resolve_slug_key(conn, slug) else {
+fn page_is_head(slug: &str, namespace_filter: Option<&str>, conn: &Connection) -> bool {
+    let Some(page_id) = resolve_page_id(conn, slug, namespace_filter) else {
         return false;
     };
 
     conn.query_row(
-        "SELECT superseded_by IS NULL FROM pages WHERE collection_id = ?1 AND slug = ?2",
-        rusqlite::params![collection_id, resolved_slug],
+        "SELECT superseded_by IS NULL FROM pages WHERE id = ?1",
+        [page_id],
         |row| row.get::<_, bool>(0),
     )
     .unwrap_or(false)
+}
+
+fn resolve_page_id(conn: &Connection, slug: &str, namespace_filter: Option<&str>) -> Option<i64> {
+    let (collection_id, resolved_slug) = resolve_slug_key(conn, slug)?;
+    pages::resolve_optional(
+        conn,
+        &PageKey {
+            collection_id,
+            namespace: namespace_filter,
+            slug: &resolved_slug,
+        },
+    )
+    .ok()
+    .flatten()
 }
 
 /// Fetch outbound link targets from a page, returning them as SearchResults.

--- a/src/core/reconciler.rs
+++ b/src/core/reconciler.rs
@@ -2750,8 +2750,14 @@ fn apply_reingest(
     let absolute_path = root_path.join(relative_path);
     let raw_bytes = fs::read(&absolute_path)?;
     let parsed = parse_vault_file(&raw_bytes, &absolute_path, root_path)?;
-    let current_page =
-        load_existing_page_identity(conn, collection_id, existing_page_id, &parsed.slug)?;
+    let namespace = crate::core::pages::derive_namespace_from_relative_path(relative_path);
+    let current_page = load_existing_page_identity(
+        conn,
+        collection_id,
+        existing_page_id,
+        &namespace,
+        &parsed.slug,
+    )?;
 
     // Fail closed: an existing page must already have raw_imports history.
     // row_count == 0 means the restore anchor is absent; silently bootstrapping the first
@@ -2777,7 +2783,7 @@ fn apply_reingest(
     }
 
     if let Some((page_id, _)) = current_page.as_ref() {
-        let prior_page = crate::commands::get::get_page_by_key(conn, collection_id, &parsed.slug)
+        let prior_page = crate::commands::get::get_page_by_id(conn, *page_id)
             .map_err(|err| ReconcileError::Other(format!("apply_reingest: {err}")))?;
         let edited_page = EditedPage {
             slug: parsed.slug.clone(),
@@ -2885,12 +2891,13 @@ fn apply_reingest(
     } else {
         tx.execute(
             "INSERT INTO pages
-                 (collection_id, slug, uuid, type, title, summary, compiled_truth, timeline,
-                   frontmatter, wing, room, version,
+                 (collection_id, namespace, slug, uuid, type, title, summary, compiled_truth,
+                  timeline, frontmatter, wing, room, version,
                   created_at, updated_at, truth_updated_at, timeline_updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, 1, ?12, ?12, ?12, ?12)",
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, 1, ?13, ?13, ?13, ?13)",
             rusqlite::params![
                 collection_id,
+                namespace,
                 parsed.slug,
                 page_uuid,
                 parsed.page_type,
@@ -2947,6 +2954,7 @@ fn load_existing_page_identity(
     conn: &Connection,
     collection_id: i64,
     preferred_page_id: Option<i64>,
+    namespace: &str,
     slug: &str,
 ) -> Result<Option<(i64, Option<String>)>, ReconcileError> {
     if let Some(page_id) = preferred_page_id {
@@ -2960,11 +2968,13 @@ fn load_existing_page_identity(
             .map_err(Into::into);
     }
 
+    // Exact namespace match: a file under `<ns>/extracted/...` must never
+    // bind to (or overwrite) a same-slug page in another namespace.
     conn.query_row(
         "SELECT id, uuid
          FROM pages
-         WHERE collection_id = ?1 AND slug = ?2",
-        rusqlite::params![collection_id, slug],
+         WHERE collection_id = ?1 AND namespace = ?2 AND slug = ?3",
+        rusqlite::params![collection_id, namespace, slug],
         |row| Ok((row.get(0)?, row.get(1)?)),
     )
     .optional()

--- a/src/mcp/errors.rs
+++ b/src/mcp/errors.rs
@@ -379,11 +379,23 @@ fn resolved_page_version(
     resolved: &vault_sync::ResolvedSlug,
 ) -> Result<Option<i64>, rmcp::Error> {
     use rusqlite::OptionalExtension;
+    // Close-action puts always write the global namespace, so the version
+    // readback pins namespace = '' explicitly.
+    let page_id = crate::core::pages::resolve_optional(
+        db,
+        &crate::core::pages::PageKey {
+            collection_id: resolved.collection_id,
+            namespace: Some(""),
+            slug: &resolved.slug,
+        },
+    )
+    .map_err(map_db_error)?;
+    let Some(page_id) = page_id else {
+        return Ok(None);
+    };
     db.query_row(
-        "SELECT version
-         FROM pages
-         WHERE collection_id = ?1 AND slug = ?2",
-        rusqlite::params![resolved.collection_id, &resolved.slug],
+        "SELECT version FROM pages WHERE id = ?1",
+        [page_id],
         |row| row.get(0),
     )
     .optional()

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -113,11 +113,15 @@ pub(crate) fn resolve_memory_collection_filter_for_mcp(
 pub(crate) fn page_id_for_resolved(
     db: &Connection,
     resolved: &vault_sync::ResolvedSlug,
+    namespace: Option<&str>,
 ) -> Result<i64, rmcp::Error> {
-    db.query_row(
-        "SELECT id FROM pages WHERE collection_id = ?1 AND slug = ?2",
-        rusqlite::params![resolved.collection_id, &resolved.slug],
-        |row| row.get(0),
+    crate::core::pages::resolve(
+        db,
+        &crate::core::pages::PageKey {
+            collection_id: resolved.collection_id,
+            namespace,
+            slug: &resolved.slug,
+        },
     )
     .map_err(|error| match error {
         rusqlite::Error::QueryReturnedNoRows => {
@@ -231,6 +235,9 @@ impl QuaidServer {
 pub struct MemoryGetInput {
     /// Page slug to retrieve
     pub slug: String,
+    /// Optional namespace to resolve in (named namespace falls back to
+    /// global memory); omitted resolves deterministically across namespaces
+    pub namespace: Option<String>,
 }
 
 /// Input schema for the `memory_put` MCP tool.
@@ -361,6 +368,9 @@ pub struct MemoryLinkInput {
     pub from_slug: String,
     /// Slug of the target page (the "to" end of the directed link).
     pub to_slug: String,
+    /// Optional namespace both endpoints resolve in (named namespace falls
+    /// back to global memory); omitted resolves deterministically
+    pub namespace: Option<String>,
     /// Relationship token classifying the link (e.g. `works_at`).
     pub relationship: String,
     /// Optional ISO-8601 lower bound for when the link is valid.
@@ -383,6 +393,9 @@ pub struct MemoryLinkCloseInput {
 pub struct MemoryBacklinksInput {
     /// Slug of the page whose inbound edges should be listed.
     pub slug: String,
+    /// Optional namespace to resolve in (named namespace falls back to
+    /// global memory); omitted resolves deterministically across namespaces
+    pub namespace: Option<String>,
     /// Maximum number of backlinks to return.
     pub limit: Option<u32>,
     /// Optional temporal filter (`active` or `all`); defaults to `active`.
@@ -394,6 +407,9 @@ pub struct MemoryBacklinksInput {
 pub struct MemoryGraphInput {
     /// Slug of the page to use as the graph root.
     pub slug: String,
+    /// Optional namespace to resolve in (named namespace falls back to
+    /// global memory); omitted resolves deterministically across namespaces
+    pub namespace: Option<String>,
     /// Optional traversal depth (clamped to `graph::MAX_DEPTH`).
     pub depth: Option<u32>,
     /// Optional temporal filter (`active` or `all`); defaults to `active`.
@@ -406,6 +422,9 @@ pub struct MemoryCheckInput {
     /// Optional slug restricting the check to a single page; omitted runs
     /// detection across every page.
     pub slug: Option<String>,
+    /// Optional namespace to resolve in (named namespace falls back to
+    /// global memory); omitted resolves deterministically across namespaces
+    pub namespace: Option<String>,
 }
 
 /// Input schema for the `memory_timeline` MCP tool.
@@ -413,6 +432,9 @@ pub struct MemoryCheckInput {
 pub struct MemoryTimelineInput {
     /// Slug of the page whose timeline entries should be returned.
     pub slug: String,
+    /// Optional namespace to resolve in (named namespace falls back to
+    /// global memory); omitted resolves deterministically across namespaces
+    pub namespace: Option<String>,
     /// Maximum number of entries to return.
     pub limit: Option<u32>,
 }
@@ -422,6 +444,9 @@ pub struct MemoryTimelineInput {
 pub struct MemoryTagsInput {
     /// Slug of the page whose tags should be listed or mutated.
     pub slug: String,
+    /// Optional namespace to resolve in (named namespace falls back to
+    /// global memory); omitted resolves deterministically across namespaces
+    pub namespace: Option<String>,
     /// Optional tag tokens to add (created if missing).
     pub add: Option<Vec<String>>,
     /// Optional tag tokens to remove.
@@ -477,6 +502,9 @@ pub struct MemoryNamespaceDestroyInput {
 pub struct MemoryRawInput {
     /// Page slug to attach raw data to
     pub slug: String,
+    /// Optional namespace to resolve in (named namespace falls back to
+    /// global memory); omitted resolves deterministically across namespaces
+    pub namespace: Option<String>,
     /// Source identifier (e.g. "crustdata", "exa", "meeting")
     pub source: String,
     /// Arbitrary JSON object to store (must be a JSON object, not array/scalar)
@@ -1486,6 +1514,7 @@ mod tests {
 
         server
             .memory_link(MemoryLinkInput {
+                namespace: None,
                 from_slug: "people/alice".to_string(),
                 to_slug: "companies/acme".to_string(),
                 relationship: "works_at".to_string(),
@@ -1538,6 +1567,7 @@ mod tests {
 
         server
             .memory_tags(MemoryTagsInput {
+                namespace: None,
                 slug: "memory::people/alice".to_string(),
                 add: Some(vec!["memory".to_string()]),
                 remove: None,
@@ -1604,6 +1634,7 @@ mod tests {
 
         let result = server
             .memory_timeline(MemoryTimelineInput {
+                namespace: None,
                 slug: "people/alice".to_string(),
                 limit: Some(1),
             })
@@ -2052,6 +2083,7 @@ mod tests {
 
         let result = server
             .memory_raw(MemoryRawInput {
+                namespace: None,
                 slug: "people/alice".to_string(),
                 source: "crustdata".to_string(),
                 data: json!({"funding": "$10M", "headcount": 50}),
@@ -2086,6 +2118,7 @@ mod tests {
 
         server
             .memory_raw(MemoryRawInput {
+                namespace: None,
                 slug: "people/alice".to_string(),
                 source: "crustdata".to_string(),
                 data: json!({"v": 1}),
@@ -2096,6 +2129,7 @@ mod tests {
         // Explicit overwrite must succeed and persist new data.
         server
             .memory_raw(MemoryRawInput {
+                namespace: None,
                 slug: "people/alice".to_string(),
                 source: "crustdata".to_string(),
                 data: json!({"v": 2}),
@@ -2134,6 +2168,7 @@ mod tests {
 
         let error = server
             .memory_raw(MemoryRawInput {
+                namespace: None,
                 slug: "people/alice".to_string(),
                 source: "crustdata".to_string(),
                 data: json!({"v": 1}),
@@ -2327,6 +2362,7 @@ mod tests {
 
         let error = server
             .memory_link(MemoryLinkInput {
+                namespace: None,
                 from_slug: "people/alice".to_string(),
                 to_slug: "companies/acme".to_string(),
                 relationship: "works_at".to_string(),
@@ -2367,6 +2403,7 @@ mod tests {
 
         let error = server
             .memory_link(MemoryLinkInput {
+                namespace: None,
                 from_slug: "people/bob".to_string(),
                 to_slug: "companies/initech".to_string(),
                 relationship: "works_at".to_string(),
@@ -2403,6 +2440,7 @@ mod tests {
 
         let error = server
             .memory_check(MemoryCheckInput {
+                namespace: None,
                 slug: Some("notes/check-restoring".to_string()),
             })
             .unwrap_err();
@@ -2434,6 +2472,7 @@ mod tests {
 
         let error = server
             .memory_check(MemoryCheckInput {
+                namespace: None,
                 slug: Some("notes/check-needs-sync".to_string()),
             })
             .unwrap_err();
@@ -2466,6 +2505,7 @@ mod tests {
 
         let error = server
             .memory_raw(MemoryRawInput {
+                namespace: None,
                 slug: "people/carol".to_string(),
                 source: "crustdata".to_string(),
                 data: json!({"v": 1}),

--- a/src/mcp/tools/assertions.rs
+++ b/src/mcp/tools/assertions.rs
@@ -41,12 +41,19 @@ impl QuaidServer {
             .map(|slug| resolve_slug_for_mcp(&db, slug, OpKind::WriteUpdate))
             .transpose()?;
 
+        crate::core::namespace::validate_optional_namespace(input.namespace.as_deref())
+            .map_err(crate::mcp::errors::map_namespace_error)?;
         let selected_page_id = if let Some(resolved) = slug_filter.as_ref() {
             vault_sync::ensure_collection_write_allowed(&db, resolved.collection_id)
                 .map_err(map_vault_sync_error)?;
-            let page_id = page_id_for_resolved(&db, resolved)?;
-            let page = get::get_page_by_key(&db, resolved.collection_id, &resolved.slug)
-                .map_err(map_anyhow_error)?;
+            let page_id = page_id_for_resolved(&db, resolved, input.namespace.as_deref())?;
+            let page = get::get_page_by_key_with_namespace(
+                &db,
+                resolved.collection_id,
+                &resolved.slug,
+                input.namespace.as_deref(),
+            )
+            .map_err(map_anyhow_error)?;
             crate::core::assertions::extract_assertions(&page, &db)
                 .map_err(|error| map_anyhow_error(error.into()))?;
             crate::core::assertions::check_assertions_for_page_id(page_id, &db)

--- a/src/mcp/tools/conversation.rs
+++ b/src/mcp/tools/conversation.rs
@@ -219,12 +219,21 @@ impl QuaidServer {
         )
         .map_err(|error| map_close_action_put_error(&db, &resolved, error))?;
 
+        // The put above wrote the global namespace; read the version back
+        // from exactly that row.
+        let page_id = crate::core::pages::resolve(
+            &db,
+            &crate::core::pages::PageKey {
+                collection_id: resolved.collection_id,
+                namespace: Some(""),
+                slug: &resolved.slug,
+            },
+        )
+        .map_err(map_db_error)?;
         let (updated_at, version): (String, i64) = db
             .query_row(
-                "SELECT updated_at, version
-                 FROM pages
-                 WHERE collection_id = ?1 AND slug = ?2",
-                rusqlite::params![resolved.collection_id, &resolved.slug],
+                "SELECT updated_at, version FROM pages WHERE id = ?1",
+                [page_id],
                 |row| Ok((row.get(0)?, row.get(1)?)),
             )
             .map_err(map_db_error)?;

--- a/src/mcp/tools/gaps.rs
+++ b/src/mcp/tools/gaps.rs
@@ -51,7 +51,7 @@ impl QuaidServer {
             let resolved = resolve_slug_for_mcp(&db, slug, OpKind::WriteUpdate)?;
             vault_sync::ensure_collection_write_allowed(&db, resolved.collection_id)
                 .map_err(map_vault_sync_error)?;
-            Some(page_id_for_resolved(&db, &resolved)?)
+            Some(page_id_for_resolved(&db, &resolved, None)?)
         } else {
             None
         };

--- a/src/mcp/tools/links.rs
+++ b/src/mcp/tools/links.rs
@@ -42,19 +42,22 @@ impl QuaidServer {
         if let Some(valid_until) = input.valid_until.as_deref() {
             validate_temporal_value(valid_until, "valid_until")?;
         }
+        crate::core::namespace::validate_optional_namespace(input.namespace.as_deref())
+            .map_err(crate::mcp::errors::map_namespace_error)?;
         let db = self.db().lock().unwrap_or_else(|e| e.into_inner());
         let from = resolve_slug_for_mcp(&db, &input.from_slug, OpKind::WriteUpdate)?;
         let to = resolve_slug_for_mcp(&db, &input.to_slug, OpKind::WriteUpdate)?;
         let from_slug = canonical_slug(&from.collection_name, &from.slug);
         let to_slug = canonical_slug(&to.collection_name, &to.slug);
 
-        link::run_silent(
+        link::run_silent_with_namespace(
             &db,
             &from_slug,
             &to_slug,
             &input.relationship,
             input.valid_from,
             input.valid_until,
+            input.namespace.as_deref(),
         )
         .map_err(map_anyhow_error)?;
 
@@ -101,8 +104,10 @@ impl QuaidServer {
         let filter = parse_temporal_filter(input.temporal.as_deref())?;
         let limit = input.limit.unwrap_or(100).min(MAX_LIMIT);
         let db = self.db().lock().unwrap_or_else(|e| e.into_inner());
+        crate::core::namespace::validate_optional_namespace(input.namespace.as_deref())
+            .map_err(crate::mcp::errors::map_namespace_error)?;
         let resolved = resolve_slug_for_mcp(&db, &input.slug, OpKind::Read)?;
-        let to_id = page_id_for_resolved(&db, &resolved)?;
+        let to_id = page_id_for_resolved(&db, &resolved, input.namespace.as_deref())?;
 
         #[derive(Serialize)]
         struct BacklinkRow {
@@ -167,8 +172,10 @@ impl QuaidServer {
 
         let depth = input.depth.unwrap_or(1).min(graph::MAX_DEPTH);
         let filter = parse_temporal_filter(input.temporal.as_deref())?;
+        crate::core::namespace::validate_optional_namespace(input.namespace.as_deref())
+            .map_err(crate::mcp::errors::map_namespace_error)?;
         let resolved = resolve_slug_for_mcp(&db, &input.slug, OpKind::Read)?;
-        let page_id = page_id_for_resolved(&db, &resolved)?;
+        let page_id = page_id_for_resolved(&db, &resolved, input.namespace.as_deref())?;
         let result = graph::neighborhood_graph_for_page(
             page_id,
             &resolved.collection_name,

--- a/src/mcp/tools/pages.rs
+++ b/src/mcp/tools/pages.rs
@@ -39,9 +39,26 @@ impl QuaidServer {
         #[tool(aggr)] input: MemoryGetInput,
     ) -> Result<CallToolResult, rmcp::Error> {
         validate_slug(&input.slug)?;
+        namespace::validate_optional_namespace(input.namespace.as_deref())
+            .map_err(map_namespace_error)?;
         let db = self.db().lock().unwrap_or_else(|e| e.into_inner());
         let resolved = resolve_slug_for_mcp(&db, &input.slug, OpKind::Read)?;
-        let page = vault_sync::get_page_by_input(&db, &input.slug).map_err(map_vault_sync_error)?;
+        let page = crate::commands::get::get_page_by_key_with_namespace(
+            &db,
+            resolved.collection_id,
+            &resolved.slug,
+            input.namespace.as_deref(),
+        )
+        .map_err(|err| {
+            let message = err.to_string();
+            if message.contains("page not found") {
+                map_vault_sync_error(vault_sync::VaultSyncError::PageNotFound {
+                    slug: input.slug.clone(),
+                })
+            } else {
+                map_anyhow_error(err)
+            }
+        })?;
         let canonical_page = canonicalize_page_for_mcp(&page, &resolved);
         let successor_slug = supersede::successor_slug_by_id(&db, canonical_page.superseded_by)
             .map_err(map_db_error)?;
@@ -279,12 +296,14 @@ impl QuaidServer {
             )));
         }
         let overwrite = input.overwrite.unwrap_or(false);
+        namespace::validate_optional_namespace(input.namespace.as_deref())
+            .map_err(map_namespace_error)?;
         let db = self.db().lock().unwrap_or_else(|e| e.into_inner());
         let resolved = resolve_slug_for_mcp(&db, &input.slug, OpKind::WriteUpdate)?;
         vault_sync::ensure_collection_write_allowed(&db, resolved.collection_id)
             .map_err(map_vault_sync_error)?;
 
-        let page_id = page_id_for_resolved(&db, &resolved)?;
+        let page_id = page_id_for_resolved(&db, &resolved, input.namespace.as_deref())?;
         let canonical_page_slug = canonical_slug(&resolved.collection_name, &resolved.slug);
 
         // Guard against silent replacement of existing source data.

--- a/src/mcp/tools/tags.rs
+++ b/src/mcp/tools/tags.rs
@@ -39,10 +39,17 @@ impl QuaidServer {
 
         let limit = input.limit.unwrap_or(20).min(MAX_LIMIT);
 
-        let page = get::get_page_by_key(&db, resolved.collection_id, &resolved.slug)
-            .map_err(map_anyhow_error)?;
+        crate::core::namespace::validate_optional_namespace(input.namespace.as_deref())
+            .map_err(crate::mcp::errors::map_namespace_error)?;
+        let page = get::get_page_by_key_with_namespace(
+            &db,
+            resolved.collection_id,
+            &resolved.slug,
+            input.namespace.as_deref(),
+        )
+        .map_err(map_anyhow_error)?;
 
-        let page_id = page_id_for_resolved(&db, &resolved)?;
+        let page_id = page_id_for_resolved(&db, &resolved, input.namespace.as_deref())?;
 
         // Query structured timeline_entries table
         let mut stmt = db
@@ -120,21 +127,25 @@ impl QuaidServer {
         let remove = input.remove.unwrap_or_default();
         validate_tag_list(&add, "add")?;
         validate_tag_list(&remove, "remove")?;
+        crate::core::namespace::validate_optional_namespace(input.namespace.as_deref())
+            .map_err(crate::mcp::errors::map_namespace_error)?;
         let resolved = resolve_slug_for_mcp(&db, &input.slug, OpKind::WriteUpdate)?;
         if !add.is_empty() || !remove.is_empty() {
             vault_sync::ensure_collection_write_allowed(&db, resolved.collection_id)
                 .map_err(map_vault_sync_error)?;
         }
-        let page_id: i64 = db
-            .query_row(
-                "SELECT id FROM pages WHERE collection_id = ?1 AND slug = ?2",
-                rusqlite::params![resolved.collection_id, &resolved.slug],
-                |row| row.get(0),
-            )
-            .map_err(|error| match error {
-                rusqlite::Error::QueryReturnedNoRows => page_not_found(&input.slug),
-                other => map_db_error(other),
-            })?;
+        let page_id: i64 = crate::core::pages::resolve(
+            &db,
+            &crate::core::pages::PageKey {
+                collection_id: resolved.collection_id,
+                namespace: input.namespace.as_deref(),
+                slug: &resolved.slug,
+            },
+        )
+        .map_err(|error| match error {
+            rusqlite::Error::QueryReturnedNoRows => page_not_found(&input.slug),
+            other => map_db_error(other),
+        })?;
 
         for tag in &add {
             db.execute(

--- a/tests/file_edit_supersede.rs
+++ b/tests/file_edit_supersede.rs
@@ -234,6 +234,7 @@ fn editing_chained_extracted_preference_preserves_one_linear_chain() {
     let graph: Value = serde_json::from_str(&extract_text(
         &server
             .memory_graph(MemoryGraphInput {
+                namespace: None,
                 slug: "preferences/foo".to_string(),
                 depth: Some(3),
                 temporal: Some("all".to_string()),

--- a/tests/mcp_namespace_matrix.rs
+++ b/tests/mcp_namespace_matrix.rs
@@ -1,0 +1,241 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::print_stdout,
+    reason = "test fixtures legitimately panic on setup failure and print diagnostics; per-site #[expect] would generate noise across thousands of test sites"
+)]
+
+//! Namespace matrix across the MCP tool surface: one slug exists in the
+//! global namespace and in two named namespaces, and every namespace-aware
+//! tool input must bind to the requested page deterministically. Pre-#212
+//! these tools were slug-only and bound to an arbitrary row.
+
+#[path = "common/mcp_harness.rs"]
+mod harness;
+use harness::{extract_text, open_test_db};
+use quaid::mcp::server::{
+    MemoryBacklinksInput, MemoryGetInput, MemoryGraphInput, MemoryLinkInput, MemoryPutInput,
+    MemoryRawInput, MemoryTagsInput, MemoryTimelineInput, QuaidServer,
+};
+use rusqlite::Connection;
+
+const SLUG: &str = "notes/shared";
+const TARGET_SLUG: &str = "notes/target";
+
+fn put(server: &QuaidServer, slug: &str, namespace: Option<&str>, marker: &str) {
+    server
+        .memory_put(MemoryPutInput {
+            slug: slug.to_string(),
+            content: format!(
+                "---\ntitle: {marker}\ntype: concept\n---\n{marker} body\n\n---\n\n2026-06-01: {marker} event\n"
+            ),
+            expected_version: None,
+            namespace: namespace.map(str::to_string),
+        })
+        .unwrap();
+}
+
+/// Returns the server plus a second connection to the same database file so
+/// assertions can inspect state without reaching into the server's private
+/// `db` handle.
+fn seeded_server() -> (tempfile::TempDir, QuaidServer, Connection) {
+    let (dir, conn) = open_test_db();
+    let verify = quaid::core::db::open(dir.path().join("server.db").to_str().unwrap()).unwrap();
+    let server = QuaidServer::new(conn);
+    for (namespace, marker) in [
+        (None, "global"),
+        (Some("ns-a"), "alpha"),
+        (Some("ns-b"), "bravo"),
+    ] {
+        put(&server, SLUG, namespace, marker);
+        put(&server, TARGET_SLUG, namespace, &format!("{marker}-target"));
+    }
+    (dir, server, verify)
+}
+
+fn page_id(verify: &Connection, namespace: &str, slug: &str) -> i64 {
+    verify
+        .query_row(
+            "SELECT id FROM pages WHERE namespace = ?1 AND slug = ?2",
+            rusqlite::params![namespace, slug],
+            |row| row.get(0),
+        )
+        .unwrap()
+}
+
+#[test]
+fn memory_get_resolves_requested_namespace_with_global_fallback() {
+    let (_dir, server, _verify) = seeded_server();
+
+    for (namespace, marker) in [
+        (Some("ns-a"), "alpha"),
+        (Some("ns-b"), "bravo"),
+        (Some(""), "global"),
+        (None, "global"),
+        // documented fallback: unknown namespace reads global memory
+        (Some("ns-c"), "global"),
+    ] {
+        let result = server
+            .memory_get(MemoryGetInput {
+                slug: SLUG.to_string(),
+                namespace: namespace.map(str::to_string),
+            })
+            .unwrap();
+        let payload: serde_json::Value = serde_json::from_str(&extract_text(&result)).unwrap();
+        assert_eq!(
+            payload["title"], *marker,
+            "namespace {namespace:?} must bind to the {marker} page"
+        );
+    }
+}
+
+#[test]
+fn memory_link_and_backlinks_bind_to_namespaced_endpoints() {
+    let (_dir, server, verify) = seeded_server();
+
+    server
+        .memory_link(MemoryLinkInput {
+            from_slug: SLUG.to_string(),
+            to_slug: TARGET_SLUG.to_string(),
+            namespace: Some("ns-a".to_string()),
+            relationship: "related".to_string(),
+            valid_from: None,
+            valid_until: None,
+        })
+        .unwrap();
+
+    let from_id = page_id(&verify, "ns-a", SLUG);
+    let to_id = page_id(&verify, "ns-a", TARGET_SLUG);
+    let (linked_from, linked_to): (i64, i64) = verify
+        .query_row(
+            "SELECT from_page_id, to_page_id FROM links WHERE relationship = 'related'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!((linked_from, linked_to), (from_id, to_id));
+
+    // Backlinks of the ns-a target see the link; the global target does not.
+    let ns_backlinks = server
+        .memory_backlinks(MemoryBacklinksInput {
+            slug: TARGET_SLUG.to_string(),
+            namespace: Some("ns-a".to_string()),
+            limit: None,
+            temporal: None,
+        })
+        .unwrap();
+    let rows: Vec<serde_json::Value> = serde_json::from_str(&extract_text(&ns_backlinks)).unwrap();
+    assert_eq!(rows.len(), 1, "ns-a target must list the inbound link");
+
+    let global_backlinks = server
+        .memory_backlinks(MemoryBacklinksInput {
+            slug: TARGET_SLUG.to_string(),
+            namespace: Some("".to_string()),
+            limit: None,
+            temporal: None,
+        })
+        .unwrap();
+    let rows: Vec<serde_json::Value> =
+        serde_json::from_str(&extract_text(&global_backlinks)).unwrap();
+    assert!(rows.is_empty(), "global target must have no backlinks");
+}
+
+#[test]
+fn memory_graph_roots_at_the_namespaced_page() {
+    let (_dir, server, _verify) = seeded_server();
+    server
+        .memory_link(MemoryLinkInput {
+            from_slug: SLUG.to_string(),
+            to_slug: TARGET_SLUG.to_string(),
+            namespace: Some("ns-b".to_string()),
+            relationship: "related".to_string(),
+            valid_from: None,
+            valid_until: None,
+        })
+        .unwrap();
+
+    let graph_ns = server
+        .memory_graph(MemoryGraphInput {
+            slug: SLUG.to_string(),
+            namespace: Some("ns-b".to_string()),
+            depth: Some(1),
+            temporal: None,
+        })
+        .unwrap();
+    let payload: serde_json::Value = serde_json::from_str(&extract_text(&graph_ns)).unwrap();
+    let edges = payload["edges"].as_array().unwrap();
+    assert_eq!(edges.len(), 1, "ns-b root must reach its ns-b neighbour");
+
+    let graph_global = server
+        .memory_graph(MemoryGraphInput {
+            slug: SLUG.to_string(),
+            namespace: Some("".to_string()),
+            depth: Some(1),
+            temporal: None,
+        })
+        .unwrap();
+    let payload: serde_json::Value = serde_json::from_str(&extract_text(&graph_global)).unwrap();
+    let edges = payload["edges"].as_array().unwrap();
+    assert!(edges.is_empty(), "global root has no outbound links");
+}
+
+#[test]
+fn memory_tags_and_raw_attach_to_the_namespaced_page() {
+    let (_dir, server, verify) = seeded_server();
+
+    server
+        .memory_tags(MemoryTagsInput {
+            slug: SLUG.to_string(),
+            namespace: Some("ns-a".to_string()),
+            add: Some(vec!["scoped".to_string()]),
+            remove: None,
+        })
+        .unwrap();
+    server
+        .memory_raw(MemoryRawInput {
+            slug: SLUG.to_string(),
+            namespace: Some("ns-a".to_string()),
+            source: "matrix-test".to_string(),
+            data: serde_json::json!({"k": "v"}),
+            overwrite: None,
+        })
+        .unwrap();
+
+    let ns_a_id = page_id(&verify, "ns-a", SLUG);
+    let tagged: i64 = verify
+        .query_row("SELECT page_id FROM tags WHERE tag = 'scoped'", [], |row| {
+            row.get(0)
+        })
+        .unwrap();
+    let raw_bound: i64 = verify
+        .query_row(
+            "SELECT page_id FROM raw_data WHERE source = 'matrix-test'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(tagged, ns_a_id, "tag must attach to the ns-a page");
+    assert_eq!(raw_bound, ns_a_id, "raw data must attach to the ns-a page");
+}
+
+#[test]
+fn memory_timeline_reads_the_namespaced_page_timeline() {
+    let (_dir, server, _verify) = seeded_server();
+
+    let result = server
+        .memory_timeline(MemoryTimelineInput {
+            slug: SLUG.to_string(),
+            namespace: Some("ns-b".to_string()),
+            limit: None,
+        })
+        .unwrap();
+    let payload: serde_json::Value = serde_json::from_str(&extract_text(&result)).unwrap();
+    let entries = payload["entries"].as_array().unwrap();
+    assert!(
+        entries
+            .iter()
+            .any(|entry| entry.as_str().unwrap_or_default().contains("bravo event")),
+        "timeline must come from the ns-b page, got {entries:?}"
+    );
+}

--- a/tests/mcp_server_check_timeline_tags.rs
+++ b/tests/mcp_server_check_timeline_tags.rs
@@ -32,6 +32,7 @@ fn memory_check_on_clean_page_returns_empty_array() {
 
     let result = server
         .memory_check(MemoryCheckInput {
+            namespace: None,
             slug: Some("people/alice".to_string()),
         })
         .unwrap();
@@ -53,6 +54,7 @@ fn memory_check_detects_contradiction_on_page() {
 
     let result = server
         .memory_check(MemoryCheckInput {
+            namespace: None,
             slug: Some("people/alice".to_string()),
         })
         .unwrap();
@@ -79,12 +81,14 @@ fn memory_check_filters_output_to_requested_slug() {
 
     server
         .memory_check(MemoryCheckInput {
+            namespace: None,
             slug: Some("people/bob".to_string()),
         })
         .unwrap();
 
     let result = server
         .memory_check(MemoryCheckInput {
+            namespace: None,
             slug: Some("people/alice".to_string()),
         })
         .unwrap();
@@ -117,12 +121,14 @@ fn memory_check_explicit_collection_slug_filters_to_resolved_page_when_slug_coll
 
     server
         .memory_check(MemoryCheckInput {
+            namespace: None,
             slug: Some("default::people/alice".to_string()),
         })
         .unwrap();
 
     let result = server
         .memory_check(MemoryCheckInput {
+            namespace: None,
             slug: Some("memory::people/alice".to_string()),
         })
         .unwrap();
@@ -147,7 +153,10 @@ fn memory_check_without_slug_returns_all_unresolved_contradictions() {
     );
 
     let result = server
-        .memory_check(MemoryCheckInput { slug: None })
+        .memory_check(MemoryCheckInput {
+            namespace: None,
+            slug: None,
+        })
         .unwrap();
 
     let parsed: Vec<serde_json::Value> = serde_json::from_str(&extract_text(&result)).unwrap();
@@ -161,6 +170,7 @@ fn memory_timeline_on_unknown_slug_returns_not_found() {
 
     let error = server
         .memory_timeline(MemoryTimelineInput {
+            namespace: None,
             slug: "nobody/ghost".to_string(),
             limit: None,
         })
@@ -181,6 +191,7 @@ fn memory_timeline_returns_entries_for_page_with_timeline() {
 
     let result = server
         .memory_timeline(MemoryTimelineInput {
+            namespace: None,
             slug: "people/alice".to_string(),
             limit: Some(10),
         })
@@ -203,6 +214,7 @@ fn memory_timeline_returns_empty_entries_for_page_without_timeline_data() {
 
     let result = server
         .memory_timeline(MemoryTimelineInput {
+            namespace: None,
             slug: "people/alice".to_string(),
             limit: None,
         })
@@ -225,6 +237,7 @@ fn memory_tags_list_add_remove_round_trip() {
     // List tags — should be empty
     let result = server
         .memory_tags(MemoryTagsInput {
+            namespace: None,
             slug: "people/alice".to_string(),
             add: None,
             remove: None,
@@ -237,6 +250,7 @@ fn memory_tags_list_add_remove_round_trip() {
     // Add tags
     let result = server
         .memory_tags(MemoryTagsInput {
+            namespace: None,
             slug: "people/alice".to_string(),
             add: Some(vec!["investor".to_string(), "founder".to_string()]),
             remove: None,
@@ -249,6 +263,7 @@ fn memory_tags_list_add_remove_round_trip() {
     // Remove a tag
     let result = server
         .memory_tags(MemoryTagsInput {
+            namespace: None,
             slug: "people/alice".to_string(),
             add: None,
             remove: Some(vec!["investor".to_string()]),
@@ -266,6 +281,7 @@ fn memory_tags_unknown_slug_returns_not_found() {
 
     let error = server
         .memory_tags(MemoryTagsInput {
+            namespace: None,
             slug: "nobody/ghost".to_string(),
             add: Some(vec!["tag".to_string()]),
             remove: None,
@@ -287,6 +303,7 @@ fn memory_tags_rejects_invalid_tag_values() {
 
     let error = server
         .memory_tags(MemoryTagsInput {
+            namespace: None,
             slug: "people/alice".to_string(),
             add: Some(vec!["bad tag".to_string()]),
             remove: None,

--- a/tests/mcp_server_gap_stats.rs
+++ b/tests/mcp_server_gap_stats.rs
@@ -248,6 +248,7 @@ fn memory_raw_with_unknown_slug_returns_not_found() {
 
     let error = server
         .memory_raw(MemoryRawInput {
+            namespace: None,
             slug: "nobody/ghost".to_string(),
             source: "test".to_string(),
             data: json!({"key": "value"}),
@@ -270,6 +271,7 @@ fn memory_raw_rejects_empty_source() {
 
     let error = server
         .memory_raw(MemoryRawInput {
+            namespace: None,
             slug: "people/alice".to_string(),
             source: "".to_string(),
             data: json!({}),
@@ -287,6 +289,7 @@ fn memory_raw_rejects_invalid_slug() {
 
     let error = server
         .memory_raw(MemoryRawInput {
+            namespace: None,
             slug: "Invalid/SLUG!".to_string(),
             source: "test".to_string(),
             data: json!({}),
@@ -309,6 +312,7 @@ fn memory_raw_rejects_array_payload() {
 
     let error = server
         .memory_raw(MemoryRawInput {
+            namespace: None,
             slug: "people/alice".to_string(),
             source: "crustdata".to_string(),
             data: json!([1, 2, 3]),
@@ -333,6 +337,7 @@ fn memory_raw_rejects_scalar_payload() {
     for bad in [json!("string"), json!(42), json!(true), json!(null)] {
         let error = server
             .memory_raw(MemoryRawInput {
+                namespace: None,
                 slug: "people/alice".to_string(),
                 source: "crustdata".to_string(),
                 data: bad,
@@ -355,6 +360,7 @@ fn memory_raw_rejects_duplicate_source_without_overwrite() {
 
     server
         .memory_raw(MemoryRawInput {
+            namespace: None,
             slug: "people/alice".to_string(),
             source: "crustdata".to_string(),
             data: json!({"v": 1}),
@@ -365,6 +371,7 @@ fn memory_raw_rejects_duplicate_source_without_overwrite() {
     // Second write without overwrite must fail.
     let error = server
         .memory_raw(MemoryRawInput {
+            namespace: None,
             slug: "people/alice".to_string(),
             source: "crustdata".to_string(),
             data: json!({"v": 2}),

--- a/tests/mcp_server_get_put.rs
+++ b/tests/mcp_server_get_put.rs
@@ -29,6 +29,7 @@ fn memory_get_returns_not_found_error_code_for_missing_slug() {
 
     let error = server
         .memory_get(MemoryGetInput {
+            namespace: None,
             slug: "definitely-does-not-exist".to_string(),
         })
         .unwrap_err();
@@ -43,6 +44,7 @@ fn memory_get_rejects_invalid_slug() {
 
     let error = server
         .memory_get(MemoryGetInput {
+            namespace: None,
             slug: "Invalid/SLUG!".to_string(),
         })
         .unwrap_err();
@@ -69,6 +71,7 @@ fn memory_get_returns_structured_ambiguity_payload_for_colliding_bare_slug() {
 
     let error = server
         .memory_get(MemoryGetInput {
+            namespace: None,
             slug: "people/alice".to_string(),
         })
         .unwrap_err();
@@ -111,6 +114,7 @@ fn memory_get_explicit_collection_slug_reads_resolved_page_when_slug_collides() 
 
     let result = server
         .memory_get(MemoryGetInput {
+            namespace: None,
             slug: "memory::people/alice".to_string(),
         })
         .unwrap();
@@ -144,6 +148,7 @@ fn memory_get_renders_persisted_memory_id_after_update_omits_frontmatter_uuid() 
 
     let result = server
         .memory_get(MemoryGetInput {
+            namespace: None,
             slug: "notes/uuid".to_string(),
         })
         .unwrap();

--- a/tests/mcp_server_link_graph.rs
+++ b/tests/mcp_server_link_graph.rs
@@ -32,6 +32,7 @@ fn memory_link_with_unknown_from_slug_returns_not_found() {
 
     let error = server
         .memory_link(MemoryLinkInput {
+            namespace: None,
             from_slug: "people/ghost".to_string(),
             to_slug: "companies/acme".to_string(),
             relationship: "works_at".to_string(),
@@ -60,6 +61,7 @@ fn memory_link_creates_link_between_existing_pages() {
 
     let result = server
         .memory_link(MemoryLinkInput {
+            namespace: None,
             from_slug: "people/alice".to_string(),
             to_slug: "companies/acme".to_string(),
             relationship: "works_at".to_string(),
@@ -91,6 +93,7 @@ fn memory_link_rejects_invalid_relationship() {
 
     let error = server
         .memory_link(MemoryLinkInput {
+            namespace: None,
             from_slug: "people/alice".to_string(),
             to_slug: "companies/acme".to_string(),
             relationship: "works at".to_string(),
@@ -149,6 +152,7 @@ fn memory_backlinks_returns_link_array() {
 
     server
         .memory_link(MemoryLinkInput {
+            namespace: None,
             from_slug: "people/alice".to_string(),
             to_slug: "companies/acme".to_string(),
             relationship: "works_at".to_string(),
@@ -159,6 +163,7 @@ fn memory_backlinks_returns_link_array() {
 
     let result = server
         .memory_backlinks(MemoryBacklinksInput {
+            namespace: None,
             slug: "companies/acme".to_string(),
             limit: None,
             temporal: None,
@@ -180,6 +185,7 @@ fn memory_backlinks_unknown_slug_returns_not_found() {
 
     let error = server
         .memory_backlinks(MemoryBacklinksInput {
+            namespace: None,
             slug: "nobody/ghost".to_string(),
             limit: None,
             temporal: None,
@@ -207,6 +213,7 @@ fn memory_backlinks_applies_limit() {
         );
         server
             .memory_link(MemoryLinkInput {
+                namespace: None,
                 from_slug: slug.to_string(),
                 to_slug: "companies/acme".to_string(),
                 relationship: "works_at".to_string(),
@@ -218,6 +225,7 @@ fn memory_backlinks_applies_limit() {
 
     let result = server
         .memory_backlinks(MemoryBacklinksInput {
+            namespace: None,
             slug: "companies/acme".to_string(),
             limit: Some(2),
             temporal: None,
@@ -246,6 +254,7 @@ fn memory_backlinks_temporal_all_includes_closed_links() {
 
     server
         .memory_link(MemoryLinkInput {
+            namespace: None,
             from_slug: "people/alice".to_string(),
             to_slug: "companies/acme".to_string(),
             relationship: "works_at".to_string(),
@@ -256,6 +265,7 @@ fn memory_backlinks_temporal_all_includes_closed_links() {
 
     let result = server
         .memory_backlinks(MemoryBacklinksInput {
+            namespace: None,
             slug: "companies/acme".to_string(),
             limit: None,
             temporal: Some("all".to_string()),
@@ -273,6 +283,7 @@ fn memory_backlinks_rejects_invalid_temporal_filter() {
 
     let error = server
         .memory_backlinks(MemoryBacklinksInput {
+            namespace: None,
             slug: "people/alice".to_string(),
             limit: None,
             temporal: Some("future".to_string()),
@@ -299,6 +310,7 @@ fn memory_graph_returns_nodes_and_edges_json() {
 
     server
         .memory_link(MemoryLinkInput {
+            namespace: None,
             from_slug: "people/alice".to_string(),
             to_slug: "companies/acme".to_string(),
             relationship: "works_at".to_string(),
@@ -309,6 +321,7 @@ fn memory_graph_returns_nodes_and_edges_json() {
 
     let result = server
         .memory_graph(MemoryGraphInput {
+            namespace: None,
             slug: "people/alice".to_string(),
             depth: Some(2),
             temporal: None,
@@ -337,6 +350,7 @@ fn memory_graph_unknown_slug_returns_not_found() {
 
     let error = server
         .memory_graph(MemoryGraphInput {
+            namespace: None,
             slug: "people/ghost".to_string(),
             depth: None,
             temporal: None,
@@ -363,6 +377,7 @@ fn memory_graph_temporal_all_includes_closed_links() {
 
     server
         .memory_link(MemoryLinkInput {
+            namespace: None,
             from_slug: "people/alice".to_string(),
             to_slug: "companies/acme".to_string(),
             relationship: "works_at".to_string(),
@@ -373,6 +388,7 @@ fn memory_graph_temporal_all_includes_closed_links() {
 
     let result = server
         .memory_graph(MemoryGraphInput {
+            namespace: None,
             slug: "people/alice".to_string(),
             depth: None,
             temporal: Some("all".to_string()),

--- a/tests/mcp_server_query_search_list.rs
+++ b/tests/mcp_server_query_search_list.rs
@@ -41,6 +41,7 @@ fn memory_query_auto_depth_expands_linked_results() {
     );
     server
         .memory_link(MemoryLinkInput {
+            namespace: None,
             from_slug: "concepts/root".to_string(),
             to_slug: "concepts/child".to_string(),
             relationship: "related".to_string(),
@@ -89,6 +90,7 @@ fn memory_query_auto_depth_does_not_expand_across_collections() {
     // Cross-collection link: default::concepts/anchor -> work::concepts/outside
     server
         .memory_link(MemoryLinkInput {
+            namespace: None,
             from_slug: "default::concepts/anchor".to_string(),
             to_slug: "work::concepts/outside".to_string(),
             relationship: "related".to_string(),

--- a/tests/memory_correct.rs
+++ b/tests/memory_correct.rs
@@ -87,6 +87,7 @@ impl Harness {
         let result = self
             .server
             .memory_get(MemoryGetInput {
+                namespace: None,
                 slug: slug.to_string(),
             })
             .unwrap();

--- a/tests/namespace_page_identity.rs
+++ b/tests/namespace_page_identity.rs
@@ -1,0 +1,204 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::print_stdout,
+    reason = "test fixtures legitimately panic on setup failure and print diagnostics; per-site #[expect] would generate noise across thousands of test sites"
+)]
+
+//! Namespace matrix tests for `core::pages::resolve` — the single sanctioned
+//! `(collection, namespace, slug)` → page-id lookup. One slug is written to
+//! the global namespace and to two named namespaces; every filter shape must
+//! resolve deterministically. These tests lock the semantics BEFORE call
+//! sites migrate onto `resolve`, so any drift in the fallback ordering is a
+//! test failure rather than a silent behaviour change.
+
+use std::path::Path;
+
+use quaid::commands::put;
+use quaid::core::db;
+use quaid::core::pages::{self, PageKey};
+use rusqlite::Connection;
+
+const SLUG: &str = "notes/shared-slug";
+
+fn open_seeded_db() -> Connection {
+    let conn = db::open(":memory:").expect("open db");
+    for (namespace, marker) in [
+        (Some("ns-b"), "bravo"),
+        (Some("ns-a"), "alpha"),
+        (None, "global"),
+    ] {
+        let content =
+            format!("---\ntitle: Shared {marker}\ntype: concept\n---\n{marker} body content\n");
+        put::put_from_string_with_namespace(&conn, SLUG, &content, namespace, None)
+            .expect("seed page");
+    }
+    conn
+}
+
+fn page_id_for_namespace(conn: &Connection, namespace: &str) -> i64 {
+    conn.query_row(
+        "SELECT id FROM pages WHERE namespace = ?1 AND slug = ?2",
+        rusqlite::params![namespace, SLUG],
+        |row| row.get(0),
+    )
+    .expect("seeded page id")
+}
+
+#[test]
+fn resolve_exact_global_namespace_matches_global_row_only() {
+    let conn = open_seeded_db();
+    let global_id = page_id_for_namespace(&conn, "");
+
+    let resolved = pages::resolve(
+        &conn,
+        &PageKey {
+            collection_id: 1,
+            namespace: Some(""),
+            slug: SLUG,
+        },
+    )
+    .expect("resolve global");
+    assert_eq!(resolved, global_id);
+}
+
+#[test]
+fn resolve_named_namespace_prefers_namespace_row_over_global() {
+    let conn = open_seeded_db();
+    let ns_a_id = page_id_for_namespace(&conn, "ns-a");
+    let ns_b_id = page_id_for_namespace(&conn, "ns-b");
+
+    for (namespace, expected) in [("ns-a", ns_a_id), ("ns-b", ns_b_id)] {
+        let resolved = pages::resolve(
+            &conn,
+            &PageKey {
+                collection_id: 1,
+                namespace: Some(namespace),
+                slug: SLUG,
+            },
+        )
+        .expect("resolve namespaced");
+        assert_eq!(resolved, expected, "namespace {namespace} must win");
+    }
+}
+
+#[test]
+fn resolve_named_namespace_falls_back_to_global_but_never_other_namespaces() {
+    let conn = open_seeded_db();
+    let global_id = page_id_for_namespace(&conn, "");
+
+    // ns-c has no row of its own: documented fallback goes to global.
+    let resolved = pages::resolve(
+        &conn,
+        &PageKey {
+            collection_id: 1,
+            namespace: Some("ns-c"),
+            slug: SLUG,
+        },
+    )
+    .expect("resolve with global fallback");
+    assert_eq!(resolved, global_id);
+
+    // Remove the global row: ns-c must NOT see ns-a/ns-b rows.
+    conn.execute(
+        "DELETE FROM pages WHERE namespace = '' AND slug = ?1",
+        [SLUG],
+    )
+    .expect("delete global row");
+    let resolved = pages::resolve_optional(
+        &conn,
+        &PageKey {
+            collection_id: 1,
+            namespace: Some("ns-c"),
+            slug: SLUG,
+        },
+    )
+    .expect("resolve_optional");
+    assert_eq!(resolved, None, "other namespaces must never leak");
+}
+
+#[test]
+fn resolve_unfiltered_prefers_global_then_lexicographic_namespace() {
+    let conn = open_seeded_db();
+    let global_id = page_id_for_namespace(&conn, "");
+    let ns_a_id = page_id_for_namespace(&conn, "ns-a");
+
+    let resolved = pages::resolve(
+        &conn,
+        &PageKey {
+            collection_id: 1,
+            namespace: None,
+            slug: SLUG,
+        },
+    )
+    .expect("resolve unfiltered");
+    assert_eq!(resolved, global_id, "global row wins when present");
+
+    conn.execute(
+        "DELETE FROM pages WHERE namespace = '' AND slug = ?1",
+        [SLUG],
+    )
+    .expect("delete global row");
+    let resolved = pages::resolve(
+        &conn,
+        &PageKey {
+            collection_id: 1,
+            namespace: None,
+            slug: SLUG,
+        },
+    )
+    .expect("resolve unfiltered without global");
+    assert_eq!(
+        resolved, ns_a_id,
+        "lexicographically smallest namespace breaks the tie deterministically"
+    );
+}
+
+#[test]
+fn resolve_missing_slug_returns_no_rows_and_resolve_optional_returns_none() {
+    let conn = open_seeded_db();
+    let missing = PageKey {
+        collection_id: 1,
+        namespace: None,
+        slug: "notes/does-not-exist",
+    };
+    assert!(matches!(
+        pages::resolve(&conn, &missing),
+        Err(rusqlite::Error::QueryReturnedNoRows)
+    ));
+    assert_eq!(pages::resolve_optional(&conn, &missing).unwrap(), None);
+}
+
+#[test]
+fn resolve_is_collection_scoped() {
+    let conn = open_seeded_db();
+    let missing = PageKey {
+        collection_id: 999,
+        namespace: None,
+        slug: SLUG,
+    };
+    assert_eq!(pages::resolve_optional(&conn, &missing).unwrap(), None);
+}
+
+#[test]
+fn derive_namespace_from_relative_path_matches_extraction_tree_layout() {
+    for (path, expected) in [
+        ("extracted/decisions/foo-ab12.md", ""),
+        ("ns-a/extracted/decisions/foo-ab12.md", "ns-a"),
+        (
+            "session.2026/extracted/preferences/editor-1f00.md",
+            "session.2026",
+        ),
+        ("people/alice.md", ""),
+        ("projects/extracted-notes/alpha.md", ""),
+        // Invalid namespace ids are treated as plain directories.
+        ("bad ns/extracted/decisions/foo.md", ""),
+    ] {
+        assert_eq!(
+            pages::derive_namespace_from_relative_path(Path::new(path)),
+            expected,
+            "path {path}"
+        );
+    }
+}

--- a/tests/namespace_reingest.rs
+++ b/tests/namespace_reingest.rs
@@ -1,0 +1,256 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::print_stdout,
+    reason = "test fixtures legitimately panic on setup failure and print diagnostics; per-site #[expect] would generate noise across thousands of test sites"
+)]
+
+//! Watcher-reingest and open-time backfill coverage for namespace-aware page
+//! identity (issue #212): files under `<ns>/extracted/...` must land in
+//! namespace `<ns>`, never overwrite same-slug pages in other namespaces,
+//! and become visible to the supersede head partition
+//! (`head_candidates` filters `namespace = ?2`).
+
+#[path = "common/reconciler_fixtures.rs"]
+mod common_reconciler_fixtures;
+
+use common_reconciler_fixtures::*;
+use quaid::core::conversation::supersede::{
+    resolve_in_scope_with_similarity, write_fact_in_context, FactWriteContext, Resolution,
+};
+use quaid::core::file_state::{self, FileStat};
+use quaid::core::reconciler::reconcile;
+use quaid::core::types::RawFact;
+use rusqlite::{params, Connection, OptionalExtension};
+use std::fs;
+use std::path::Path;
+use tempfile::TempDir;
+
+fn page_row(conn: &Connection, namespace: &str, slug: &str) -> Option<(i64, String, i64)> {
+    conn.query_row(
+        "SELECT id, compiled_truth, version FROM pages WHERE namespace = ?1 AND slug = ?2",
+        params![namespace, slug],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+    )
+    .optional()
+    .unwrap()
+}
+
+fn preference_fact(summary: &str) -> RawFact {
+    RawFact::Preference {
+        about: "programming-language".to_string(),
+        strength: None,
+        summary: summary.to_string(),
+    }
+}
+
+fn write_context(collection_id: i64, root: &Path, namespace: &str) -> FactWriteContext {
+    FactWriteContext {
+        collection_id,
+        root_path: root.to_path_buf(),
+        namespace: namespace.to_string(),
+        session_id: "session-1".to_string(),
+        source_turns: vec!["1".to_string()],
+        extracted_at: "2026-06-01T09:00:00Z".to_string(),
+        extracted_by: "phi-3.5-mini".to_string(),
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn reingest_assigns_namespace_from_extracted_path_and_isolates_other_namespaces() {
+    let conn = open_test_db();
+    let root = TempDir::new().unwrap();
+    let collection = insert_collection(&conn, root.path());
+
+    // Established post-fix state: a same-slug fact already lives in ns-b.
+    let ns_b_relative = "ns-b/extracted/preferences/lang-pref.md";
+    let ns_b_body = "---\nslug: lang-pref\ntitle: lang-pref\ntype: preference\nkind: preference\nabout: programming-language\n---\nPrefers Go.\n";
+    fs::create_dir_all(root.path().join("ns-b/extracted/preferences")).unwrap();
+    fs::write(root.path().join(ns_b_relative), ns_b_body).unwrap();
+    let ns_b_stat = stat_for(root.path(), ns_b_relative);
+    let ns_b_sha = file_state::hash_file(&root.path().join(ns_b_relative)).unwrap();
+    let ns_b_page_id = seed_page_with_identity(
+        &conn,
+        collection.id,
+        SeededPageIdentity {
+            slug: "lang-pref",
+            uuid: "01969f11-9448-7d79-8d3f-c68f54761234",
+            relative_path: ns_b_relative,
+            stat: &ns_b_stat,
+            sha256: &ns_b_sha,
+            compiled_truth: "Prefers Go.",
+            timeline: "",
+        },
+    );
+    conn.execute(
+        "UPDATE pages SET namespace = 'ns-b', type = 'preference' WHERE id = ?1",
+        [ns_b_page_id],
+    )
+    .unwrap();
+
+    // The watcher discovers a brand-new fact file in ns-a with the SAME slug.
+    let ns_a_relative = "ns-a/extracted/preferences/lang-pref.md";
+    let ns_a_body = "---\nslug: lang-pref\ntitle: lang-pref\ntype: preference\nkind: preference\nabout: programming-language\n---\nPrefers Rust.\n";
+    fs::create_dir_all(root.path().join("ns-a/extracted/preferences")).unwrap();
+    fs::write(root.path().join(ns_a_relative), ns_a_body).unwrap();
+
+    reconcile(&conn, &collection).unwrap();
+
+    let (_, ns_a_truth, _) =
+        page_row(&conn, "ns-a", "lang-pref").expect("ns-a fact page must be created");
+    assert!(
+        ns_a_truth.contains("Prefers Rust."),
+        "ns-a page must carry the ns-a file body, got: {ns_a_truth}"
+    );
+
+    let (ns_b_id_after, ns_b_truth, ns_b_version) =
+        page_row(&conn, "ns-b", "lang-pref").expect("ns-b page must survive");
+    assert_eq!(ns_b_id_after, ns_b_page_id, "ns-b page row must be intact");
+    assert_eq!(
+        ns_b_truth, "Prefers Go.",
+        "ns-b page content must not be overwritten by the ns-a file"
+    );
+    assert_eq!(ns_b_version, 1, "ns-b page must not be version-bumped");
+
+    assert_eq!(
+        page_row(&conn, "", "lang-pref"),
+        None,
+        "no global-namespace row may be fabricated for a namespaced file"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn head_candidates_find_prior_head_after_watcher_ingest_of_namespaced_fact() {
+    let conn = open_test_db();
+    let root = TempDir::new().unwrap();
+    let collection = insert_collection(&conn, root.path());
+    let context = write_context(collection.id, root.path(), "ns-a");
+    let similarity = |_: &str, _: &str| Ok(0.5_f64);
+
+    // First fact: empty head partition -> Coexist, file written to
+    // ns-a/extracted/... and ingested by the watcher.
+    let first = preference_fact("Prefers Rust for systems work.");
+    let resolution =
+        resolve_in_scope_with_similarity(&first, &conn, collection.id, "ns-a", similarity).unwrap();
+    assert!(matches!(resolution, Resolution::Coexist));
+    let written = write_fact_in_context(&resolution, &first, &conn, &context).unwrap();
+    let first_slug = written.slug.expect("coexist write allocates a slug");
+    let relative_path = written.relative_path.expect("coexist write emits a file");
+    assert!(
+        relative_path.starts_with("ns-a/extracted/"),
+        "fact file must live under the namespace prefix, got {relative_path}"
+    );
+
+    reconcile(&conn, &collection).unwrap();
+
+    let (_, _, _) = page_row(&conn, "ns-a", &first_slug)
+        .expect("watcher-ingested fact page must land in namespace ns-a (issue #212)");
+
+    // Second fact in the same (kind, key) partition: the prior head MUST be
+    // found. Pre-fix, the page row sat in '' so head_candidates (namespace =
+    // ?2) saw nothing and resolution stayed Coexist forever, accumulating
+    // duplicates.
+    let second = preference_fact("Prefers Zig now.");
+    let resolution =
+        resolve_in_scope_with_similarity(&second, &conn, collection.id, "ns-a", similarity)
+            .unwrap();
+    match resolution {
+        Resolution::Supersede { prior_slug, .. } => assert_eq!(prior_slug, first_slug),
+        other => panic!("expected Supersede of the watcher-ingested head, got {other:?}"),
+    }
+
+    // Other namespaces stay isolated: their partitions are still empty.
+    let elsewhere =
+        resolve_in_scope_with_similarity(&second, &conn, collection.id, "ns-other", similarity)
+            .unwrap();
+    assert!(matches!(elsewhere, Resolution::Coexist));
+}
+
+fn seed_pre_fix_page(
+    conn: &Connection,
+    namespace: &str,
+    slug: &str,
+    relative_path: Option<&str>,
+) -> i64 {
+    conn.execute(
+        "INSERT INTO pages (collection_id, namespace, slug, uuid, type, title, compiled_truth)
+         VALUES (1, ?1, ?2, ?3, 'preference', ?2, 'body')",
+        params![namespace, slug, format!("uuid-{namespace}-{slug}")],
+    )
+    .unwrap();
+    let page_id = conn.last_insert_rowid();
+    if let Some(relative_path) = relative_path {
+        let stat = FileStat {
+            mtime_ns: 1,
+            ctime_ns: Some(1),
+            size_bytes: 4,
+            inode: Some(page_id),
+        };
+        file_state::upsert_file_state(conn, 1, relative_path, page_id, &stat, "deadbeef").unwrap();
+    }
+    page_id
+}
+
+#[test]
+fn open_time_backfill_rehomes_pre_fix_rows_from_file_state_paths() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("memory.db");
+    let conn = quaid::core::db::open(db_path.to_str().unwrap()).unwrap();
+
+    // Pre-fix shape: watcher-ingested namespaced facts sat in namespace ''.
+    let rehomed = seed_pre_fix_page(
+        &conn,
+        "",
+        "pref-a",
+        Some("ns-a/extracted/preferences/pref-a.md"),
+    );
+    // Conflict shape: the ns-b target slot is already occupied.
+    let conflicted = seed_pre_fix_page(
+        &conn,
+        "",
+        "pref-b",
+        Some("ns-b/extracted/preferences/pref-b.md"),
+    );
+    let occupant = seed_pre_fix_page(&conn, "ns-b", "pref-b", None);
+    // Plain vault page: no namespace prefix, must stay global.
+    let global = seed_pre_fix_page(&conn, "", "global-note", Some("notes/global-note.md"));
+    drop(conn);
+
+    let conn = quaid::core::db::open(db_path.to_str().unwrap()).unwrap();
+    let namespace_of = |page_id: i64| -> String {
+        conn.query_row(
+            "SELECT namespace FROM pages WHERE id = ?1",
+            [page_id],
+            |row| row.get(0),
+        )
+        .unwrap()
+    };
+
+    assert_eq!(
+        namespace_of(rehomed),
+        "ns-a",
+        "pre-fix row with a namespaced file_state path must be re-homed"
+    );
+    assert_eq!(
+        namespace_of(conflicted),
+        "",
+        "rows whose target slot is occupied are skipped, not clobbered"
+    );
+    assert_eq!(namespace_of(occupant), "ns-b");
+    assert_eq!(namespace_of(global), "");
+
+    // Idempotent: a third open changes nothing.
+    drop(conn);
+    let conn = quaid::core::db::open(db_path.to_str().unwrap()).unwrap();
+    let count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM pages WHERE namespace = 'ns-a'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(count, 1);
+}

--- a/tests/namespace_source_audit.rs
+++ b/tests/namespace_source_audit.rs
@@ -1,0 +1,178 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::print_stdout,
+    reason = "test fixtures legitimately panic on setup failure and print diagnostics; per-site #[expect] would generate noise across thousands of test sites"
+)]
+
+//! Source-text audit pinning namespace-aware page identity (issue #212).
+//!
+//! Every production SQL lookup that matches `slug = ?` against the `pages`
+//! table must either go through `core::pages::resolve*` or carry a namespace
+//! predicate in the same statement. Sites that are deliberately
+//! namespace-blind are allowlisted below with a documented reason; the test
+//! fails both on NEW unlisted sites (drift) and on STALE allowlist entries
+//! (so the list shrinks as sites migrate).
+
+use std::path::{Path, PathBuf};
+
+/// Deliberately namespace-blind lookups, with reasons.
+const ALLOWLIST: &[(&str, usize, &str)] = &[
+    (
+        "src/core/collections.rs",
+        1,
+        "slug -> owning-collection resolution: namespaces partition pages, not collections",
+    ),
+    (
+        "src/core/entities.rs",
+        1,
+        "basename surface matcher with LIMIT 2 ambiguity guard; multi-match resolves to Unresolved",
+    ),
+    (
+        "src/core/novelty.rs",
+        1,
+        "cosine dedup joins every same-slug embedding; cross-namespace dedup is intentionally conservative",
+    ),
+    (
+        "src/core/quarantine.rs",
+        1,
+        "quarantined-page load is collection-scoped and predicated on quarantined_at",
+    ),
+    (
+        "src/core/search.rs",
+        1,
+        "link-frontier expansion over collection-scoped result slugs; namespace filter applies to the seed results upstream",
+    ),
+];
+
+fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    for entry in std::fs::read_dir(dir).expect("read src dir") {
+        let entry = entry.expect("dir entry");
+        let path = entry.path();
+        if path.is_dir() {
+            collect_rs_files(&path, out);
+        } else if path.extension().is_some_and(|ext| ext == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+/// Strip the trailing `#[cfg(test)] mod ...` block; fn-level `#[cfg(test)]`
+/// items (e.g. in search.rs) are kept because production code follows them.
+fn production_source(source: &str) -> &str {
+    let mut search_from = 0;
+    while let Some(offset) = source[search_from..].find("#[cfg(test)]") {
+        let start = search_from + offset;
+        let rest = source[start + "#[cfg(test)]".len()..].trim_start();
+        if rest.starts_with("mod") {
+            return &source[..start];
+        }
+        search_from = start + "#[cfg(test)]".len();
+    }
+    source
+}
+
+fn violation_count(production: &str) -> usize {
+    let needle = "slug = ?";
+    let mut count = 0;
+    let mut search_from = 0;
+    while let Some(offset) = production[search_from..].find(needle) {
+        let index = search_from + offset;
+        search_from = index + needle.len();
+
+        // Identifier suffix matches like `resolved_by_slug = ?1` are not
+        // pages-slug lookups.
+        let preceding = production[..index].chars().next_back().unwrap_or(' ');
+        if preceding.is_alphanumeric() || preceding == '_' {
+            continue;
+        }
+        // `UPDATE pages SET slug = ?` assigns a slug to an id-keyed row; it
+        // is not an identity lookup.
+        if production[..index].trim_end().ends_with("SET") {
+            continue;
+        }
+
+        let window_start = index.saturating_sub(600);
+        let window_end = (index + 600).min(production.len());
+        let window = &production[window_start..window_end];
+        if !window.contains("pages") {
+            continue;
+        }
+        if window.contains("namespace") {
+            continue;
+        }
+        count += 1;
+    }
+    count
+}
+
+#[test]
+fn pages_slug_lookups_outside_core_pages_carry_a_namespace_predicate() {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
+    let src_root = Path::new(&manifest_dir).join("src");
+    let mut files = Vec::new();
+    collect_rs_files(&src_root, &mut files);
+    files.sort();
+    assert!(
+        files.len() > 50,
+        "audit walked suspiciously few files: {}",
+        files.len()
+    );
+
+    let mut unexpected: Vec<String> = Vec::new();
+    let mut stale: Vec<String> = Vec::new();
+
+    for file in &files {
+        let relative = file
+            .strip_prefix(&manifest_dir)
+            .expect("path under manifest dir")
+            .to_string_lossy()
+            .replace('\\', "/");
+        if relative == "src/core/pages.rs" {
+            // The sanctioned resolver implementation.
+            continue;
+        }
+
+        let source = std::fs::read_to_string(file).expect("read source file");
+        let count = violation_count(production_source(&source));
+
+        match ALLOWLIST
+            .iter()
+            .find(|(allowed, _, _)| *allowed == relative)
+        {
+            Some((_, allowed_count, reason)) => {
+                if count > *allowed_count {
+                    unexpected.push(format!(
+                        "{relative}: {count} namespace-blind pages-slug lookups \
+                         (allowlist permits {allowed_count}: {reason})"
+                    ));
+                } else if count < *allowed_count {
+                    stale.push(format!(
+                        "{relative}: allowlist permits {allowed_count} but found {count}; \
+                         shrink the allowlist entry"
+                    ));
+                }
+            }
+            None => {
+                if count > 0 {
+                    unexpected.push(format!(
+                        "{relative}: {count} namespace-blind pages-slug lookups; \
+                         migrate to core::pages::resolve or add a namespace predicate"
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(
+        unexpected.is_empty(),
+        "namespace-blind `slug = ?` lookups against pages detected:\n{}",
+        unexpected.join("\n")
+    );
+    assert!(
+        stale.is_empty(),
+        "stale namespace source-audit allowlist entries:\n{}",
+        stale.join("\n")
+    );
+}

--- a/tests/supersede_chain.rs
+++ b/tests/supersede_chain.rs
@@ -168,6 +168,7 @@ fn supersede_chain_write_rejects_non_head_and_memory_get_returns_successor_point
     let superseded_a: Value = serde_json::from_str(&extract_text(
         &server
             .memory_get(MemoryGetInput {
+                namespace: None,
                 slug: "facts/a".to_string(),
             })
             .unwrap(),
@@ -176,6 +177,7 @@ fn supersede_chain_write_rejects_non_head_and_memory_get_returns_successor_point
     let head_c: Value = serde_json::from_str(&extract_text(
         &server
             .memory_get(MemoryGetInput {
+                namespace: None,
                 slug: "facts/c".to_string(),
             })
             .unwrap(),
@@ -342,6 +344,7 @@ fn retrieval_defaults_to_heads_and_include_superseded_restores_history() {
     let graph: Value = serde_json::from_str(&extract_text(
         &server
             .memory_graph(MemoryGraphInput {
+                namespace: None,
                 slug: "facts/c".to_string(),
                 depth: Some(2),
                 temporal: Some("all".to_string()),


### PR DESCRIPTION
Implements **Area 4 — namespace-aware page identity** of the codebase review (`docs/fable-review.md` on `code-review-2`). This is the root-cause fix behind #212: the schema keys pages on `(collection_id, namespace, slug)` but ~17 production lookups ignored namespace, and the reconciler never wrote it at all.

## Changes
- **`core/pages.rs`**: `PageKey` + `resolve()`/`resolve_optional()` — namespace semantics decided once. Locked by a matrix test *before* call-site migration: `Some("")` = global only; `Some(ns)` = ns preferred, global fallback, never other namespaces; `None` = deterministic (global preferred, then lexicographic) replacing the old arbitrary `LIMIT 1`.
- **~17 namespace-blind sites migrated** to `resolve()`: MCP `page_id_for_resolved`, get/check/timeline/link/graph/tags/embed/ingest commands, links derived-edge sync (now threads the source page's namespace), entities lookup, progressive token_cost/page_is_head, MCP errors, conversation/correction.
- **Reconciler**: `apply_reingest` derives namespace from the relative-path prefix (`<ns>/extracted/...`), INSERTs it on new pages, and matches identity exact-namespace — watcher-ingested extracted facts stop landing in the global namespace, so supersede/dedup `head_candidates` finds prior heads again (the #212 regression shape, now test-pinned).
- **Open-time backfill** (idempotent `ensure_`-style, consistent with repo practice; SCHEMA_VERSION untouched — flagged for the Area 17 migration ladder): re-homes pre-fix rows whose file_state path carries a namespace prefix.
- **MCP surface**: optional `namespace` input on Get/Link/Backlinks/Graph/Check/Timeline/Tags/Raw.
- **Source-audit test** (repo-precedented): forbids slug-only page SQL without a namespace predicate outside `core/pages.rs`; detector converges on exactly the 5 allowlisted sites.

## Validation
fmt/clippy (-D warnings) clean; full `cargo test --lib` 928 passed. New: namespace_page_identity (8), namespace_reingest (3, incl. the #212 head_candidates regression + backfill), mcp_namespace_matrix (5), namespace_source_audit. ~30 targeted suites green incl. all mcp_server_*, supersede chains, reconciler_* suites, links_derived_edge_sync, entity_extraction, graph_retrieval.

## Semantic notes
- `namespace=None` resolution is now deterministic where it was arbitrary — observable only for vaults already containing same-slug multi-namespace rows.
- A new file whose slug matches a page in a *different* namespace now creates a sibling page instead of rebinding (the intended fix; backfill re-homes pre-fix rows first).
- Conflicts expected with the extraction-atomicity PR in `apply_reingest` (both touch it) — whichever merges second gets a small rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)