### PR TITLE
fix(extraction): atomicity & idempotency — supersede wiring, content-aware paths, locked cursor, rollover (area 5)

### DIFF
--- a/src/core/conversation/extractor.rs
+++ b/src/core/conversation/extractor.rs
@@ -3,8 +3,12 @@
 //! hands the validated facts to a pluggable `FactWriter` (either the
 //! resolving writer that performs full supersede semantics or a no-op
 //! writer for tests). Cursor state in the conversation frontmatter is
-//! advanced only after every window of a job succeeds so partial failures
-//! re-extract from the same boundary.
+//! advanced after each window's facts are written, so a mid-job failure or
+//! lease-expiry rerun resumes from the first incomplete window instead of
+//! re-emitting facts for windows that already succeeded. The cursor write
+//! holds the same per-session mutex + flock as `turn_writer::append_turn`
+//! and rewrites only the cursor frontmatter lines, so concurrently appended
+//! turns survive.
 //!
 //! See also: `super::queue` for the SQLite-backed job table this worker
 //! consumes, `super::slm` for the SLM runtime, `super::supersede` for the
@@ -13,6 +17,7 @@
 //! windows.
 
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::thread;
 use std::time::Duration;
@@ -181,6 +186,11 @@ pub enum WorkerError {
     /// The fact-write seam refused or failed on a produced fact.
     #[error("fact resolution error: {0}")]
     FactResolution(#[from] FactResolutionError),
+
+    /// Acquiring the per-session locks (or resolving the memory root) failed
+    /// while persisting the extraction cursor.
+    #[error("turn writer error: {0}")]
+    TurnWrite(#[from] turn_writer::TurnWriteError),
 }
 
 impl<'db, S, W> Worker<'db, S, W>
@@ -335,12 +345,13 @@ where
     }
 
     /// Run every window of a leased job through the SLM and the fact
-    /// writer, advance the conversation's extraction cursor on success,
+    /// writer, advancing the conversation's extraction cursor after each
+    /// window so a rerun skips windows whose facts were already written,
     /// and mark the queue row done; records `last_error` and surfaces the
     /// failure when any step fails.
     pub fn process_job(&self, job: &ExtractionJob) -> Result<(), WorkerError> {
         let conversation_path = self.resolve_conversation_path(&job.conversation_path)?;
-        let mut conversation = format::parse(&conversation_path)?;
+        let conversation = format::parse(&conversation_path)?;
         let windows = self.compute_windows(&conversation, job.trigger_kind);
 
         for window in &windows {
@@ -360,20 +371,61 @@ where
                 self.record_job_failure(job, &error)?;
                 return Err(error);
             }
-        }
 
-        if !windows.is_empty() {
-            let extracted_at = queue::current_timestamp(self.db)?;
-            persist_cursor_update(
-                &conversation_path,
-                &mut conversation,
-                &windows,
-                &extracted_at,
-            )?;
+            // Per-window cursor advance: the facts for this window are on
+            // disk, so persist the cursor now. Partial progress surviving a
+            // later-window failure is deliberate — facts are already written
+            // per window, and a rerun must not re-emit them.
+            if let Err(error) = self.persist_window_cursor(job, &conversation_path, window) {
+                self.record_job_failure(job, &error)?;
+                return Err(error);
+            }
         }
 
         self._vault_writer.before_mark_done(self.db, job)?;
         queue::mark_done(self.db, job.id, job.attempts).map_err(WorkerError::from)
+    }
+
+    /// Persist the extraction cursor for one completed window by rewriting
+    /// only the cursor frontmatter lines of the day-file, under the same
+    /// per-session mutex + flock that `turn_writer::append_turn` holds, so
+    /// a turn appended while the SLM was running survives the rewrite.
+    fn persist_window_cursor(
+        &self,
+        job: &ExtractionJob,
+        conversation_path: &Path,
+        window: &WindowedTurns,
+    ) -> Result<(), WorkerError> {
+        let extracted_at = queue::current_timestamp(self.db)?;
+        let last_new_ordinal = window.last_new_ordinal();
+        match self.session_lock_scope(&job.conversation_path)? {
+            Some((root, namespace, session_id)) => {
+                turn_writer::with_session_locks(&root, namespace.as_deref(), &session_id, || {
+                    rewrite_cursor_frontmatter(conversation_path, last_new_ordinal, &extracted_at)
+                })
+            }
+            // Absolute job paths cannot be mapped back to a session lock
+            // scope; fall back to an unlocked (but still frontmatter-only)
+            // rewrite.
+            None => rewrite_cursor_frontmatter(conversation_path, last_new_ordinal, &extracted_at),
+        }
+    }
+
+    /// Derive the `(memory root, namespace, session id)` lock scope for a
+    /// job's vault-relative conversation path, or `None` when the path does
+    /// not follow the canonical relative scheme (e.g. absolute test paths).
+    fn session_lock_scope(
+        &self,
+        job_conversation_path: &str,
+    ) -> Result<Option<(turn_writer::MemoryRoot, Option<String>, String)>, WorkerError> {
+        let Ok(parsed) = format::parse_relative_conversation_path(job_conversation_path) else {
+            return Ok(None);
+        };
+        let root =
+            turn_writer::resolve_memory_root(self.db).map_err(|error| WorkerError::Config {
+                message: error.to_string(),
+            })?;
+        Ok(Some((root, parsed.namespace, parsed.session_id)))
     }
 
     /// Persist a truncated copy of the offending raw SLM output to the
@@ -558,22 +610,82 @@ fn is_parse_failure(error: &WorkerError) -> bool {
     matches!(error, WorkerError::Slm(SlmError::Parse { .. }))
 }
 
-fn persist_cursor_update(
+/// Rewrite only the `last_extracted_at` / `last_extracted_turn` frontmatter
+/// lines of the day-file at `path`, re-reading the file fresh so turns
+/// appended after the worker's pre-inference snapshot are preserved
+/// byte-for-byte instead of being clobbered by a stale full-file render.
+fn rewrite_cursor_frontmatter(
     path: &Path,
-    conversation: &mut ConversationFile,
-    windows: &[WindowedTurns],
+    last_new_ordinal: Option<i64>,
     extracted_at: &str,
 ) -> Result<(), WorkerError> {
-    if let Some(last_new_ordinal) = windows
-        .iter()
-        .filter_map(WindowedTurns::last_new_ordinal)
-        .max()
-    {
-        conversation.frontmatter.last_extracted_turn = last_new_ordinal;
-    }
-    conversation.frontmatter.last_extracted_at = Some(extracted_at.to_owned());
-    fs::write(path, format::render(conversation))?;
+    let raw = fs::read_to_string(path)?;
+    let updated = update_cursor_frontmatter(&raw, last_new_ordinal, extracted_at)?;
+    let mut file = fs::File::create(path)?;
+    file.write_all(updated.as_bytes())?;
+    file.sync_all()?;
     Ok(())
+}
+
+fn update_cursor_frontmatter(
+    raw: &str,
+    last_new_ordinal: Option<i64>,
+    extracted_at: &str,
+) -> Result<String, WorkerError> {
+    let mut out = String::with_capacity(raw.len() + 64);
+    let mut in_frontmatter = false;
+    let mut frontmatter_done = false;
+    let mut wrote_extracted_at = false;
+    // No ordinal to persist means the existing cursor line is kept as-is.
+    let mut wrote_extracted_turn = last_new_ordinal.is_none();
+
+    for line in raw.split_inclusive('\n') {
+        if !frontmatter_done {
+            let trimmed = line.trim_end_matches(['\r', '\n']);
+            if !in_frontmatter {
+                if out.is_empty() && trimmed == "---" {
+                    in_frontmatter = true;
+                }
+            } else if trimmed == "---" {
+                // Closing boundary: insert any cursor lines the file did not
+                // already carry (legacy files may lack `last_extracted_at`).
+                if !wrote_extracted_at {
+                    out.push_str("last_extracted_at: ");
+                    out.push_str(extracted_at);
+                    out.push('\n');
+                }
+                if !wrote_extracted_turn {
+                    if let Some(ordinal) = last_new_ordinal {
+                        out.push_str(&format!("last_extracted_turn: {ordinal}\n"));
+                    }
+                }
+                in_frontmatter = false;
+                frontmatter_done = true;
+            } else if trimmed.starts_with("last_extracted_at:") {
+                out.push_str("last_extracted_at: ");
+                out.push_str(extracted_at);
+                out.push('\n');
+                wrote_extracted_at = true;
+                continue;
+            } else if trimmed.starts_with("last_extracted_turn:") {
+                if let Some(ordinal) = last_new_ordinal {
+                    out.push_str(&format!("last_extracted_turn: {ordinal}\n"));
+                    wrote_extracted_turn = true;
+                    continue;
+                }
+            }
+        }
+        out.push_str(line);
+    }
+
+    if !frontmatter_done {
+        return Err(WorkerError::Format(
+            format::ConversationFormatError::InvalidFrontmatter {
+                message: "cursor update requires a closed frontmatter block".to_owned(),
+            },
+        ));
+    }
+    Ok(out)
 }
 
 fn parse_usize_config(db: &Connection, key: &str, default: usize) -> Result<usize, WorkerError> {

--- a/src/core/conversation/queue.rs
+++ b/src/core/conversation/queue.rs
@@ -55,8 +55,12 @@ pub enum ExtractionQueueError {
 }
 
 /// Enqueue a debounce / session_close / non-force manual job, collapsing
-/// pending rows per `session_id`. Force-reset enqueues use
-/// [`enqueue_force_path`] instead so each day-file gets its own pending row.
+/// pending rows per `(session_id, conversation_path)`. A different
+/// `conversation_path` for the same session (a midnight rollover onto a new
+/// day-file) gets its own pending row instead of overwriting the existing
+/// row's path, so the prior day's unextracted tail still gets parsed.
+/// Force-reset enqueues use [`enqueue_force_path`] instead so each day-file
+/// gets its own `manual` pending row.
 pub fn enqueue(
     conn: &Connection,
     session_id: &str,
@@ -69,10 +73,10 @@ pub fn enqueue(
             .query_row(
                 "SELECT id, trigger_kind, scheduled_for
                  FROM extraction_queue
-                 WHERE session_id = ?1 AND status = 'pending'
+                 WHERE session_id = ?1 AND conversation_path = ?2 AND status = 'pending'
                  ORDER BY id
                  LIMIT 1",
-                [session_id],
+                params![session_id, conversation_path],
                 |row| {
                     Ok((
                         row.get::<_, i64>(0)?,
@@ -95,19 +99,13 @@ pub fn enqueue(
             );
             conn.execute(
                 "UPDATE extraction_queue
-                 SET conversation_path = ?2,
-                     trigger_kind = ?3,
-                     scheduled_for = ?4,
+                 SET trigger_kind = ?2,
+                     scheduled_for = ?3,
                      attempts = 0,
                      last_error = NULL,
                      enqueued_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
                  WHERE id = ?1",
-                params![
-                    job_id,
-                    conversation_path,
-                    trigger_kind.as_str(),
-                    scheduled_for
-                ],
+                params![job_id, trigger_kind.as_str(), scheduled_for],
             )?;
         } else {
             conn.execute(
@@ -526,7 +524,7 @@ mod tests {
         enqueue(
             &conn,
             "s1",
-            "conversations/2026-05-03/updated.md",
+            "conversations/2026-05-03/original.md",
             ExtractionTriggerKind::Manual,
             "2026-05-03T10:00:02Z",
         )
@@ -542,7 +540,7 @@ mod tests {
             )
             .unwrap();
 
-        assert_eq!(row.0, "conversations/2026-05-03/updated.md");
+        assert_eq!(row.0, "conversations/2026-05-03/original.md");
         assert_eq!(row.1, "manual");
         assert_eq!(row.2, 0);
         assert_eq!(row.3, None);

--- a/src/core/conversation/supersede.rs
+++ b/src/core/conversation/supersede.rs
@@ -350,24 +350,22 @@ pub fn write_fact_in_context(
             })
         }
         Resolution::Supersede { prior_slug, .. } => {
-            let (slug, relative_path) = allocate_output_path(raw_fact, conn, context)?;
-            let markdown =
-                render_fact_markdown(raw_fact, context, &slug, Some(prior_slug.as_str()), None)?;
-            write_markdown(&context.root_path, &relative_path, &markdown)?;
+            let output =
+                allocate_output_path(raw_fact, conn, context, Some(prior_slug.as_str()), None)?;
+            persist_allocated_fact(&context.root_path, &output)?;
             Ok(FactWriteResult {
                 resolution: resolution.clone(),
-                slug: Some(slug),
-                relative_path: Some(path_to_slash(&relative_path)),
+                slug: Some(output.slug),
+                relative_path: Some(path_to_slash(&output.relative_path)),
             })
         }
         Resolution::Coexist => {
-            let (slug, relative_path) = allocate_output_path(raw_fact, conn, context)?;
-            let markdown = render_fact_markdown(raw_fact, context, &slug, None, None)?;
-            write_markdown(&context.root_path, &relative_path, &markdown)?;
+            let output = allocate_output_path(raw_fact, conn, context, None, None)?;
+            persist_allocated_fact(&context.root_path, &output)?;
             Ok(FactWriteResult {
                 resolution: resolution.clone(),
-                slug: Some(slug),
-                relative_path: Some(path_to_slash(&relative_path)),
+                slug: Some(output.slug),
+                relative_path: Some(path_to_slash(&output.relative_path)),
             })
         }
     }
@@ -409,22 +407,21 @@ pub fn force_supersede_fact_in_context(
     corrected_via: &str,
 ) -> Result<FactWriteResult, FactResolutionError> {
     with_immediate_transaction(conn, |conn| {
-        let (slug, relative_path) = allocate_output_path(raw_fact, conn, context)?;
-        let markdown = render_fact_markdown(
+        let output = allocate_output_path(
             raw_fact,
+            conn,
             context,
-            &slug,
             Some(prior_slug),
             Some(corrected_via),
         )?;
-        write_markdown(&context.root_path, &relative_path, &markdown)?;
+        persist_allocated_fact(&context.root_path, &output)?;
         Ok(FactWriteResult {
             resolution: Resolution::Supersede {
                 prior_slug: prior_slug.to_string(),
                 cosine: 1.0,
             },
-            slug: Some(slug),
-            relative_path: Some(path_to_slash(&relative_path)),
+            slug: Some(output.slug),
+            relative_path: Some(path_to_slash(&output.relative_path)),
         })
     })
 }
@@ -627,11 +624,30 @@ fn ensure_trustworthy_embedding_evidence(raw_fact: &RawFact) -> Result<(), FactR
     }
 }
 
+/// Output of [`allocate_output_path`]: the chosen slug, vault-relative
+/// path, and rendered markdown, plus whether the file still needs to be
+/// written (`false` when an identical fact file is already on disk).
+#[derive(Debug, Clone)]
+struct AllocatedFactFile {
+    slug: String,
+    relative_path: PathBuf,
+    markdown: String,
+    write_needed: bool,
+}
+
+/// Allocate the output slug + path for a fact, rendering each candidate so
+/// allocation is content-aware: when the file already on disk matches the
+/// rendered fact (ignoring the volatile `extracted_at` stamp), the existing
+/// slug is reused as a no-op instead of suffixing a duplicate `-N` head.
+/// This makes retried windows / lease-expiry reruns idempotent even before
+/// the async vault watcher has ingested the first attempt's file.
 fn allocate_output_path(
     raw_fact: &RawFact,
     conn: &Connection,
     context: &FactWriteContext,
-) -> Result<(String, PathBuf), FactResolutionError> {
+    supersedes: Option<&str>,
+    corrected_via: Option<&str>,
+) -> Result<AllocatedFactFile, FactResolutionError> {
     let base_slug = fact_slug_base(raw_fact);
     for attempt in 0..MAX_SLUG_COLLISION_ATTEMPTS {
         let slug = if attempt == 0 {
@@ -641,10 +657,30 @@ fn allocate_output_path(
         };
         let relative_path = relative_fact_path(raw_fact.type_plural(), &context.namespace, &slug);
         let full_path = context.root_path.join(&relative_path);
-        if !full_path.exists()
-            && !page_slug_exists(conn, context.collection_id, &context.namespace, &slug)?
-        {
-            return Ok((slug, relative_path));
+        let markdown = render_fact_markdown(raw_fact, context, &slug, supersedes, corrected_via)?;
+
+        if full_path.exists() {
+            if let Ok(existing) = fs::read_to_string(&full_path) {
+                if fact_markdown_matches(&existing, &markdown) {
+                    // Keep the existing bytes untouched so the watcher's
+                    // sha256 dedup treats the rerun as a clean no-op.
+                    return Ok(AllocatedFactFile {
+                        slug,
+                        relative_path,
+                        markdown,
+                        write_needed: false,
+                    });
+                }
+            }
+            continue;
+        }
+        if !page_slug_exists(conn, context.collection_id, &context.namespace, &slug)? {
+            return Ok(AllocatedFactFile {
+                slug,
+                relative_path,
+                markdown,
+                write_needed: true,
+            });
         }
     }
 
@@ -652,6 +688,38 @@ fn allocate_output_path(
         base_slug,
         attempts: MAX_SLUG_COLLISION_ATTEMPTS,
     })
+}
+
+fn persist_allocated_fact(
+    root_path: &Path,
+    output: &AllocatedFactFile,
+) -> Result<(), FactResolutionError> {
+    if output.write_needed {
+        write_markdown(root_path, &output.relative_path, &output.markdown)?;
+    }
+    Ok(())
+}
+
+/// Compare two rendered fact files for identity, ignoring the volatile
+/// `extracted_at:` frontmatter line so a retried extraction of the same
+/// fact compares equal across runs that differ only in wall-clock time.
+fn fact_markdown_matches(existing: &str, rendered: &str) -> bool {
+    normalize_fact_markdown(existing) == normalize_fact_markdown(rendered)
+}
+
+fn normalize_fact_markdown(content: &str) -> String {
+    let mut normalized = String::with_capacity(content.len());
+    let mut boundaries_seen = 0_u8;
+    for line in content.split_inclusive('\n') {
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        if boundaries_seen < 2 && trimmed == "---" {
+            boundaries_seen += 1;
+        } else if boundaries_seen == 1 && trimmed.starts_with("extracted_at:") {
+            continue;
+        }
+        normalized.push_str(line);
+    }
+    normalized
 }
 
 fn page_slug_exists(

--- a/src/core/reconciler.rs
+++ b/src/core/reconciler.rs
@@ -2911,6 +2911,41 @@ fn apply_reingest(
         (tx.last_insert_rowid(), true)
     };
 
+    // Stop-the-bleed supersede wiring (#135): retire the prior head exactly
+    // as the synchronous `quaid ingest` path does (src/commands/ingest.rs),
+    // so a watcher-ingested fact whose `supersedes:` frontmatter names a
+    // prior page doesn't leave two live heads in the same (kind, key)
+    // partition and park subsequent extractions on AmbiguousMatchingHeads.
+    // Semantic failures (missing / ambiguous / non-head target) are tolerated
+    // with a WARN — mirroring `sync_page_graph_artifacts_tolerant` — because
+    // an external edit must not be able to wedge the whole reconcile pass;
+    // SQLite errors still abort the transaction.
+    let supersedes = parsed
+        .frontmatter
+        .get("supersedes")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_owned);
+    if let Err(error) = crate::core::supersede::reconcile_supersede_chain(
+        &tx,
+        collection_id,
+        "",
+        page_id,
+        &parsed.slug,
+        supersedes.as_deref(),
+    ) {
+        match error {
+            crate::core::supersede::SupersedeError::Sqlite(sqlite_error) => {
+                return Err(ReconcileError::Other(format!(
+                    "apply_reingest: supersede chain: {sqlite_error}"
+                )));
+            }
+            other => eprintln!(
+                "WARN: supersede_chain_unresolved context={} error={other}",
+                absolute_path.to_string_lossy()
+            ),
+        }
+    }
+
     file_state::upsert_file_state(
         &tx,
         collection_id,

--- a/tests/extraction_atomicity.rs
+++ b/tests/extraction_atomicity.rs
@@ -1,0 +1,327 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::print_stdout,
+    reason = "test fixtures legitimately panic on setup failure and print diagnostics; per-site #[expect] would generate noise across thousands of test sites"
+)]
+
+//! Extraction pipeline atomicity tests: a concurrently appended turn must
+//! survive the worker's cursor rewrite, and a session spanning a midnight
+//! rollover must extract the tails of *both* day-files.
+
+use std::collections::VecDeque;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{mpsc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use quaid::core::conversation::{
+    extractor::{SlmClient, Worker},
+    format, queue,
+    slm::SlmError,
+    supersede::ResolvingFactWriter,
+    turn_writer,
+};
+use quaid::core::db;
+use quaid::core::types::{ExtractionTriggerKind, TurnRole};
+use rusqlite::Connection;
+
+fn open_vault_db(dir: &Path) -> (Connection, PathBuf) {
+    let db_path = dir.join("memory.db");
+    let vault_root = dir.join("vault");
+    fs::create_dir_all(&vault_root).unwrap();
+    let conn = db::open(db_path.to_str().unwrap()).unwrap();
+    conn.execute(
+        "UPDATE collections
+         SET root_path = ?1,
+             writable = 1,
+             is_write_target = 1,
+             state = 'active',
+             needs_full_sync = 0
+         WHERE id = 1",
+        [vault_root.display().to_string()],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT OR REPLACE INTO config(key, value) VALUES ('extraction.enabled', 'true')",
+        [],
+    )
+    .unwrap();
+    (conn, vault_root)
+}
+
+fn append_turn(conn: &Connection, session_id: &str, ordinal: i64, content: &str, timestamp: &str) {
+    let role = if ordinal % 2 == 0 {
+        TurnRole::Assistant
+    } else {
+        TurnRole::User
+    };
+    turn_writer::append_turn(conn, session_id, role, content, timestamp, None, None).unwrap();
+}
+
+fn extracted_markdown_files(root: &Path) -> Vec<PathBuf> {
+    fn visit(dir: &Path, files: &mut Vec<PathBuf>) {
+        if !dir.exists() {
+            return;
+        }
+        for entry in fs::read_dir(dir).unwrap() {
+            let path = entry.unwrap().path();
+            if path.is_dir() {
+                visit(&path, files);
+            } else if path.extension().and_then(|ext| ext.to_str()) == Some("md") {
+                files.push(path);
+            }
+        }
+    }
+
+    let mut files = Vec::new();
+    visit(root, &mut files);
+    files.sort();
+    files
+}
+
+/// SLM stub that signals when inference starts and blocks until the test
+/// releases it, so the test can deterministically interleave an
+/// `append_turn` with an in-flight extraction window.
+struct BlockingSlm {
+    entered_tx: mpsc::Sender<()>,
+    release_rx: mpsc::Receiver<()>,
+    output: String,
+}
+
+impl SlmClient for BlockingSlm {
+    fn infer(&self, _alias: &str, _prompt: &str, _max_tokens: usize) -> Result<String, SlmError> {
+        self.entered_tx.send(()).expect("signal inference entered");
+        self.release_rx
+            .recv()
+            .expect("await release from test thread");
+        Ok(self.output.clone())
+    }
+}
+
+/// Minimal FIFO stub that pops one canned response per inference call.
+struct QueueStubSlm {
+    outputs: Mutex<VecDeque<String>>,
+}
+
+impl QueueStubSlm {
+    fn new(outputs: impl IntoIterator<Item = &'static str>) -> Self {
+        Self {
+            outputs: Mutex::new(outputs.into_iter().map(str::to_owned).collect()),
+        }
+    }
+}
+
+impl SlmClient for QueueStubSlm {
+    fn infer(&self, _alias: &str, _prompt: &str, _max_tokens: usize) -> Result<String, SlmError> {
+        Ok(self
+            .outputs
+            .lock()
+            .unwrap()
+            .pop_front()
+            .unwrap_or_else(|| "{\"facts\":[]}".to_string()))
+    }
+}
+
+#[test]
+fn turn_appended_during_slow_extraction_window_survives_cursor_rewrite() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let (conn, vault_root) = open_vault_db(dir.path());
+    let db_path = dir.path().join("memory.db");
+
+    for ordinal in 1..=4 {
+        append_turn(
+            &conn,
+            "slow-session",
+            ordinal,
+            &format!("turn {ordinal}"),
+            &format!("2026-05-05T09:0{ordinal}:00Z"),
+        );
+    }
+    queue::enqueue(
+        &conn,
+        "slow-session",
+        "conversations/2026-05-05/slow-session.md",
+        ExtractionTriggerKind::Manual,
+        "2000-01-01T00:00:00Z",
+    )
+    .unwrap();
+
+    let (entered_tx, entered_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    let slm = BlockingSlm {
+        entered_tx,
+        release_rx,
+        output: r#"{"facts":[{"kind":"preference","about":"systems-language","strength":"high","summary":"The team prefers Rust for systems work."}]}"#
+            .to_string(),
+    };
+
+    let worker_thread = thread::spawn(move || {
+        let worker_conn = db::open(db_path.to_str().unwrap()).unwrap();
+        let worker = Worker::new(&worker_conn, slm, ResolvingFactWriter)
+            .unwrap()
+            .with_limits(Duration::from_millis(1), 256);
+        worker.process_next_job().map(|job| job.is_some())
+    });
+
+    entered_rx
+        .recv_timeout(Duration::from_secs(30))
+        .expect("worker must reach SLM inference");
+    // The window [1..4] is mid-inference; append a fifth turn through the
+    // production locked append path. The worker's cursor write must take the
+    // same per-session locks afterwards and must not clobber this turn with
+    // its pre-inference snapshot.
+    append_turn(
+        &conn,
+        "slow-session",
+        5,
+        "fifth turn arrives mid-extraction",
+        "2026-05-05T09:05:00Z",
+    );
+    release_tx.send(()).expect("release the stubbed SLM");
+
+    let processed = worker_thread
+        .join()
+        .expect("worker thread must not panic")
+        .expect("process_next_job must succeed");
+    assert!(processed, "worker must have claimed and processed the job");
+
+    let day_file = vault_root
+        .join("conversations")
+        .join("2026-05-05")
+        .join("slow-session.md");
+    let parsed = format::parse(&day_file).unwrap();
+    assert_eq!(
+        parsed.turns.len(),
+        5,
+        "turn appended during extraction must survive the cursor rewrite"
+    );
+    assert_eq!(parsed.turns[4].ordinal, 5);
+    assert!(parsed.turns[4]
+        .content
+        .contains("fifth turn arrives mid-extraction"));
+    assert_eq!(
+        parsed.frontmatter.last_extracted_turn, 4,
+        "cursor must reflect only the extracted window, leaving turn 5 for the next job"
+    );
+    assert!(parsed.frontmatter.last_extracted_at.is_some());
+
+    let fact_files = extracted_markdown_files(&vault_root.join("extracted"));
+    assert_eq!(fact_files.len(), 1, "the window's fact must be on disk");
+}
+
+#[test]
+fn midnight_rollover_extracts_both_day_file_tails() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let (conn, vault_root) = open_vault_db(dir.path());
+
+    // Two turns just before midnight land in the 2026-05-05 day-file; two
+    // more after midnight land in 2026-05-06 (ordinals continue at 3, 4).
+    append_turn(
+        &conn,
+        "roll-session",
+        1,
+        "evening: we settled on tabs over spaces",
+        "2026-05-05T23:58:00Z",
+    );
+    append_turn(
+        &conn,
+        "roll-session",
+        2,
+        "noted before midnight",
+        "2026-05-05T23:59:00Z",
+    );
+    append_turn(
+        &conn,
+        "roll-session",
+        3,
+        "morning: we chose pnpm for the monorepo",
+        "2026-05-06T00:01:00Z",
+    );
+    append_turn(
+        &conn,
+        "roll-session",
+        4,
+        "captured after midnight",
+        "2026-05-06T00:02:00Z",
+    );
+
+    // Mirror the production add-turn enqueue across the rollover: one
+    // enqueue per day-file path. Pre-fix, the second call overwrote the
+    // pending row's conversation_path and stranded the 05-05 tail.
+    queue::enqueue(
+        &conn,
+        "roll-session",
+        "conversations/2026-05-05/roll-session.md",
+        ExtractionTriggerKind::Debounce,
+        "2000-01-01T00:00:01Z",
+    )
+    .unwrap();
+    queue::enqueue(
+        &conn,
+        "roll-session",
+        "conversations/2026-05-06/roll-session.md",
+        ExtractionTriggerKind::Debounce,
+        "2000-01-01T00:00:02Z",
+    )
+    .unwrap();
+
+    let pending: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM extraction_queue
+             WHERE session_id = 'roll-session' AND status = 'pending'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(pending, 2, "each day-file must keep its own pending row");
+
+    let slm = QueueStubSlm::new([
+        r#"{"facts":[{"kind":"decision","chose":"tabs-over-spaces","summary":"The team settled on tabs over spaces."}]}"#,
+        r#"{"facts":[{"kind":"decision","chose":"pnpm-monorepo","summary":"The team chose pnpm for the monorepo."}]}"#,
+    ]);
+    let worker = Worker::new(&conn, slm, ResolvingFactWriter)
+        .unwrap()
+        .with_limits(Duration::from_millis(1), 256);
+
+    let first = worker.process_next_job().unwrap();
+    assert!(first.is_some(), "first day-file job must be claimed");
+    let second = worker.process_next_job().unwrap();
+    assert!(second.is_some(), "second day-file job must be claimed");
+    assert!(
+        worker.process_next_job().unwrap().is_none(),
+        "no third job expected"
+    );
+
+    let day_one = format::parse(
+        &vault_root
+            .join("conversations")
+            .join("2026-05-05")
+            .join("roll-session.md"),
+    )
+    .unwrap();
+    let day_two = format::parse(
+        &vault_root
+            .join("conversations")
+            .join("2026-05-06")
+            .join("roll-session.md"),
+    )
+    .unwrap();
+    assert_eq!(
+        day_one.frontmatter.last_extracted_turn, 2,
+        "the prior day's tail must have been extracted"
+    );
+    assert_eq!(
+        day_two.frontmatter.last_extracted_turn, 4,
+        "the new day's tail must have been extracted"
+    );
+
+    let fact_files = extracted_markdown_files(&vault_root.join("extracted"));
+    assert_eq!(
+        fact_files.len(),
+        2,
+        "both day tails must have produced their fact file: {fact_files:?}"
+    );
+}

--- a/tests/extraction_idempotency.rs
+++ b/tests/extraction_idempotency.rs
@@ -201,6 +201,120 @@ fn hash_shim_forced() -> bool {
 }
 
 #[test]
+fn force_reextract_without_manual_ingest_emits_no_duplicate_suffix_files() {
+    // Regression for the production sequencing: the vault watcher (not a
+    // manual `ingest::run`) is responsible for page rows, so a re-extraction
+    // typically runs while the first attempt's fact files are on disk but
+    // not yet ingested. The rerun must reuse the existing files instead of
+    // suffixing `-2` duplicates (which, once ingested, produce two heads in
+    // the same partition and park later jobs on AmbiguousMatchingHeads).
+    let harness = Harness::new();
+
+    for (ordinal, role, content) in [
+        (1, "user", "I prefer Rust for systems work."),
+        (2, "assistant", "Noted: Rust is the current preference."),
+        (3, "user", "We chose SQLite for the local cache."),
+        (4, "assistant", "Decision captured."),
+    ] {
+        harness
+            .server
+            .memory_add_turn(MemoryAddTurnInput {
+                session_id: "idem-no-ingest".to_string(),
+                role: role.to_string(),
+                content: content.to_string(),
+                timestamp: Some(format!("2026-05-05T09:0{ordinal}:00Z")),
+                metadata: None,
+                namespace: None,
+            })
+            .unwrap();
+    }
+    harness
+        .server
+        .memory_close_session(MemoryCloseSessionInput {
+            session_id: "idem-no-ingest".to_string(),
+            namespace: None,
+        })
+        .unwrap();
+
+    let slm_output = r#"{"facts":[
+        {"kind":"preference","about":"systems-language","strength":"high","summary":"The team prefers Rust for systems work."},
+        {"kind":"decision","chose":"sqlite-local-cache","summary":"The team chose SQLite for the local cache."}
+    ]}"#;
+    let initial_worker = Worker::new(
+        &harness.inspect,
+        StubSlm::with_results([Ok(slm_output)]),
+        ResolvingFactWriter,
+    )
+    .unwrap()
+    .with_limits(Duration::from_millis(1), 128);
+    initial_worker
+        .process_next_job()
+        .unwrap()
+        .expect("initial extraction job");
+
+    let extracted_root = harness.vault_root.join("extracted");
+    let initial_files = markdown_files(&extracted_root);
+    assert_eq!(
+        initial_files.len(),
+        2,
+        "initial extraction should write two fact files"
+    );
+    let initial_contents = initial_files
+        .iter()
+        .map(|path| fs::read(path).unwrap())
+        .collect::<Vec<_>>();
+
+    // Crucially: NO ingest::run between passes — the pages table has no fact
+    // rows, so the rerun resolves Coexist and must hit the content-aware
+    // allocation no-op (this path never consults embeddings, so it holds
+    // under the hash shim too).
+    let output = run_quaid(&harness.db_path, &["extract", "idem-no-ingest", "--force"]);
+    assert!(
+        output.status.success(),
+        "extract --force failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let replay_worker = Worker::new(
+        &harness.inspect,
+        StubSlm::with_results([Ok(slm_output)]),
+        ResolvingFactWriter,
+    )
+    .unwrap()
+    .with_limits(Duration::from_millis(1), 128);
+    // An Err here (e.g. AmbiguousMatchingHeads) would mean the rerun saw
+    // duplicate heads; success is part of the assertion.
+    replay_worker
+        .process_next_job()
+        .unwrap()
+        .expect("forced replay job");
+
+    let replay_files = markdown_files(&extracted_root);
+    assert_eq!(
+        replay_files, initial_files,
+        "rerun without ingest must not grow the extracted fact set"
+    );
+    assert!(
+        replay_files.iter().all(|path| {
+            !path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or_default()
+                .ends_with("-2.md")
+        }),
+        "no -2 suffix duplicates may appear: {replay_files:?}"
+    );
+    let replay_contents = replay_files
+        .iter()
+        .map(|path| fs::read(path).unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        replay_contents, initial_contents,
+        "idempotent rerun must leave the original fact bytes untouched"
+    );
+}
+
+#[test]
 fn force_reextract_keeps_structurally_equivalent_head_set_and_chain_shape() {
     let harness = Harness::new();
 

--- a/tests/extraction_queue.rs
+++ b/tests/extraction_queue.rs
@@ -75,6 +75,56 @@ fn enqueue_collapses_burst_and_session_close_takes_precedence() {
 }
 
 #[test]
+fn enqueue_keeps_separate_pending_rows_per_day_file_on_rollover() {
+    // Midnight rollover regression: a session whose turns span two day-files
+    // must keep one pending row per `conversation_path` so the prior day's
+    // unextracted tail is still parsed instead of being overwritten by the
+    // newest day-file's path.
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("memory.db");
+    let conn = open_queue_db(&db_path);
+
+    enqueue(
+        &conn,
+        "s1",
+        "conversations/2026-05-03/s1.md",
+        ExtractionTriggerKind::Debounce,
+        "2026-05-03T23:59:50Z",
+    )
+    .unwrap();
+    enqueue(
+        &conn,
+        "s1",
+        "conversations/2026-05-04/s1.md",
+        ExtractionTriggerKind::Debounce,
+        "2026-05-04T00:00:10Z",
+    )
+    .unwrap();
+
+    let mut stmt = conn
+        .prepare(
+            "SELECT conversation_path FROM extraction_queue
+             WHERE session_id = 's1' AND status = 'pending'
+             ORDER BY conversation_path",
+        )
+        .unwrap();
+    let paths = stmt
+        .query_map([], |row| row.get::<_, String>(0))
+        .unwrap()
+        .map(|row| row.unwrap())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        paths,
+        vec![
+            "conversations/2026-05-03/s1.md".to_string(),
+            "conversations/2026-05-04/s1.md".to_string(),
+        ],
+        "rollover must not collapse the prior day's pending row"
+    );
+}
+
+#[test]
 fn dequeue_returns_jobs_in_scheduled_order() {
     let dir = tempfile::TempDir::new().unwrap();
     let db_path = dir.path().join("memory.db");

--- a/tests/extraction_worker.rs
+++ b/tests/extraction_worker.rs
@@ -664,13 +664,15 @@ fn slash_to_platform(path: &str) -> String {
     path.replace('/', std::path::MAIN_SEPARATOR_STR)
 }
 
-// ── spec item 9.3 — no partial cursor advance when a later window fails ────
+// ── per-window cursor advance: completed windows survive a later failure ───
 
 #[test]
-fn process_job_should_not_partially_advance_cursor_when_later_window_fails() {
+fn process_job_persists_completed_window_cursor_when_later_window_fails() {
     // 10 turns with window_turns=5 → 2 windows: [1..5] then [6..10].
-    // Window 1 gets valid JSON; window 2 gets garbage. persist_cursor_update is
-    // only called after all windows succeed, so the cursor must stay at 0.
+    // Window 1 gets valid JSON; window 2 gets garbage. The cursor is now
+    // persisted per window (facts are written per window, so a rerun must
+    // not re-emit window 1's facts): after the window-2 failure the cursor
+    // must sit at 5, and the retry must resume from turn 6.
     let dir = tempfile::TempDir::new().unwrap();
     let db_path = dir.path().join("memory.db");
     let conn = open_worker_db_at(&db_path);
@@ -686,10 +688,13 @@ fn process_job_should_not_partially_advance_cursor_when_later_window_fails() {
     )
     .unwrap();
 
-    let worker = worker_with_stub(
-        &conn,
-        StubSlm::with_results([Ok("{\"facts\":[]}"), Ok("not json — window 2 explodes")]),
-    );
+    let slm = StubSlm::with_results([
+        Ok("{\"facts\":[]}"),
+        Ok("not json — window 2 explodes"),
+        Ok("{\"facts\":[]}"),
+    ]);
+    let probe = slm.clone();
+    let worker = worker_with_stub(&conn, slm);
     let result = worker.process_next_job();
     assert!(
         result.is_err(),
@@ -698,13 +703,30 @@ fn process_job_should_not_partially_advance_cursor_when_later_window_fails() {
 
     let parsed = format::parse(&dir.path().join(slash_to_platform(&conversation_path))).unwrap();
     assert_eq!(
-        parsed.frontmatter.last_extracted_turn, 0,
-        "cursor must not partially advance — window-1 success does not count when window-2 fails"
+        parsed.frontmatter.last_extracted_turn, 5,
+        "window-1 success must persist its cursor so a rerun skips it"
     );
-    assert_eq!(
-        parsed.frontmatter.last_extracted_at, None,
-        "last_extracted_at must remain unset when any window fails"
+    assert!(
+        parsed.frontmatter.last_extracted_at.is_some(),
+        "last_extracted_at must record the completed window"
     );
+
+    // The retry must resume from the persisted cursor: only turns 6..10.
+    let retried = worker.process_next_job().unwrap().unwrap();
+    assert_eq!(retried.session_id, "s1");
+
+    let calls = probe.recorded_calls();
+    assert_eq!(calls.len(), 3);
+    assert!(
+        calls[2]
+            .prompt
+            .contains("New turns to extract from (turns 6..10):"),
+        "retry must skip the already-completed window [1..5]; prompt: {}",
+        calls[2].prompt
+    );
+    let parsed_after_retry =
+        format::parse(&dir.path().join(slash_to_platform(&conversation_path))).unwrap();
+    assert_eq!(parsed_after_retry.frontmatter.last_extracted_turn, 10);
 }
 
 // ── spec item 5.2 gap — acceptance bar (currently unimplemented) ───────────

--- a/tests/fact_write.rs
+++ b/tests/fact_write.rs
@@ -259,13 +259,60 @@ fn write_fact_coexist_writes_null_supersedes_without_page_insert() {
 }
 
 #[test]
-fn write_fact_slug_collision_appends_counter_suffix() {
+fn write_fact_identical_rerun_reuses_existing_file_without_suffix() {
+    // Idempotency: a retried window re-renders the same fact; allocation
+    // must recognise the identical on-disk file (even across a different
+    // `extracted_at` stamp) and reuse the base slug instead of emitting a
+    // duplicate `-2` head.
     let dir = tempfile::TempDir::new().unwrap();
     let conn = open_test_db(&dir.path().join("memory.db"));
     let context = write_context(dir.path(), None);
     let fact = preference_fact("Matt prefers Rust");
 
     let first = write_fact_in_context(&Resolution::Coexist, &fact, &conn, &context).unwrap();
+    let first_path = dir.path().join(
+        first
+            .relative_path
+            .clone()
+            .unwrap()
+            .replace('/', std::path::MAIN_SEPARATOR_STR),
+    );
+    let first_bytes = fs::read(&first_path).unwrap();
+
+    let mut later_context = context;
+    later_context.extracted_at = "2026-05-05T09:07:31Z".to_string();
+    let rerun = write_fact_in_context(&Resolution::Coexist, &fact, &conn, &later_context).unwrap();
+
+    assert_eq!(first.slug, rerun.slug);
+    assert_eq!(first.relative_path, rerun.relative_path);
+    assert_eq!(
+        fs::read(&first_path).unwrap(),
+        first_bytes,
+        "idempotent rerun must leave the existing file's bytes untouched"
+    );
+}
+
+#[test]
+fn write_fact_true_slug_collision_appends_counter_suffix() {
+    // A genuinely different file already occupying the base path (e.g. an
+    // externally edited fact) must still push allocation to the `-2` suffix.
+    let dir = tempfile::TempDir::new().unwrap();
+    let conn = open_test_db(&dir.path().join("memory.db"));
+    let context = write_context(dir.path(), None);
+    let fact = preference_fact("Matt prefers Rust");
+
+    let first = write_fact_in_context(&Resolution::Coexist, &fact, &conn, &context).unwrap();
+    let first_path = dir.path().join(
+        first
+            .relative_path
+            .clone()
+            .unwrap()
+            .replace('/', std::path::MAIN_SEPARATOR_STR),
+    );
+    let mut tampered = fs::read_to_string(&first_path).unwrap();
+    tampered.push_str("\nManually edited addendum.\n");
+    fs::write(&first_path, tampered).unwrap();
+
     let second = write_fact_in_context(&Resolution::Coexist, &fact, &conn, &context).unwrap();
 
     assert_ne!(first.slug, second.slug);

--- a/tests/reconciler_supersede_wiring.rs
+++ b/tests/reconciler_supersede_wiring.rs
@@ -1,0 +1,188 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::print_stdout,
+    reason = "test fixtures legitimately panic on setup failure and print diagnostics; per-site #[expect] would generate noise across thousands of test sites"
+)]
+
+//! Watcher-ingest supersede wiring: `apply_reingest` must honour the
+//! `supersedes:` frontmatter that the extraction pipeline writes, retiring
+//! the prior head exactly like the synchronous `quaid ingest` path does, so
+//! a `(kind, key)` partition never accumulates two live heads.
+
+#[path = "common/reconciler_fixtures.rs"]
+mod common_reconciler_fixtures;
+
+use common_reconciler_fixtures::*;
+use quaid::core::reconciler::reconcile;
+use rusqlite::Connection;
+use std::fs;
+use tempfile::TempDir;
+
+fn page_row(conn: &Connection, slug: &str) -> (i64, Option<i64>) {
+    conn.query_row(
+        "SELECT id, superseded_by FROM pages WHERE collection_id = 1 AND slug = ?1",
+        [slug],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )
+    .unwrap()
+}
+
+fn preference_fact_markdown(slug: &str, supersedes: Option<&str>, body: &str) -> String {
+    let mut out = format!(
+        "---\nabout: beverage\nkind: preference\nslug: {slug}\ntitle: beverage\ntype: preference\n"
+    );
+    if let Some(supersedes) = supersedes {
+        out.push_str(&format!("supersedes: {supersedes}\n"));
+    }
+    out.push_str("---\n");
+    out.push_str(body);
+    out.push('\n');
+    out
+}
+
+#[cfg(unix)]
+#[test]
+fn reconcile_wires_superseded_by_from_supersedes_frontmatter() {
+    let conn = open_test_db();
+    let root = TempDir::new().unwrap();
+    let collection = insert_collection(&conn, root.path());
+    let fact_dir = root.path().join("extracted").join("preferences");
+    fs::create_dir_all(&fact_dir).unwrap();
+
+    fs::write(
+        fact_dir.join("beverage-aaaa.md"),
+        preference_fact_markdown(
+            "beverage-aaaa",
+            None,
+            "The user prefers tea over coffee in the evening.",
+        ),
+    )
+    .unwrap();
+    reconcile(&conn, &collection).unwrap();
+
+    // The extractor's supersede resolution writes a new file carrying
+    // `supersedes:` frontmatter; the watcher's reingest must retire the
+    // prior head when it picks the file up.
+    fs::write(
+        fact_dir.join("beverage-bbbb.md"),
+        preference_fact_markdown(
+            "beverage-bbbb",
+            Some("beverage-aaaa"),
+            "The user now prefers coffee at all times of day.",
+        ),
+    )
+    .unwrap();
+    reconcile(&conn, &collection).unwrap();
+
+    let (prior_id, prior_superseded_by) = page_row(&conn, "beverage-aaaa");
+    let (successor_id, successor_superseded_by) = page_row(&conn, "beverage-bbbb");
+    assert_eq!(
+        prior_superseded_by,
+        Some(successor_id),
+        "prior head must be retired by the watcher reingest"
+    );
+    assert_eq!(
+        successor_superseded_by, None,
+        "the superseding fact must be the sole live head"
+    );
+    assert_ne!(prior_id, successor_id);
+
+    let live_heads: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM pages
+             WHERE collection_id = 1
+               AND type = 'preference'
+               AND superseded_by IS NULL
+               AND json_extract(frontmatter, '$.about') = 'beverage'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        live_heads, 1,
+        "the (preference, beverage) partition must have exactly one live head"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn reconcile_reingest_is_idempotent_for_already_wired_supersede_chain() {
+    // Concept pages bypass the extracted-file edit flow, so a modified
+    // reingest re-runs the full apply path — including the supersede chain
+    // reconciliation — against an already-wired chain. The chain shape must
+    // stay stable across the rerun.
+    let conn = open_test_db();
+    let root = TempDir::new().unwrap();
+    let collection = insert_collection(&conn, root.path());
+    let notes_dir = root.path().join("notes");
+    fs::create_dir_all(&notes_dir).unwrap();
+
+    fs::write(
+        notes_dir.join("note-a.md"),
+        "---\nslug: notes/a\ntitle: Note A\ntype: concept\n---\nOriginal body that is long enough to ingest cleanly.\n",
+    )
+    .unwrap();
+    reconcile(&conn, &collection).unwrap();
+    fs::write(
+        notes_dir.join("note-b.md"),
+        "---\nslug: notes/b\nsupersedes: notes/a\ntitle: Note B\ntype: concept\n---\nReplacement body that is long enough to ingest cleanly.\n",
+    )
+    .unwrap();
+    reconcile(&conn, &collection).unwrap();
+
+    let (_, prior_superseded_by) = page_row(&conn, "notes/a");
+    let (successor_id, _) = page_row(&conn, "notes/b");
+    assert_eq!(prior_superseded_by, Some(successor_id), "chain wired");
+
+    // Modify the successor's body: the reingest re-runs the supersede chain
+    // call with the same target, which must be a no-op rather than an error.
+    fs::write(
+        notes_dir.join("note-b.md"),
+        "---\nslug: notes/b\nsupersedes: notes/a\ntitle: Note B\ntype: concept\n---\nEdited replacement body that is still long enough to ingest cleanly.\n",
+    )
+    .unwrap();
+    reconcile(&conn, &collection).unwrap();
+
+    let (_, prior_superseded_by) = page_row(&conn, "notes/a");
+    let (successor_id_after, successor_superseded_by) = page_row(&conn, "notes/b");
+    assert_eq!(successor_id_after, successor_id);
+    assert_eq!(prior_superseded_by, Some(successor_id));
+    assert_eq!(successor_superseded_by, None);
+}
+
+#[cfg(unix)]
+#[test]
+fn reconcile_tolerates_unresolvable_supersedes_target() {
+    // An externally edited file naming a nonexistent supersede target must
+    // not wedge the reconcile pass: the page still ingests, the chain is
+    // simply left unwired (logged at WARN).
+    let conn = open_test_db();
+    let root = TempDir::new().unwrap();
+    let collection = insert_collection(&conn, root.path());
+    let fact_dir = root.path().join("extracted").join("preferences");
+    fs::create_dir_all(&fact_dir).unwrap();
+
+    fs::write(
+        fact_dir.join("beverage-cccc.md"),
+        preference_fact_markdown(
+            "beverage-cccc",
+            Some("no-such-slug"),
+            "The user prefers sparkling water.",
+        ),
+    )
+    .unwrap();
+    reconcile(&conn, &collection).unwrap();
+
+    let (_, superseded_by) = page_row(&conn, "beverage-cccc");
+    assert_eq!(superseded_by, None);
+    let page_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM pages WHERE collection_id = 1",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(page_count, 1, "the page itself must still be ingested");
+}


### PR DESCRIPTION
**Stacked on #230** (`fable/w2-conn-hygiene`) — auto-retargets to main when #230 merges. Implements **Area 5 — extraction pipeline atomicity & idempotency** (plan steps 1–5; step 6's shared core writer deliberately deferred to the Area 16 write-path workstream).

## The four compounding failures, fixed
1. **Dead supersede pipeline**: the watcher's `apply_reingest` now reads `supersedes:` frontmatter and calls `reconcile_supersede_chain` inside its transaction (exactly as CLI `ingest` does) — prior heads finally get retired on watcher ingest, ending the `AmbiguousMatchingHeads` → parked-job cascade. Semantic failures tolerate-with-WARN (mirroring graph-artifact tolerance) so an external edit can't wedge a reconcile pass.
2. **Retry duplicates**: `allocate_output_path` is content-aware — an existing byte-identical fact file (modulo the volatile `extracted_at:` line) reuses the base slug as a no-op instead of emitting `-2.md`; the on-disk bytes stay untouched so the watcher's sha256 dedup also no-ops.
3. **Lost turns**: the cursor rewrite now holds the same mutex+flock as `append_turn` and rewrites **only** the cursor frontmatter lines (fresh re-read, byte-preserving) instead of dumping a whole pre-inference snapshot — a turn appended mid-extraction survives.
4. **Midnight stranding**: `queue::enqueue` collapses pending rows per `(session, conversation_path)` — a new day-file gets its own pending row, so the prior day's unextracted tail still processes.

Plus **per-window cursor advance** (step 5): reruns after mid-job failure/lease expiry skip completed windows instead of re-emitting facts (failure semantics documented in module docs; the old no-partial-advance test rewritten to assert resume-from-window-2).

## Validation
fmt/clippy (-D warnings)/rustdoc clean. New suites: extraction_atomicity (2 — incl. a channel-blocked-SLM concurrency test where an append during inference survives), reconciler_supersede_wiring (3), extraction_idempotency variant that re-runs `process_next_job` **without** the manual `ingest::run` the old test used to mask the bug. ~25 targeted suites green incl. extraction_worker (11), extraction_queue (8), fact_write (9), supersede_chain (40), all reconciler suites, watcher_core, airgap_extraction.

## Merge notes
- `apply_reingest` edit kept to one additive ~35-line block; the namespace PR #232 will thread its derived namespace into this single call site (currently `""`, matching what apply_reingest writes today). Whichever merges second has a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)