### PR TITLE
fix(vault-sync): truthful quarantine, isolated heartbeat, fail-safe staleness, per-file dup-uuid (area 6)

### DIFF
--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -363,6 +363,7 @@ fn open_connection(path: &str) -> Result<Connection, DbError> {
     ensure_serve_session_columns(&conn)?;
     ensure_collection_name_guards(&conn)?;
     ensure_raw_import_hash_schema(&conn)?;
+    ensure_file_state_uuid_cache_schema(&conn)?;
     set_version(&conn)?;
     ensure_default_collection(&conn)?;
 
@@ -691,6 +692,29 @@ fn ensure_raw_import_hash_schema(conn: &Connection) -> Result<(), DbError> {
             )?;
         }
         tx.commit()?;
+    }
+
+    Ok(())
+}
+
+/// Adds the `file_state.frontmatter_uuid` cache column to databases created
+/// before it existed in `schema.sql`. NULL means "not yet cached" so the
+/// reconciler's duplicate-uuid scan lazily backfills it on the next pass;
+/// no eager backfill is needed here.
+fn ensure_file_state_uuid_cache_schema(conn: &Connection) -> Result<(), DbError> {
+    if !table_exists(conn, "file_state")? {
+        return Ok(());
+    }
+
+    let mut stmt = conn.prepare("PRAGMA table_info(file_state)")?;
+    let existing_columns = stmt
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<Result<HashSet<_>, _>>()?;
+
+    if !existing_columns.contains("frontmatter_uuid") {
+        conn.execute_batch(
+            "ALTER TABLE file_state ADD COLUMN frontmatter_uuid TEXT DEFAULT NULL;",
+        )?;
     }
 
     Ok(())

--- a/src/core/file_state.rs
+++ b/src/core/file_state.rs
@@ -163,6 +163,11 @@ pub struct FileStateRow {
 /// Upsert a `file_state` row after ingesting a file.
 ///
 /// This should be called in the same transaction as the `pages` insert/update.
+///
+/// Resets `frontmatter_uuid` to NULL ("not yet cached") on conflict so callers
+/// that install new content at an existing path (reingest, restore, remap)
+/// can never leave a stale uuid cache behind; the reconciler's duplicate-uuid
+/// scan re-reads and re-caches the value on its next pass.
 pub fn upsert_file_state(
     conn: &Connection,
     collection_id: i64,
@@ -181,6 +186,7 @@ pub fn upsert_file_state(
              size_bytes = excluded.size_bytes,
              inode = excluded.inode,
              sha256 = excluded.sha256,
+             frontmatter_uuid = NULL,
              last_seen_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now'),
              last_full_hash_at = excluded.last_full_hash_at",
         rusqlite::params![

--- a/src/core/reconciler.rs
+++ b/src/core/reconciler.rs
@@ -34,7 +34,7 @@ use crate::core::raw_imports;
 use ignore::WalkBuilder;
 use rusqlite::{params, Connection, OptionalExtension};
 use sha2::{Digest, Sha256};
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::ffi::OsStr;
 use std::fs;
 #[cfg(unix)]
@@ -77,8 +77,11 @@ pub struct ReconcileStats {
     /// Missing/new pairs resolved by matching a uniquely-identifying content
     /// hash across both sides.
     pub hash_renamed: usize,
-    /// Pages quarantined because rename resolution found multiple candidate
-    /// matches and could not pick safely.
+    /// Pages actually quarantined this pass because their disposition could
+    /// not be resolved safely: rename resolution found multiple candidate
+    /// matches, or the on-disk file lost a duplicate-uuid contest. Counted
+    /// at apply time, so the number is truthful (a page later reclaimed by a
+    /// slug-matching reingest in the same pass is not counted).
     pub quarantined_ambiguous: usize,
     /// Pages quarantined because the database row carries state (links,
     /// tags, …) that must not be silently dropped on delete.
@@ -232,6 +235,9 @@ impl DriftCaptureSummary {
         Self {
             pages_updated: stats.modified,
             pages_added: stats.new,
+            // Both counters are recorded at apply time (see ApplySummary), so
+            // this reports pages that were actually quarantined — not merely
+            // paths whose rename inference was refused.
             pages_quarantined: stats.quarantined_ambiguous + stats.quarantined_db_state,
             pages_deleted: stats.hard_deleted,
         }
@@ -370,23 +376,41 @@ pub(crate) fn reconcile_with_native_events(
                     "reconcile: refusing to walk with stale .quaidignore state: {err}"
                 ))
             })?;
-        let walked = walk_collection(conn, &root_fd, collection)?;
-        detect_duplicate_uuids_in_tree(Path::new(&collection.root_path), &walked.files)?;
-        let diff = stat_diff_from_walk(
+        let mut walked = walk_collection(conn, &root_fd, collection)?;
+        let duplicate_losers = detect_duplicate_uuids_in_tree(
+            conn,
+            collection.id,
+            Path::new(&collection.root_path),
+            &walked.files,
+            UuidCachePolicy::TrustStatCache,
+        )?;
+        for loser in &duplicate_losers {
+            walked.files.remove(loser);
+        }
+        let mut diff = stat_diff_from_walk(
             conn,
             collection.id,
             Path::new(&collection.root_path),
             walked.files,
         )?;
-        let rename_resolution = resolve_rename_resolution(
+        // Tracked duplicate-uuid losers land in `missing` (their file_state
+        // row exists but the file was excluded above); divert them to the
+        // quarantine path so the delete/quarantine pass can't fire on them.
+        let tracked_losers: Vec<PathBuf> = duplicate_losers
+            .iter()
+            .filter(|loser| diff.missing.remove(*loser))
+            .cloned()
+            .collect();
+        let mut rename_resolution = resolve_rename_resolution(
             conn,
             collection.id,
             Path::new(&collection.root_path),
             &diff,
             native_renames,
         )?;
+        rename_resolution.ambiguous.extend(tracked_losers);
         eprintln!(
-            "INFO: reconcile_plan collection={} walked={} unchanged={} modified={} new={} missing={} native_renamed={} hash_renamed={} quarantined_ambiguous={}",
+            "INFO: reconcile_plan collection={} walked={} unchanged={} modified={} new={} missing={} native_renamed={} hash_renamed={} unresolved_quarantine_candidates={}",
             collection.name,
             walked.walked,
             diff.unchanged.len(),
@@ -395,7 +419,7 @@ pub(crate) fn reconcile_with_native_events(
             rename_resolution.remaining_missing.len(),
             rename_resolution.native_renamed,
             rename_resolution.hash_renamed,
-            rename_resolution.quarantined_ambiguous
+            rename_resolution.ambiguous.len()
         );
         let apply_summary = apply_reconciliation(
             conn,
@@ -405,10 +429,11 @@ pub(crate) fn reconcile_with_native_events(
             Path::new(&collection.root_path),
         )?;
         eprintln!(
-            "INFO: reconcile_apply collection={} reingested={} created={} quarantined_db_state={} hard_deleted={}",
+            "INFO: reconcile_apply collection={} reingested={} created={} quarantined_ambiguous={} quarantined_db_state={} hard_deleted={}",
             collection.name,
             apply_summary.reingested,
             apply_summary.created,
+            apply_summary.quarantined_ambiguous,
             apply_summary.quarantined_db_state,
             apply_summary.hard_deleted
         );
@@ -422,7 +447,7 @@ pub(crate) fn reconcile_with_native_events(
             native_renamed: rename_resolution.native_renamed,
             uuid_renamed: rename_resolution.uuid_renamed,
             hash_renamed: rename_resolution.hash_renamed,
-            quarantined_ambiguous: rename_resolution.quarantined_ambiguous,
+            quarantined_ambiguous: apply_summary.quarantined_ambiguous,
             quarantined_db_state: apply_summary.quarantined_db_state,
             hard_deleted: apply_summary.hard_deleted,
         })
@@ -516,11 +541,28 @@ pub fn full_hash_reconcile_authorized(
                 "full_hash_reconcile: refusing to walk with stale .quaidignore state: {err}"
             ))
         })?;
-        let walked = walk_collection(conn, &root_fd, &collection)?;
-        detect_duplicate_uuids_in_tree(root_path, &walked.files)?;
-        let plan = build_full_hash_plan(conn, collection.id, root_path, &walked.files)?;
-        let rename_resolution =
+        let mut walked = walk_collection(conn, &root_fd, &collection)?;
+        // Full-hash passes exist to catch content drift behind unchanged
+        // stats, so the uuid stat-cache is bypassed (every file is re-read).
+        let duplicate_losers = detect_duplicate_uuids_in_tree(
+            conn,
+            collection.id,
+            root_path,
+            &walked.files,
+            UuidCachePolicy::Bypass,
+        )?;
+        for loser in &duplicate_losers {
+            walked.files.remove(loser);
+        }
+        let mut plan = build_full_hash_plan(conn, collection.id, root_path, &walked.files)?;
+        let tracked_losers: Vec<PathBuf> = duplicate_losers
+            .iter()
+            .filter(|loser| plan.diff.missing.remove(*loser))
+            .cloned()
+            .collect();
+        let mut rename_resolution =
             resolve_rename_resolution(conn, collection.id, root_path, &plan.diff, &[])?;
+        rename_resolution.ambiguous.extend(tracked_losers);
 
         assert_full_hash_raw_import_invariants(conn, collection.id)?;
         apply_full_hash_metadata_self_heal(conn, collection.id, &plan.unchanged)?;
@@ -536,7 +578,7 @@ pub fn full_hash_reconcile_authorized(
             native_renamed: rename_resolution.native_renamed,
             uuid_renamed: rename_resolution.uuid_renamed,
             hash_renamed: rename_resolution.hash_renamed,
-            quarantined_ambiguous: rename_resolution.quarantined_ambiguous,
+            quarantined_ambiguous: apply_summary.quarantined_ambiguous,
             quarantined_db_state: apply_summary.quarantined_db_state,
             hard_deleted: apply_summary.hard_deleted,
         })
@@ -1771,7 +1813,13 @@ struct RenameResolution {
     native_renamed: usize,
     uuid_renamed: usize,
     hash_renamed: usize,
-    quarantined_ambiguous: usize,
+    /// Missing paths whose page must be quarantined (not deleted) because
+    /// its disposition could not be resolved safely: rename inference found
+    /// multiple candidates, or the file lost a duplicate-uuid contest.
+    /// `build_apply_actions` turns each entry into a `QuarantinePage` action
+    /// so the page row — with its links, assertions, and history — survives
+    /// instead of being deleted by the next pass.
+    ambiguous: BTreeSet<PathBuf>,
     remaining_new: HashMap<PathBuf, FileStat>,
     remaining_missing: HashSet<PathBuf>,
     matches: Vec<RenameMatch>,
@@ -1780,6 +1828,14 @@ struct RenameResolution {
 #[derive(Debug, Clone)]
 enum ApplyAction {
     DeleteOrQuarantine {
+        page_id: i64,
+        relative_path: PathBuf,
+    },
+    /// Quarantine a page whose disposition could not be resolved safely
+    /// (ambiguous rename inference or duplicate-uuid loser): sets
+    /// `pages.quarantined_at` and clears the `file_state` binding so the
+    /// next pass neither deletes the page nor treats the path as missing.
+    QuarantinePage {
         page_id: i64,
         relative_path: PathBuf,
     },
@@ -1795,6 +1851,7 @@ enum ApplyAction {
 struct ApplySummary {
     reingested: usize,
     created: usize,
+    quarantined_ambiguous: usize,
     quarantined_db_state: usize,
     hard_deleted: usize,
 }
@@ -1936,7 +1993,7 @@ fn apply_uuid_rename_matches(
             [] => {}
             _ => {
                 resolution.remaining_missing.remove(&path);
-                resolution.quarantined_ambiguous += 1;
+                resolution.ambiguous.insert(path);
             }
         }
     }
@@ -2044,13 +2101,13 @@ fn apply_hash_rename_matches(
                 };
                 log_hash_refusal(&reason, &path, &remaining_candidates);
                 resolution.remaining_missing.remove(&path);
-                resolution.quarantined_ambiguous += 1;
+                resolution.ambiguous.insert(path);
             }
             PageIdentityResolution::DuplicateUuid { .. } => {
                 let reason = "duplicate_uuid_candidates".to_owned();
                 log_hash_refusal(&reason, &path, &remaining_candidates);
                 resolution.remaining_missing.remove(&path);
-                resolution.quarantined_ambiguous += 1;
+                resolution.ambiguous.insert(path);
             }
         }
     }
@@ -2224,37 +2281,159 @@ fn load_new_tree_identities(
     Ok(identities)
 }
 
+/// Whether the duplicate-uuid scan may trust the `file_state.frontmatter_uuid`
+/// cache for files whose stat tuple is unchanged, or must re-read every file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UuidCachePolicy {
+    /// Trust the cached uuid when the stored stat tuple matches the walked
+    /// one — the watcher-driven hot path, where re-reading every file's
+    /// bytes on every reconcile is the cost being avoided.
+    TrustStatCache,
+    /// Re-read every file regardless of stat metadata (full-hash passes,
+    /// which exist precisely to catch content drift behind unchanged stats).
+    /// Fresh values are still written back to the cache.
+    Bypass,
+}
+
+/// Detects files that share a frontmatter uuid and resolves each conflict
+/// per file instead of halting the collection: within each duplicate group
+/// the file currently tracked in `file_state` wins (falling back to oldest
+/// mtime, then lexicographically-first path), and every other file is
+/// quarantined — excluded from this reconciliation pass and reported back to
+/// the caller — with an ERROR log naming the uuid, loser, and winner. The
+/// losing bytes are left untouched on disk so the conflict is reversible by
+/// editing the uuid; a git merge-conflict copy therefore degrades to one
+/// loudly-skipped file rather than a collection-wide `reconcile_halted_at`.
+///
+/// Caches each file's frontmatter uuid in `file_state.frontmatter_uuid`
+/// (`''` = no uuid) so unchanged files are not re-read on subsequent passes.
 fn detect_duplicate_uuids_in_tree(
+    conn: &Connection,
+    collection_id: i64,
     root_path: &Path,
     walked_files: &HashMap<PathBuf, FileStat>,
-) -> Result<(), ReconcileError> {
+    cache_policy: UuidCachePolicy,
+) -> Result<Vec<PathBuf>, ReconcileError> {
     let mut relative_paths = walked_files.keys().cloned().collect::<Vec<_>>();
     relative_paths.sort();
 
-    let mut uuids: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    let cached = load_frontmatter_uuid_cache(conn, collection_id)?;
+    let mut update_cache_stmt = conn.prepare(
+        "UPDATE file_state
+         SET frontmatter_uuid = ?3
+         WHERE collection_id = ?1 AND relative_path = ?2",
+    )?;
+
+    let mut uuids: BTreeMap<String, Vec<PathBuf>> = BTreeMap::new();
     for relative_path in relative_paths {
-        let absolute_path = root_path.join(&relative_path);
-        let raw_bytes = fs::read(&absolute_path)?;
-        let raw = String::from_utf8_lossy(&raw_bytes);
-        let (frontmatter, _) = markdown::parse_frontmatter(&raw);
-        if let Some(uuid) = page_uuid::parse_frontmatter_uuid(&frontmatter).map_err(|err| {
-            ReconcileError::Other(format!(
-                "detect_duplicate_uuids_in_tree: {} has invalid frontmatter uuid: {err}",
-                relative_path.display()
-            ))
-        })? {
-            uuids
-                .entry(uuid)
-                .or_default()
-                .push(path_to_string(&relative_path));
+        let walked_stat = &walked_files[&relative_path];
+        let cache_entry = cached.get(&relative_path);
+        let cached_uuid = match (cache_policy, cache_entry) {
+            (UuidCachePolicy::TrustStatCache, Some((stored_stat, Some(cached_uuid))))
+                if !file_state::stat_differs(walked_stat, stored_stat) =>
+            {
+                Some(cached_uuid.clone())
+            }
+            _ => None,
+        };
+        let uuid = match cached_uuid {
+            Some(cached_uuid) if cached_uuid.is_empty() => None,
+            Some(cached_uuid) => Some(cached_uuid),
+            None => {
+                let absolute_path = root_path.join(&relative_path);
+                let raw_bytes = fs::read(&absolute_path)?;
+                let raw = String::from_utf8_lossy(&raw_bytes);
+                let (frontmatter, _) = markdown::parse_frontmatter(&raw);
+                let parsed_uuid =
+                    page_uuid::parse_frontmatter_uuid(&frontmatter).map_err(|err| {
+                        ReconcileError::Other(format!(
+                            "detect_duplicate_uuids_in_tree: {} has invalid frontmatter uuid: {err}",
+                            relative_path.display()
+                        ))
+                    })?;
+                if cache_entry.is_some() {
+                    update_cache_stmt.execute(params![
+                        collection_id,
+                        path_to_string(&relative_path),
+                        parsed_uuid.clone().unwrap_or_default(),
+                    ])?;
+                }
+                parsed_uuid
+            }
+        };
+        if let Some(uuid) = uuid {
+            uuids.entry(uuid).or_default().push(relative_path);
         }
     }
 
-    if let Some((uuid, paths)) = uuids.into_iter().find(|(_, paths)| paths.len() > 1) {
-        return Err(ReconcileError::DuplicateUuidError { uuid, paths });
+    let mut quarantined = Vec::new();
+    for (uuid, paths) in uuids {
+        if paths.len() < 2 {
+            continue;
+        }
+        let winner = paths
+            .iter()
+            .min_by_key(|path| {
+                (
+                    // Prefer the file already bound in file_state: quarantining
+                    // an untracked conflict copy touches no page row, while
+                    // quarantining the tracked original would orphan its page.
+                    usize::from(!cached.contains_key(*path)),
+                    walked_files[*path].mtime_ns,
+                    (*path).clone(),
+                )
+            })
+            .cloned()
+            .unwrap_or_default();
+        for path in paths {
+            if path == winner {
+                continue;
+            }
+            eprintln!(
+                "ERROR: reconcile_duplicate_uuid_file_quarantined uuid={} loser={} winner={} \
+                 (file left on disk and excluded from sync; edit its frontmatter uuid to resolve)",
+                uuid,
+                path.display(),
+                winner.display()
+            );
+            quarantined.push(path);
+        }
     }
 
-    Ok(())
+    quarantined.sort();
+    Ok(quarantined)
+}
+
+/// Loads the per-path `(stored stat tuple, cached frontmatter uuid)` map the
+/// duplicate-uuid scan consults; `None` uuid = never cached, `Some("")` =
+/// cached as "file has no frontmatter uuid".
+fn load_frontmatter_uuid_cache(
+    conn: &Connection,
+    collection_id: i64,
+) -> Result<HashMap<PathBuf, (FileStat, Option<String>)>, ReconcileError> {
+    let mut stmt = conn.prepare(
+        "SELECT relative_path, mtime_ns, ctime_ns, size_bytes, inode, frontmatter_uuid
+         FROM file_state
+         WHERE collection_id = ?1",
+    )?;
+    let rows = stmt.query_map([collection_id], |row| {
+        let path: String = row.get(0)?;
+        let stat = FileStat {
+            mtime_ns: row.get(1)?,
+            ctime_ns: row.get(2)?,
+            size_bytes: row.get(3)?,
+            inode: row.get(4)?,
+        };
+        let cached_uuid: Option<String> = row.get(5)?;
+        Ok((PathBuf::from(path), (stat, cached_uuid)))
+    })?;
+
+    let mut cache = HashMap::new();
+    for row in rows {
+        let (path, entry) = row?;
+        cache.insert(path, entry);
+    }
+    Ok(cache)
 }
 
 // ── DB-Only State Predicate (stub) ────────────────────────────
@@ -2659,6 +2838,18 @@ fn build_apply_actions(
         });
     }
 
+    // Quarantine actions run after every reingest so a page that a
+    // slug-matching reingest legitimately reclaimed in this pass is left
+    // alive instead of being quarantined out from under its new binding.
+    for relative_path in &rename_resolution.ambiguous {
+        if let Some(page_id) = page_id_for_relative_path(conn, collection_id, relative_path)? {
+            actions.push(ApplyAction::QuarantinePage {
+                page_id,
+                relative_path: relative_path.clone(),
+            });
+        }
+    }
+
     Ok(actions)
 }
 
@@ -2674,6 +2865,12 @@ fn apply_action(
             page_id,
             relative_path,
         } => apply_delete_or_quarantine(conn, collection_id, *page_id, relative_path, summary),
+        ApplyAction::QuarantinePage {
+            page_id,
+            relative_path,
+        } => {
+            apply_quarantine_unresolved_page(conn, collection_id, *page_id, relative_path, summary)
+        }
         ApplyAction::Reingest {
             existing_page_id,
             old_relative_path,
@@ -2734,6 +2931,53 @@ fn apply_delete_or_quarantine(
     tx.execute("DELETE FROM pages WHERE id = ?1", [page_id])?;
     tx.commit()?;
     summary.hard_deleted += 1;
+    Ok(())
+}
+
+/// Quarantines a page whose missing path could not be resolved safely
+/// (ambiguous rename inference or duplicate-uuid loser): clears the stale
+/// `file_state` binding and sets `pages.quarantined_at` so the page — with
+/// its links, assertions, and version history — survives instead of being
+/// deleted on the next pass. If a reingest earlier in the same pass already
+/// reclaimed the page under a new path (slug match), the page is left alive
+/// and only the stale binding is removed; nothing is counted as quarantined
+/// in that case, keeping `ReconcileStats::quarantined_ambiguous` truthful.
+fn apply_quarantine_unresolved_page(
+    conn: &Connection,
+    collection_id: i64,
+    page_id: i64,
+    relative_path: &Path,
+    summary: &mut ApplySummary,
+) -> Result<(), ReconcileError> {
+    let tx = conn.unchecked_transaction()?;
+    file_state::delete_file_state(&tx, collection_id, &path_to_string(relative_path))?;
+    let still_bound: i64 = tx.query_row(
+        "SELECT COUNT(*) FROM file_state WHERE page_id = ?1",
+        [page_id],
+        |row| row.get(0),
+    )?;
+    if still_bound > 0 {
+        tx.commit()?;
+        eprintln!(
+            "INFO: reconcile_unresolved_page_reclaimed page_id={} stale_path={}",
+            page_id,
+            relative_path.display()
+        );
+        return Ok(());
+    }
+    tx.execute(
+        "UPDATE pages
+         SET quarantined_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+         WHERE id = ?1",
+        [page_id],
+    )?;
+    tx.commit()?;
+    summary.quarantined_ambiguous += 1;
+    eprintln!(
+        "WARN: reconcile_quarantined_unresolved page_id={} path={}",
+        page_id,
+        relative_path.display()
+    );
     Ok(())
 }
 
@@ -5426,7 +5670,8 @@ mod tests {
             resolve_rename_resolution(&conn, collection.id, root.path(), &diff, &[]).unwrap();
 
         assert_eq!(resolution.hash_renamed, 0);
-        assert_eq!(resolution.quarantined_ambiguous, 1);
+        assert_eq!(resolution.ambiguous.len(), 1);
+        assert!(resolution.ambiguous.contains(Path::new("old-name.md")));
         assert_eq!(resolution.remaining_new.len(), 2);
         assert!(resolution.remaining_missing.is_empty());
     }
@@ -6027,7 +6272,9 @@ mod tests {
 
     #[test]
     fn detect_duplicate_uuids_in_tree_rejects_invalid_frontmatter_uuid() {
+        let conn = open_test_db();
         let root = TempDir::new().unwrap();
+        let collection = insert_collection(&conn, root.path());
         fs::write(
             root.path().join("broken.md"),
             b"---\nmemory_id: not-a-uuid\ntitle: Broken\ntype: concept\n---\nbody\n",
@@ -6038,33 +6285,107 @@ mod tests {
             stat_for(root.path(), "broken.md"),
         )]);
 
-        let error = detect_duplicate_uuids_in_tree(root.path(), &walked_files).unwrap_err();
+        let error = detect_duplicate_uuids_in_tree(
+            &conn,
+            collection.id,
+            root.path(),
+            &walked_files,
+            UuidCachePolicy::TrustStatCache,
+        )
+        .unwrap_err();
 
         assert!(error
             .to_string()
             .contains("detect_duplicate_uuids_in_tree: broken.md has invalid frontmatter uuid"));
     }
 
+    // Formerly an abort expectation (collection-wide DuplicateUuidError):
+    // duplicate frontmatter uuids now quarantine per file, newest mtime
+    // losing, so a git merge-conflict copy can't halt the collection.
     #[test]
-    fn detect_duplicate_uuids_in_tree_rejects_duplicate_uuid_paths() {
+    fn detect_duplicate_uuids_in_tree_quarantines_newest_mtime_loser() {
+        let conn = open_test_db();
         let root = TempDir::new().unwrap();
+        let collection = insert_collection(&conn, root.path());
         let raw_bytes =
             b"---\nmemory_id: 01969f11-9448-7d79-8d3f-c68f54761234\ntitle: Duplicate\ntype: concept\n---\nbody\n";
         fs::write(root.path().join("one.md"), raw_bytes).unwrap();
         fs::write(root.path().join("two.md"), raw_bytes).unwrap();
+        let older = FileStat {
+            mtime_ns: 1_000,
+            ctime_ns: Some(1_000),
+            size_bytes: raw_bytes.len() as i64,
+            inode: Some(1),
+        };
+        let newer = FileStat {
+            mtime_ns: 2_000,
+            ctime_ns: Some(2_000),
+            size_bytes: raw_bytes.len() as i64,
+            inode: Some(2),
+        };
         let walked_files = HashMap::from([
-            (PathBuf::from("one.md"), stat_for(root.path(), "one.md")),
-            (PathBuf::from("two.md"), stat_for(root.path(), "two.md")),
+            (PathBuf::from("one.md"), older),
+            (PathBuf::from("two.md"), newer),
         ]);
 
-        let error = detect_duplicate_uuids_in_tree(root.path(), &walked_files).unwrap_err();
+        let quarantined = detect_duplicate_uuids_in_tree(
+            &conn,
+            collection.id,
+            root.path(),
+            &walked_files,
+            UuidCachePolicy::TrustStatCache,
+        )
+        .unwrap();
 
-        assert!(matches!(
-            error,
-            ReconcileError::DuplicateUuidError { ref uuid, ref paths }
-                if uuid == "01969f11-9448-7d79-8d3f-c68f54761234"
-                    && paths == &vec!["one.md".to_owned(), "two.md".to_owned()]
-        ));
+        assert_eq!(quarantined, vec![PathBuf::from("two.md")]);
+    }
+
+    // The file already tracked in file_state wins even when it is newer:
+    // quarantining an untracked conflict copy touches no page row, while
+    // quarantining the tracked original would orphan its page.
+    #[test]
+    fn detect_duplicate_uuids_in_tree_prefers_tracked_file_over_mtime() {
+        let conn = open_test_db();
+        let root = TempDir::new().unwrap();
+        let collection = insert_collection(&conn, root.path());
+        let raw_bytes =
+            b"---\nmemory_id: 01969f11-9448-7d79-8d3f-c68f54761234\ntitle: Duplicate\ntype: concept\n---\nbody\n";
+        fs::write(root.path().join("tracked.md"), raw_bytes).unwrap();
+        fs::write(root.path().join("copy.md"), raw_bytes).unwrap();
+        let tracked_stat = FileStat {
+            mtime_ns: 2_000,
+            ctime_ns: Some(2_000),
+            size_bytes: raw_bytes.len() as i64,
+            inode: Some(1),
+        };
+        let copy_stat = FileStat {
+            mtime_ns: 1_000,
+            ctime_ns: Some(1_000),
+            size_bytes: raw_bytes.len() as i64,
+            inode: Some(2),
+        };
+        seed_file_state(
+            &conn,
+            collection.id,
+            "notes/tracked",
+            "tracked.md",
+            &tracked_stat,
+        );
+        let walked_files = HashMap::from([
+            (PathBuf::from("tracked.md"), tracked_stat),
+            (PathBuf::from("copy.md"), copy_stat),
+        ]);
+
+        let quarantined = detect_duplicate_uuids_in_tree(
+            &conn,
+            collection.id,
+            root.path(),
+            &walked_files,
+            UuidCachePolicy::TrustStatCache,
+        )
+        .unwrap();
+
+        assert_eq!(quarantined, vec![PathBuf::from("copy.md")]);
     }
 
     #[test]

--- a/src/core/vault_sync/mod.rs
+++ b/src/core/vault_sync/mod.rs
@@ -1711,6 +1711,24 @@ fn sync_collection_watchers(
         if !needs_replace {
             continue;
         }
+        let rearming_after_crash = watchers
+            .get(&collection_id)
+            .is_some_and(|state| matches!(state.mode, WatcherMode::Crashed));
+        if rearming_after_crash {
+            // Fail-safe staleness: the crash discarded the event buffer, so
+            // events may have been lost while the watcher was down. Flag the
+            // collection for a full-hash recovery pass before trusting
+            // incremental events again; a failed flag write is logged loudly
+            // because silence here is exactly how collections go stale.
+            match mark_collection_needs_full_sync(conn, collection_id) {
+                Ok(()) => eprintln!(
+                    "WARN: watcher_rearm_flagged_full_sync collection_id={collection_id}"
+                ),
+                Err(error) => eprintln!(
+                    "ERROR: watcher_rearm_needs_full_sync_write_failed collection_id={collection_id} error={error}"
+                ),
+            }
+        }
         let previous_failures = watchers
             .get(&collection_id)
             .map(|state| state.consecutive_failures)
@@ -2881,7 +2899,19 @@ fn run_supervisor_loop(
     #[cfg(unix)] ipc_in_flight: Arc<AtomicUsize>,
     #[cfg(unix)] mut watchers: HashMap<i64, CollectionWatcherState>,
 ) {
-    let mut last_heartbeat = Instant::now();
+    // The session heartbeat runs on its own thread so long work on this
+    // thread (watcher reconciles, full-hash audits, inline embedding
+    // inference) can never stall the keepalive past SESSION_LIVENESS_SECS —
+    // which would let another process's sweep delete the live session and
+    // hand runtime ownership away mid-operation.
+    let heartbeat_handle = {
+        let heartbeat_db_path = db_path.clone();
+        let heartbeat_session_id = session_id_for_thread.clone();
+        let heartbeat_stop = Arc::clone(&stop_signal);
+        thread::spawn(move || {
+            run_session_heartbeat_loop(&heartbeat_db_path, &heartbeat_session_id, &heartbeat_stop);
+        })
+    };
     let mut last_idle_close_sweep =
         Instant::now() - Duration::from_secs(IDLE_CLOSE_SWEEP_INTERVAL_SECS);
     let mut last_janitor_sweep = Instant::now() - Duration::from_secs(JANITOR_SWEEP_INTERVAL_SECS);
@@ -2898,12 +2928,8 @@ fn run_supervisor_loop(
     let mut last_embedding_drain =
         Instant::now() - Duration::from_secs(embedding::drain_interval_secs());
     while !stop_signal.load(Ordering::SeqCst) {
+        maybe_hold_supervisor_tick_for_tests(&stop_signal);
         if let Ok(conn) = db::open_runtime(&db_path) {
-            if last_heartbeat.elapsed() >= Duration::from_secs(HEARTBEAT_INTERVAL_SECS) {
-                let _ = sweep_stale_sessions(&conn);
-                let _ = heartbeat_session(&conn, &session_id_for_thread);
-                last_heartbeat = Instant::now();
-            }
             if last_idle_close_sweep.elapsed()
                 >= Duration::from_secs(IDLE_CLOSE_SWEEP_INTERVAL_SECS)
             {
@@ -3034,11 +3060,67 @@ fn run_supervisor_loop(
         }
         thread::sleep(Duration::from_millis(DEFERRED_RETRY_SECS * 200));
     }
+    // Stop the heartbeat before unregistering so a final keepalive can't
+    // race the session-row delete.
+    let _ = heartbeat_handle.join();
     if let Ok(conn) = db::open_runtime(&db_path) {
         #[cfg(unix)]
         let _ = cleanup_published_ipc_socket(&conn, &session_id_for_thread, &published_ipc.path);
         let _ = clear_supervisor_handles_for_session(&session_id_for_thread);
         let _ = unregister_session(&conn, &session_id_for_thread);
+    }
+}
+
+/// Dedicated session-heartbeat loop: refreshes `serve_sessions.heartbeat_at`
+/// (and runs the stale-session sweep) every `HEARTBEAT_INTERVAL_SECS` on a
+/// fresh [`db::open_runtime`] connection, fully isolated from the supervisor
+/// work thread so a long reconcile, audit, or inference pass cannot starve
+/// the keepalive. Failures are logged instead of swallowed — a heartbeat
+/// that silently stops is exactly how runtime ownership gets stolen.
+fn run_session_heartbeat_loop(db_path: &str, session_id: &str, stop: &AtomicBool) {
+    while !stop.load(Ordering::SeqCst) {
+        match db::open_runtime(db_path) {
+            Ok(conn) => {
+                if let Err(error) = sweep_stale_sessions(&conn) {
+                    eprintln!("WARN: session_sweep_failed session_id={session_id} error={error}");
+                }
+                if let Err(error) = heartbeat_session(&conn, session_id) {
+                    eprintln!(
+                        "WARN: session_heartbeat_failed session_id={session_id} error={error}"
+                    );
+                }
+            }
+            Err(error) => {
+                eprintln!(
+                    "WARN: session_heartbeat_open_failed session_id={session_id} error={error}"
+                );
+            }
+        }
+        let deadline = Instant::now() + Duration::from_secs(HEARTBEAT_INTERVAL_SECS);
+        while Instant::now() < deadline {
+            if stop.load(Ordering::SeqCst) {
+                return;
+            }
+            thread::sleep(Duration::from_millis(100));
+        }
+    }
+}
+
+/// Test-only injection point (mirroring `QUAID_TEST_APPEND_TURN_HOLD_MS` in
+/// `turn_writer`): when `QUAID_TEST_SUPERVISOR_TICK_HOLD_MS` is set, every
+/// supervisor work tick sleeps that long in stop-aware slices, simulating a
+/// long reconcile so integration tests can prove the dedicated heartbeat
+/// thread keeps the session alive while the work thread is busy.
+fn maybe_hold_supervisor_tick_for_tests(stop: &AtomicBool) {
+    let Some(raw_ms) = std::env::var_os("QUAID_TEST_SUPERVISOR_TICK_HOLD_MS") else {
+        return;
+    };
+    let Ok(hold_ms) = raw_ms.to_string_lossy().parse::<u64>() else {
+        return;
+    };
+    let deadline = Instant::now() + Duration::from_millis(hold_ms);
+    while Instant::now() < deadline && !stop.load(Ordering::SeqCst) {
+        thread::sleep(Duration::from_millis(25));
     }
 }
 
@@ -5129,6 +5211,16 @@ mod tests {
             WatcherMode::Native | WatcherMode::Poll
         ));
         assert!(!matches!(restarted.mode, WatcherMode::Crashed));
+        // Crash re-arm is fail-safe: events may have been lost while the
+        // watcher was down, so the re-arm must flag a full recovery pass.
+        let needs_full_sync: i64 = conn
+            .query_row(
+                "SELECT needs_full_sync FROM collections WHERE id = ?1",
+                [collection_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(needs_full_sync, 1);
     }
 
     #[cfg(unix)]
@@ -5806,15 +5898,28 @@ mod tests {
         let (dir, db_path, conn) = open_test_db_file();
         let root = tempfile::TempDir::new().unwrap();
         let collection_id = insert_collection(&conn, "work", root.path());
-        let uuid = "01969f11-9448-7d79-8d3f-c68f54768890";
-        let note_a = format!(
-            "---\nmemory_id: {uuid}\nslug: notes/a\ntitle: A\ntype: concept\n---\nThis body is comfortably above the minimum size for rename inference.\n"
+        // Duplicate uuids no longer halt reconcile (they quarantine per
+        // file), so the startup-failure fixture uses the other terminal
+        // halt: an unresolvable trivial-content hash ambiguity.
+        let content = concat!(
+            "---\n",
+            "slug: notes/template\n",
+            "title: Template Note\n",
+            "type: concept\n",
+            "meta: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n",
+            "---\n",
+            "Hi\n",
         );
-        let note_b = format!(
-            "---\nmemory_id: {uuid}\nslug: notes/b\ntitle: B\ntype: concept\n---\nThis second body is also comfortably above the minimum size for rename inference.\n"
+        fs::write(root.path().join("template.md"), content).unwrap();
+        insert_page_with_raw_import(
+            &conn,
+            collection_id,
+            "notes/template",
+            "01969f11-9448-7d79-8d3f-c68f54768890",
+            "Hi",
+            content.as_bytes(),
+            "old-template.md",
         );
-        fs::write(root.path().join("a.md"), note_a).unwrap();
-        fs::write(root.path().join("b.md"), note_b).unwrap();
         let recovery_root = dir.path().join("recovery");
         create_startup_recovery_sentinel(&recovery_root, collection_id, "write-1.needs_full_sync");
         drop(conn);
@@ -5837,9 +5942,9 @@ mod tests {
             .unwrap();
 
         assert!(row.0.is_some());
-        assert_eq!(row.1.as_deref(), Some("duplicate_uuid"));
+        assert_eq!(row.1.as_deref(), Some("unresolvable_trivial_content"));
         assert_eq!(row.2, 1);
-        assert_eq!(row.3, 0);
+        assert_eq!(row.3, 1, "only the pre-seeded page; nothing ingested");
         assert_eq!(
             startup_recovery_sentinel_count(&recovery_root, collection_id),
             1

--- a/src/core/vault_sync/session.rs
+++ b/src/core/vault_sync/session.rs
@@ -214,11 +214,10 @@ pub fn try_promote_to_serve_host(
 }
 
 fn try_promote_inner(conn: &Connection, session_id: &str) -> Result<bool, VaultSyncError> {
-    conn.execute(
-        "DELETE FROM serve_sessions
-         WHERE heartbeat_at < datetime('now', ?1)",
-        [format!("-{SESSION_LIVENESS_SECS} seconds")],
-    )?;
+    // Same pid-aware sweep as the supervisor tick: a stale-by-time row whose
+    // process is still alive on this host (e.g. wedged mid-heartbeat) must
+    // not be deleted by a promotion attempt either.
+    sweep_stale_sessions(conn)?;
 
     let caller_type: Option<String> = conn
         .query_row(
@@ -314,11 +313,73 @@ pub fn heartbeat_session(conn: &Connection, session_id: &str) -> Result<(), Vaul
 /// Deletes session rows whose `heartbeat_at` has fallen outside the
 /// liveness window and returns the number reaped — the GC the
 /// supervisor runs each tick to keep `serve_sessions` bounded.
+///
+/// Rows registered from this host whose pid is still alive (kill-0
+/// probe) are skipped with a WARN instead of deleted: a session that is
+/// busy or briefly wedged must not be reaped mid-operation, because the
+/// reaped row is what stops a second process from promoting itself to
+/// runtime owner. Rows from other hosts keep the pure time-window
+/// behaviour since pid liveness cannot be probed across hosts.
 pub fn sweep_stale_sessions(conn: &Connection) -> Result<usize, VaultSyncError> {
-    let removed = conn.execute(
-        "DELETE FROM serve_sessions
+    let liveness_window = format!("-{SESSION_LIVENESS_SECS} seconds");
+    let mut stmt = conn.prepare(
+        "SELECT session_id, pid, host
+         FROM serve_sessions
          WHERE heartbeat_at < datetime('now', ?1)",
-        [format!("-{SESSION_LIVENESS_SECS} seconds")],
     )?;
+    let stale_rows = stmt
+        .query_map([&liveness_window], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, String>(2)?,
+            ))
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let local_host = current_host();
+    let mut removed = 0usize;
+    for (session_id, pid, host) in stale_rows {
+        if host == local_host && pid_is_alive(pid) {
+            eprintln!(
+                "WARN: session_sweep_skipped_live_pid session_id={session_id} pid={pid} host={host}"
+            );
+            continue;
+        }
+        // Re-check the window in the DELETE so a row that heartbeated
+        // between the SELECT and now is not reaped.
+        removed += conn.execute(
+            "DELETE FROM serve_sessions
+             WHERE session_id = ?1 AND heartbeat_at < datetime('now', ?2)",
+            params![session_id, liveness_window],
+        )?;
+    }
     Ok(removed)
+}
+
+/// Kill-0 liveness probe for a pid on the local host. EPERM means the
+/// process exists but belongs to another user, so it counts as alive.
+#[cfg(unix)]
+fn pid_is_alive(pid: i64) -> bool {
+    let Ok(raw_pid) = i32::try_from(pid) else {
+        return false;
+    };
+    if raw_pid <= 0 {
+        return false;
+    }
+    let Some(pid) = rustix::process::Pid::from_raw(raw_pid) else {
+        return false;
+    };
+    match rustix::process::test_kill_process(pid) {
+        Ok(()) => true,
+        Err(rustix::io::Errno::PERM) => true,
+        Err(_) => false,
+    }
+}
+
+/// Non-Unix fallback: no portable kill-0 probe, so the time-window
+/// behaviour applies to every row.
+#[cfg(not(unix))]
+fn pid_is_alive(_pid: i64) -> bool {
+    false
 }

--- a/src/core/vault_sync/watcher.rs
+++ b/src/core/vault_sync/watcher.rs
@@ -342,13 +342,15 @@ pub(super) fn classify_watch_event(
     Ok(actions)
 }
 
-/// Builds the closure passed to `notify::Watcher::new`. Drops
-/// notify errors silently, classifies the event into one or more
-/// [`WatchEvent`]s, and pushes each onto the per-collection mpsc
-/// channel. On `try_send`-full it marks the collection
-/// `needs_full_sync = 1` via a fresh connection so the next
-/// supervisor pass picks up the lost events; on closed it returns
-/// (the collection has been detached).
+/// Builds the closure passed to `notify::Watcher::new`. Classifies
+/// the event into one or more [`WatchEvent`]s and pushes each onto
+/// the per-collection mpsc channel. Every degradation is fail-safe:
+/// notify backend errors (including rescan signals), classification
+/// failures, and `try_send`-full all mark the collection
+/// `needs_full_sync = 1` via a fresh [`crate::core::db::open_runtime`]
+/// connection so the next supervisor pass runs a full-hash recovery
+/// instead of silently going stale; on closed it returns (the
+/// collection has been detached).
 #[cfg(unix)]
 pub(super) fn watch_callback(
     collection_id: i64,
@@ -357,19 +359,37 @@ pub(super) fn watch_callback(
     sender: mpsc::Sender<WatchEvent>,
 ) -> impl FnMut(notify::Result<NotifyEvent>) + Send + 'static {
     move |result: notify::Result<NotifyEvent>| {
-        let Ok(event) = result else {
-            return;
+        let event = match result {
+            Ok(event) => event,
+            Err(error) => {
+                eprintln!(
+                    "ERROR: watch_event_error collection_id={} root={} error={} flagging_full_sync",
+                    collection_id,
+                    callback_root.display(),
+                    error
+                );
+                flag_needs_full_sync_via_runtime_connection(&db_path, collection_id);
+                return;
+            }
         };
-        let Ok(actions) = classify_watch_event(&callback_root, event) else {
-            return;
+        let actions = match classify_watch_event(&callback_root, event) {
+            Ok(actions) => actions,
+            Err(error) => {
+                eprintln!(
+                    "ERROR: watch_classify_error collection_id={} root={} error={} flagging_full_sync",
+                    collection_id,
+                    callback_root.display(),
+                    error
+                );
+                flag_needs_full_sync_via_runtime_connection(&db_path, collection_id);
+                return;
+            }
         };
         for action in actions {
             match sender.try_send(action) {
                 Ok(()) => {}
                 Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
-                    if let Ok(conn) = crate::core::db::open_runtime(&db_path) {
-                        let _ = super::mark_collection_needs_full_sync(&conn, collection_id);
-                    }
+                    flag_needs_full_sync_via_runtime_connection(&db_path, collection_id);
                     eprintln!(
                         "WARN: watch_channel_full collection_id={} root={}",
                         collection_id,
@@ -378,6 +398,30 @@ pub(super) fn watch_callback(
                 }
                 Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => return,
             }
+        }
+    }
+}
+
+/// Best-effort `needs_full_sync = 1` flag write over a fresh
+/// [`crate::core::db::open_runtime`] connection (5s busy timeout, so
+/// the write-burst contention that causes channel overflow doesn't
+/// instantly fail the flag write too). Failures are logged loudly:
+/// this flag is the only thing standing between a degraded watcher
+/// and a silently-stale collection.
+#[cfg(unix)]
+pub(super) fn flag_needs_full_sync_via_runtime_connection(db_path: &str, collection_id: i64) {
+    match crate::core::db::open_runtime(db_path) {
+        Ok(conn) => {
+            if let Err(error) = super::mark_collection_needs_full_sync(&conn, collection_id) {
+                eprintln!(
+                    "ERROR: needs_full_sync_flag_write_failed collection_id={collection_id} error={error}"
+                );
+            }
+        }
+        Err(error) => {
+            eprintln!(
+                "ERROR: needs_full_sync_flag_open_failed collection_id={collection_id} error={error}"
+            );
         }
     }
 }

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -361,6 +361,11 @@ CREATE TABLE IF NOT EXISTS file_state (
     size_bytes      INTEGER NOT NULL,
     inode           INTEGER DEFAULT NULL,
     sha256          TEXT    NOT NULL,
+    -- Cached frontmatter uuid for duplicate-uuid detection: NULL = not yet
+    -- cached (file must be read), '' = file has no frontmatter uuid.
+    -- Reset to NULL on every content upsert; refreshed lazily by the
+    -- reconciler's duplicate-uuid scan so unchanged files are not re-read.
+    frontmatter_uuid TEXT   DEFAULT NULL,
     last_seen_at    TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
     last_full_hash_at TEXT  NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
     PRIMARY KEY (collection_id, relative_path)

--- a/tests/reconciler_misc.rs
+++ b/tests/reconciler_misc.rs
@@ -57,7 +57,11 @@ fn reconcile_commits_in_500_file_chunks() {
 
 #[cfg(unix)]
 #[test]
-fn reconcile_halts_when_two_files_share_the_same_memory_id() {
+fn reconcile_quarantines_newest_duplicate_memory_id_file_without_halting() {
+    // Formerly an abort expectation (collection-wide DuplicateUuidError):
+    // duplicate frontmatter uuids — the exact shape a git merge-conflict
+    // copy produces — now quarantine the newest-mtime file individually so
+    // the rest of the collection keeps syncing.
     let conn = open_test_db();
     let root = TempDir::new().unwrap();
     let collection = insert_collection(&conn, root.path());
@@ -70,8 +74,41 @@ fn reconcile_halts_when_two_files_share_the_same_memory_id() {
     );
     fs::write(root.path().join("a.md"), note_a).unwrap();
     fs::write(root.path().join("b.md"), note_b).unwrap();
+    // Make the contest deterministic: a.md is older, b.md is newer → b loses.
+    filetime::set_file_mtime(
+        root.path().join("a.md"),
+        filetime::FileTime::from_unix_time(1_000_000, 0),
+    )
+    .unwrap();
+    filetime::set_file_mtime(
+        root.path().join("b.md"),
+        filetime::FileTime::from_unix_time(2_000_000, 0),
+    )
+    .unwrap();
 
-    let error = reconcile(&conn, &collection).unwrap_err().to_string();
+    let stats = reconcile(&conn, &collection).unwrap();
+    let slugs: Vec<String> = conn
+        .prepare("SELECT slug FROM pages WHERE collection_id = ?1 ORDER BY slug")
+        .unwrap()
+        .query_map([collection.id], |row| row.get(0))
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+
+    assert_eq!(slugs, vec!["notes/a".to_owned()], "only the winner ingests");
+    assert_eq!(
+        stats.quarantined_ambiguous, 0,
+        "untracked loser has no page to quarantine"
+    );
+    assert_eq!(stats.hard_deleted, 0);
+    assert!(
+        root.path().join("b.md").exists(),
+        "losing file must stay on disk for manual resolution"
+    );
+
+    // The loser stays excluded on subsequent passes instead of halting them.
+    let second = reconcile(&conn, &collection).unwrap();
+    assert_eq!(second.hard_deleted, 0);
     let page_count: i64 = conn
         .query_row(
             "SELECT COUNT(*) FROM pages WHERE collection_id = ?1",
@@ -79,14 +116,7 @@ fn reconcile_halts_when_two_files_share_the_same_memory_id() {
             |row| row.get(0),
         )
         .unwrap();
-
-    assert!(error.contains("DuplicateUuidError"));
-    assert!(error.contains("a.md"));
-    assert!(error.contains("b.md"));
-    assert_eq!(
-        page_count, 0,
-        "duplicate uuid halt must abort before mutation"
-    );
+    assert_eq!(page_count, 1);
 }
 
 #[test]

--- a/tests/reconciler_quarantine_robustness.rs
+++ b/tests/reconciler_quarantine_robustness.rs
@@ -1,0 +1,338 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::print_stdout,
+    reason = "test fixtures legitimately panic on setup failure and print diagnostics; per-site #[expect] would generate noise across thousands of test sites"
+)]
+
+//! Quarantine-instead-of-destroy reconciler behaviour: ambiguous hash
+//! renames quarantine the original page (surviving across passes, with
+//! truthful stats), duplicate frontmatter uuids quarantine individual files
+//! instead of halting the collection, and the `file_state.frontmatter_uuid`
+//! cache populates lazily and resets on content change.
+
+#[path = "common/reconciler_fixtures.rs"]
+mod common_reconciler_fixtures;
+
+use common_reconciler_fixtures::*;
+use quaid::core::file_state::{self, upsert_file_state, FileStat};
+use quaid::core::reconciler::*;
+use rusqlite::Connection;
+use std::fs;
+use tempfile::TempDir;
+
+#[cfg(unix)]
+fn page_quarantined_at(conn: &Connection, page_id: i64) -> Option<String> {
+    conn.query_row(
+        "SELECT quarantined_at FROM pages WHERE id = ?1",
+        [page_id],
+        |row| row.get(0),
+    )
+    .unwrap()
+}
+
+#[cfg(unix)]
+fn quarantined_page_count(conn: &Connection, collection_id: i64) -> usize {
+    let count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM pages
+             WHERE collection_id = ?1 AND quarantined_at IS NOT NULL",
+            [collection_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    usize::try_from(count).unwrap()
+}
+
+#[cfg(unix)]
+fn cached_frontmatter_uuid(
+    conn: &Connection,
+    collection_id: i64,
+    relative_path: &str,
+) -> Option<Option<String>> {
+    use rusqlite::OptionalExtension;
+    conn.query_row(
+        "SELECT frontmatter_uuid FROM file_state
+         WHERE collection_id = ?1 AND relative_path = ?2",
+        rusqlite::params![collection_id, relative_path],
+        |row| row.get(0),
+    )
+    .optional()
+    .unwrap()
+}
+
+/// An ambiguous hash rename (one missing page, two identical new candidate
+/// files) must quarantine the original page — preserving its row, links,
+/// and history — instead of dropping the path so the next pass deletes it.
+/// The reported `quarantined_ambiguous` count must match what was actually
+/// quarantined on both passes (the input `DriftCaptureSummary` builds from).
+#[cfg(unix)]
+#[test]
+fn ambiguous_hash_rename_quarantines_original_page_across_two_reconciles() {
+    let conn = open_test_db();
+    let root = TempDir::new().unwrap();
+    let collection = insert_collection(&conn, root.path());
+
+    // No frontmatter: candidate slugs derive from their paths, so neither
+    // candidate slug-matches (and thereby reclaims) the original page —
+    // exercising the true quarantine path.
+    let content =
+        "This body is intentionally longer than sixty-four bytes so conservative hash rename inference still considers it.\n";
+    fs::write(root.path().join("candidate-a.md"), content).unwrap();
+    fs::write(root.path().join("candidate-b.md"), content).unwrap();
+    let sha256 = file_state::hash_file(&root.path().join("candidate-a.md")).unwrap();
+
+    // Seed the missing page (uuid-less so only hash inference applies) bound
+    // to a path that no longer exists on disk.
+    conn.execute(
+        "INSERT INTO pages (collection_id, slug, type, title, compiled_truth, timeline)
+         VALUES (?1, 'notes/original', 'concept', 'Original', ?2, '')",
+        rusqlite::params![collection.id, content.trim()],
+    )
+    .unwrap();
+    let page_id = conn.last_insert_rowid();
+    let stale_stat = FileStat {
+        mtime_ns: 1,
+        ctime_ns: Some(1),
+        size_bytes: content.len() as i64,
+        inode: Some(99),
+    };
+    upsert_file_state(
+        &conn,
+        collection.id,
+        "old-name.md",
+        page_id,
+        &stale_stat,
+        &sha256,
+    )
+    .unwrap();
+
+    let first = reconcile(&conn, &collection).unwrap();
+
+    assert_eq!(first.quarantined_ambiguous, 1);
+    assert_eq!(first.hard_deleted, 0);
+    assert_eq!(first.new, 2, "both candidates reingest as new pages");
+    assert!(
+        page_quarantined_at(&conn, page_id).is_some(),
+        "original page must be quarantined, not deleted"
+    );
+    assert!(
+        file_state::get_file_state(&conn, collection.id, "old-name.md")
+            .unwrap()
+            .is_none(),
+        "stale file_state binding must be cleared"
+    );
+    // Truthful reporting: the stat the drift guard consumes equals the
+    // number of pages actually quarantined.
+    assert_eq!(
+        first.quarantined_ambiguous + first.quarantined_db_state,
+        quarantined_page_count(&conn, collection.id)
+    );
+
+    // Second pass: nothing left to delete or quarantine — the page survives.
+    let second = reconcile(&conn, &collection).unwrap();
+
+    assert_eq!(second.hard_deleted, 0);
+    assert_eq!(second.quarantined_ambiguous, 0);
+    assert_eq!(second.quarantined_db_state, 0);
+    assert!(
+        page_quarantined_at(&conn, page_id).is_some(),
+        "original page must survive quarantined across passes"
+    );
+    let page_exists: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM pages WHERE id = ?1",
+            [page_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(page_exists, 1);
+}
+
+/// The git merge-conflict shape: a tracked original plus an untracked copy
+/// sharing its frontmatter uuid. The copy (untracked, newer) loses and is
+/// excluded; the original page keeps syncing untouched and the collection
+/// is never halted.
+#[cfg(unix)]
+#[test]
+fn duplicate_uuid_conflict_copy_is_skipped_and_tracked_original_survives() {
+    let conn = open_test_db();
+    let root = TempDir::new().unwrap();
+    let collection = insert_collection(&conn, root.path());
+    let uuid = "01969f11-9448-7d79-8d3f-c68f54761111";
+    let note = format!(
+        "---\nmemory_id: {uuid}\nslug: notes/original\ntitle: Original\ntype: concept\n---\nA body long enough to be a perfectly ordinary note for this test.\n"
+    );
+    fs::write(root.path().join("original.md"), &note).unwrap();
+    reconcile(&conn, &collection).unwrap();
+    let page_id: i64 = conn
+        .query_row(
+            "SELECT id FROM pages WHERE collection_id = ?1 AND slug = 'notes/original'",
+            [collection.id],
+            |row| row.get(0),
+        )
+        .unwrap();
+
+    // Merge-conflict copy: identical bytes (same uuid), newer mtime.
+    fs::write(root.path().join("original (copy).md"), &note).unwrap();
+    filetime::set_file_mtime(
+        root.path().join("original (copy).md"),
+        filetime::FileTime::from_unix_time(4_000_000_000, 0),
+    )
+    .unwrap();
+
+    let stats = reconcile(&conn, &collection).unwrap();
+
+    assert_eq!(
+        stats.quarantined_ambiguous, 0,
+        "untracked loser touches no page"
+    );
+    assert_eq!(stats.hard_deleted, 0);
+    assert!(page_quarantined_at(&conn, page_id).is_none());
+    let page_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM pages WHERE collection_id = ?1",
+            [collection.id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(page_count, 1, "the conflict copy must not ingest");
+    assert!(root.path().join("original (copy).md").exists());
+
+    // Stable on subsequent passes.
+    let again = reconcile(&conn, &collection).unwrap();
+    assert_eq!(again.hard_deleted, 0);
+    assert_eq!(again.quarantined_ambiguous, 0);
+}
+
+/// When both duplicate-uuid files are tracked, the newest-mtime file loses:
+/// its page is quarantined (not deleted) and the file stays on disk, while
+/// the older file keeps its page and the collection keeps reconciling.
+#[cfg(unix)]
+#[test]
+fn duplicate_uuid_between_tracked_files_quarantines_newest_loser_page() {
+    let conn = open_test_db();
+    let root = TempDir::new().unwrap();
+    let collection = insert_collection(&conn, root.path());
+    let uuid_a = "01969f11-9448-7d79-8d3f-c68f54762222";
+    let uuid_b = "01969f11-9448-7d79-8d3f-c68f54763333";
+    fs::write(
+        root.path().join("a.md"),
+        format!("---\nmemory_id: {uuid_a}\nslug: notes/a\ntitle: A\ntype: concept\n---\nBody A long enough to be an ordinary note in this scenario.\n"),
+    )
+    .unwrap();
+    fs::write(
+        root.path().join("b.md"),
+        format!("---\nmemory_id: {uuid_b}\nslug: notes/b\ntitle: B\ntype: concept\n---\nBody B long enough to be an ordinary note in this scenario.\n"),
+    )
+    .unwrap();
+    reconcile(&conn, &collection).unwrap();
+    let page_b: i64 = conn
+        .query_row(
+            "SELECT id FROM pages WHERE collection_id = ?1 AND slug = 'notes/b'",
+            [collection.id],
+            |row| row.get(0),
+        )
+        .unwrap();
+
+    // b.md is hand-edited to claim a.md's uuid (e.g. a careless copy-paste),
+    // making it the newer of the two duplicates.
+    fs::write(
+        root.path().join("b.md"),
+        format!("---\nmemory_id: {uuid_a}\nslug: notes/b\ntitle: B\ntype: concept\n---\nBody B long enough to be an ordinary note in this scenario.\n"),
+    )
+    .unwrap();
+    filetime::set_file_mtime(
+        root.path().join("a.md"),
+        filetime::FileTime::from_unix_time(1_000_000, 0),
+    )
+    .unwrap();
+    filetime::set_file_mtime(
+        root.path().join("b.md"),
+        filetime::FileTime::from_unix_time(2_000_000, 0),
+    )
+    .unwrap();
+
+    let stats = reconcile(&conn, &collection).unwrap();
+
+    assert_eq!(stats.quarantined_ambiguous, 1, "loser page is quarantined");
+    assert_eq!(stats.hard_deleted, 0);
+    assert!(
+        page_quarantined_at(&conn, page_b).is_some(),
+        "the tracked loser's page must survive quarantined"
+    );
+    assert!(
+        file_state::get_file_state(&conn, collection.id, "b.md")
+            .unwrap()
+            .is_none(),
+        "loser binding must be cleared"
+    );
+    assert!(root.path().join("b.md").exists());
+
+    // Next pass is stable: the loser stays excluded, nothing is deleted.
+    let again = reconcile(&conn, &collection).unwrap();
+    assert_eq!(again.hard_deleted, 0);
+    assert!(page_quarantined_at(&conn, page_b).is_some());
+}
+
+/// The duplicate-uuid scan caches each file's frontmatter uuid in
+/// `file_state.frontmatter_uuid` ('' = no uuid) so unchanged files are not
+/// re-read every pass, and any content upsert resets the cache to NULL so
+/// it can never go stale.
+#[cfg(unix)]
+#[test]
+fn frontmatter_uuid_cache_populates_lazily_and_resets_on_content_change() {
+    let conn = open_test_db();
+    let root = TempDir::new().unwrap();
+    let collection = insert_collection(&conn, root.path());
+    let uuid = "01969f11-9448-7d79-8d3f-c68f54764444";
+    fs::write(
+        root.path().join("with-uuid.md"),
+        format!("---\nmemory_id: {uuid}\nslug: notes/with-uuid\ntitle: U\ntype: concept\n---\nBody one.\n"),
+    )
+    .unwrap();
+    fs::write(
+        root.path().join("no-uuid.md"),
+        "Plain body, no frontmatter uuid.\n",
+    )
+    .unwrap();
+
+    // Pass 1 ingests; the upsert leaves the cache NULL (not yet cached).
+    reconcile(&conn, &collection).unwrap();
+    assert_eq!(
+        cached_frontmatter_uuid(&conn, collection.id, "with-uuid.md"),
+        Some(None)
+    );
+
+    // Pass 2 re-reads once and backfills the cache.
+    reconcile(&conn, &collection).unwrap();
+    assert_eq!(
+        cached_frontmatter_uuid(&conn, collection.id, "with-uuid.md"),
+        Some(Some(uuid.to_owned()))
+    );
+    assert_eq!(
+        cached_frontmatter_uuid(&conn, collection.id, "no-uuid.md"),
+        Some(Some(String::new())),
+        "uuid-less files cache the empty-string sentinel"
+    );
+
+    // Content change: the reingest upsert must reset the cache to NULL …
+    fs::write(
+        root.path().join("with-uuid.md"),
+        format!("---\nmemory_id: {uuid}\nslug: notes/with-uuid\ntitle: U\ntype: concept\n---\nBody two, edited.\n"),
+    )
+    .unwrap();
+    reconcile(&conn, &collection).unwrap();
+    assert_eq!(
+        cached_frontmatter_uuid(&conn, collection.id, "with-uuid.md"),
+        Some(None)
+    );
+
+    // … and the next pass lazily re-caches the fresh value.
+    reconcile(&conn, &collection).unwrap();
+    assert_eq!(
+        cached_frontmatter_uuid(&conn, collection.id, "with-uuid.md"),
+        Some(Some(uuid.to_owned()))
+    );
+}

--- a/tests/vault_sync_robustness.rs
+++ b/tests/vault_sync_robustness.rs
@@ -1,0 +1,229 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::print_stdout,
+    reason = "test fixtures legitimately panic on setup failure and print diagnostics; per-site #[expect] would generate noise across thousands of test sites"
+)]
+
+//! Vault-sync robustness: heartbeat isolation from the supervisor work
+//! thread, pid-aware stale-session sweeping, and fail-safe `needs_full_sync`
+//! flagging on watcher degradation (notify errors, crash re-arm).
+
+#[path = "common/vault_sync_fixtures.rs"]
+mod fixtures;
+
+use fixtures::*;
+
+use std::thread;
+use std::time::Duration;
+
+use rusqlite::Connection;
+
+use quaid::core::vault_sync::{
+    current_host, register_session, start_serve_runtime, sweep_stale_sessions, SessionType,
+};
+
+// ── Heartbeat isolation ───────────────────────────────────────
+
+/// The session heartbeat must tick while the supervisor work thread is
+/// blocked (the deterministic equivalent of a 20s reconcile):
+/// `QUAID_TEST_SUPERVISOR_TICK_HOLD_MS` pins the work thread inside one tick
+/// for 8s — past the 5s heartbeat interval — and the dedicated heartbeat
+/// thread must still refresh `heartbeat_at` so another process's sweep can
+/// never reap the live session mid-operation.
+#[test]
+fn heartbeat_ticks_while_supervisor_work_thread_is_blocked() {
+    let _lock = env_mutation_lock().lock().unwrap();
+    let _hold = EnvVarGuard::set("QUAID_TEST_SUPERVISOR_TICK_HOLD_MS", "8000");
+
+    let (_dir, db_path, conn) = open_test_db_file();
+    drop(conn);
+
+    let runtime = start_serve_runtime(db_path.clone()).unwrap();
+    let conn = Connection::open(&db_path).unwrap();
+    let first_heartbeat: String = conn
+        .query_row(
+            "SELECT heartbeat_at FROM serve_sessions WHERE session_id = ?1",
+            [runtime.session_id.as_str()],
+            |row| row.get(0),
+        )
+        .unwrap();
+    drop(conn);
+
+    // Well inside the work thread's 8s hold, but past one 5s heartbeat
+    // interval. Before heartbeat isolation, the keepalive shared the held
+    // thread and could not have ticked yet.
+    thread::sleep(Duration::from_millis(6500));
+
+    let conn = Connection::open(&db_path).unwrap();
+    let row: Option<String> = conn
+        .query_row(
+            "SELECT heartbeat_at FROM serve_sessions WHERE session_id = ?1",
+            [runtime.session_id.as_str()],
+            |row| row.get(0),
+        )
+        .ok();
+    drop(conn);
+
+    let second_heartbeat = row.expect("session row must survive while the work thread is held");
+    assert_ne!(
+        first_heartbeat, second_heartbeat,
+        "heartbeat must advance while the supervisor work thread is blocked"
+    );
+
+    drop(runtime);
+}
+
+// ── pid-aware stale-session sweep ─────────────────────────────
+
+/// `sweep_stale_sessions` must skip a stale-by-time row whose pid is alive
+/// on this host (a busy-but-live process must not be reaped mid-operation),
+/// while keeping the pure time-window behaviour for dead local pids and for
+/// rows registered from other hosts.
+#[test]
+fn sweep_skips_live_local_pid_but_reaps_dead_and_foreign_rows() {
+    let conn = open_test_db();
+
+    // Live local session: this test process's pid, this host.
+    let live_session = register_session(&conn, SessionType::Serve).unwrap();
+    conn.execute(
+        "UPDATE serve_sessions
+         SET heartbeat_at = datetime('now', '-60 seconds')
+         WHERE session_id = ?1",
+        [live_session.as_str()],
+    )
+    .unwrap();
+
+    // Dead local pid: a spawned-and-reaped child on this host.
+    let mut child = std::process::Command::new("true").spawn().unwrap();
+    let dead_pid = i64::from(child.id());
+    child.wait().unwrap();
+    conn.execute(
+        "INSERT INTO serve_sessions (session_id, pid, host, session_type, heartbeat_at)
+         VALUES ('dead-local', ?1, ?2, 'serve', datetime('now', '-60 seconds'))",
+        rusqlite::params![dead_pid, current_host()],
+    )
+    .unwrap();
+
+    // Foreign host: pid happens to be alive here, but liveness cannot be
+    // probed across hosts, so the time window must still apply.
+    conn.execute(
+        "INSERT INTO serve_sessions (session_id, pid, host, session_type, heartbeat_at)
+         VALUES ('stale-foreign', ?1, 'definitely-not-this-host', 'serve',
+                 datetime('now', '-60 seconds'))",
+        [i64::from(std::process::id())],
+    )
+    .unwrap();
+
+    let removed = sweep_stale_sessions(&conn).unwrap();
+
+    assert_eq!(removed, 2, "dead-local and stale-foreign rows are reaped");
+    let survivors: Vec<String> = conn
+        .prepare("SELECT session_id FROM serve_sessions ORDER BY session_id")
+        .unwrap()
+        .query_map([], |row| row.get(0))
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+    assert_eq!(survivors, vec![live_session]);
+}
+
+// ── Fail-safe needs_full_sync flagging (source audits) ────────
+//
+// `watch_callback` and `sync_collection_watchers` are private to the
+// vault_sync module and notify errors cannot be injected through the public
+// API, so these follow the repo's established source-introspection pattern
+// (see tests/vault_sync_runtime.rs) to pin the fail-safe behaviour.
+
+#[test]
+fn watch_callback_flags_full_sync_on_every_degradation_path() {
+    let source = production_vault_sync_source();
+    let start = source.find("pub(super) fn watch_callback(").unwrap();
+    let end = start
+        + source[start..]
+            .find("pub(super) fn flag_needs_full_sync_via_runtime_connection(")
+            .unwrap();
+    let snippet = &source[start..end];
+
+    assert!(
+        snippet.contains("ERROR: watch_event_error"),
+        "notify backend errors must be logged, not silently dropped: {snippet}"
+    );
+    assert!(
+        snippet.contains("ERROR: watch_classify_error"),
+        "classification failures must be logged, not silently dropped: {snippet}"
+    );
+    assert!(
+        !snippet.contains("let Ok(event) = result else"),
+        "the silent notify-error drop pattern must not return: {snippet}"
+    );
+    assert_eq!(
+        snippet
+            .matches("flag_needs_full_sync_via_runtime_connection(")
+            .count(),
+        3,
+        "notify error, classify error, and channel overflow must all set needs_full_sync: {snippet}"
+    );
+
+    let helper_start = source
+        .find("pub(super) fn flag_needs_full_sync_via_runtime_connection(")
+        .unwrap();
+    let helper = &source[helper_start..helper_start + 1500];
+    assert!(
+        helper.contains("db::open_runtime")
+            && helper.contains("needs_full_sync_flag_write_failed")
+            && helper.contains("needs_full_sync_flag_open_failed"),
+        "flag writes must use a runtime connection (5s busy timeout) and log both failure modes loudly: {helper}"
+    );
+}
+
+#[test]
+fn sync_collection_watchers_flags_full_sync_when_rearming_after_crash() {
+    let source = production_vault_sync_source();
+    let start = source.find("fn sync_collection_watchers(").unwrap();
+    let end = start
+        + source[start..]
+            .find("fn detach_active_collections_with_empty_root_path(")
+            .unwrap();
+    let snippet = &source[start..end];
+
+    assert!(
+        snippet.contains("rearming_after_crash")
+            && snippet.contains("mark_collection_needs_full_sync(conn, collection_id)")
+            && snippet.contains("watcher_rearm_flagged_full_sync")
+            && snippet.contains("watcher_rearm_needs_full_sync_write_failed"),
+        "crash re-arm must flag needs_full_sync and log flag-write failures: {snippet}"
+    );
+}
+
+#[test]
+fn supervisor_heartbeat_runs_on_dedicated_thread_and_logs_failures() {
+    let source = production_vault_sync_source();
+    let loop_start = source.find("fn run_supervisor_loop(").unwrap();
+    let loop_end = loop_start
+        + source[loop_start..]
+            .find("fn run_session_heartbeat_loop(")
+            .unwrap();
+    let loop_snippet = &source[loop_start..loop_end];
+
+    assert!(
+        loop_snippet.contains("run_session_heartbeat_loop(")
+            && loop_snippet.contains("thread::spawn"),
+        "the supervisor must spawn the heartbeat on a dedicated thread: {loop_snippet}"
+    );
+    assert!(
+        !loop_snippet.contains("let _ = heartbeat_session"),
+        "the work loop must no longer run (or swallow) heartbeats inline: {loop_snippet}"
+    );
+
+    let hb_start = source.find("fn run_session_heartbeat_loop(").unwrap();
+    let hb_snippet = &source[hb_start..hb_start + 2500];
+    assert!(
+        hb_snippet.contains("db::open_runtime")
+            && hb_snippet.contains("WARN: session_heartbeat_failed")
+            && hb_snippet.contains("WARN: session_heartbeat_open_failed")
+            && hb_snippet.contains("WARN: session_sweep_failed"),
+        "the heartbeat loop must use a runtime connection and log every failure instead of `let _ =`: {hb_snippet}"
+    );
+}

--- a/tests/vault_sync_watcher.rs
+++ b/tests/vault_sync_watcher.rs
@@ -196,7 +196,11 @@ fn plain_sync_reconciles_active_root_and_clears_needs_full_sync() {
 
 #[cfg(unix)]
 #[test]
-fn plain_sync_turns_duplicate_uuid_into_terminal_reconcile_halt() {
+fn plain_sync_quarantines_duplicate_uuid_loser_without_terminal_halt() {
+    // Formerly an abort expectation (terminal reconcile_halted_at): duplicate
+    // frontmatter uuids — the exact shape a git merge-conflict copy produces —
+    // now quarantine the newest-mtime file individually; the collection keeps
+    // syncing and is never halted.
     let (_dir, _db_path, conn) = open_test_db_file();
     let root = tempfile::TempDir::new().unwrap();
     let collection_id = insert_collection(&conn, "work", root.path());
@@ -209,8 +213,19 @@ fn plain_sync_turns_duplicate_uuid_into_terminal_reconcile_halt() {
     );
     fs::write(root.path().join("a.md"), note_a).unwrap();
     fs::write(root.path().join("b.md"), note_b).unwrap();
+    // Deterministic contest: a.md older, b.md newer → b.md loses.
+    filetime::set_file_mtime(
+        root.path().join("a.md"),
+        filetime::FileTime::from_unix_time(1_000_000, 0),
+    )
+    .unwrap();
+    filetime::set_file_mtime(
+        root.path().join("b.md"),
+        filetime::FileTime::from_unix_time(2_000_000, 0),
+    )
+    .unwrap();
 
-    let error = sync_collection(&conn, "work").unwrap_err().to_string();
+    sync_collection(&conn, "work").unwrap();
     let row: (Option<String>, Option<String>, i64) = conn
         .query_row(
             "SELECT reconcile_halted_at, reconcile_halt_reason,
@@ -221,11 +236,24 @@ fn plain_sync_turns_duplicate_uuid_into_terminal_reconcile_halt() {
         )
         .unwrap();
 
-    assert!(error.contains("ReconcileHaltedError"));
-    assert!(error.contains("DuplicateUuidError"));
-    assert!(row.0.is_some());
-    assert_eq!(row.1.as_deref(), Some("duplicate_uuid"));
-    assert_eq!(row.2, 0);
+    assert!(
+        row.0.is_none(),
+        "duplicate uuid must not halt the collection"
+    );
+    assert!(row.1.is_none());
+    assert_eq!(row.2, 1, "exactly the winner file ingests");
+    let winner_slug: String = conn
+        .query_row(
+            "SELECT slug FROM pages WHERE collection_id = ?1",
+            [collection_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(winner_slug, "notes/a");
+    assert!(
+        root.path().join("b.md").exists(),
+        "losing file must stay on disk for manual resolution"
+    );
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
**Stacked on #230** (`fable/w2-conn-hygiene`) — auto-retargets to main when #230 merges. Implements **Area 6 — vault sync & reconciler robustness** (all 4 plan steps).

## Changes
1. **Ambiguous renames actually quarantine**: ambiguous uuid/hash rename candidates are collected into `RenameResolution::ambiguous` and `build_apply_actions` emits a real `QuarantinePage` action (sets `quarantined_at`, clears the file_state binding) — previously the path was silently dropped and the *next* reconcile deleted the page with its version history while reporting it "quarantined". `DriftCaptureSummary` now reports apply-time truth.
2. **Heartbeat isolation**: heartbeat + stale-session sweep moved to a dedicated thread on `db::open_runtime` connections; failures logged instead of `let _ =`; `sweep_stale_sessions` skips rows whose pid is alive on the same host (kill-0 probe, EPERM=alive; time-window fallback for foreign hosts) — a >15s reconcile/audit/embedding pass no longer lets a second process steal the live session mid-operation.
3. **Fail-safe staleness**: notify backend errors, classification errors, channel overflow, and crash re-arm all set `needs_full_sync=1` over `open_runtime` with loud ERROR logs on flag-write failure — the three silently-stale watcher paths are closed.
4. **Per-file duplicate-uuid handling**: a duplicate-uuid pair (exactly what a git merge-conflict copy produces — prerequisite for #173) quarantines the newest-mtime file individually instead of halting the entire collection; frontmatter uuids are cached in `file_state` so unchanged files are no longer fully re-read on every debounced reconcile (also kills that O(corpus) hot path from Area 11's list).

## Validation
fmt/clippy (-D warnings)/rustdoc clean. New suites: reconciler_quarantine_robustness (4), vault_sync_robustness (5, incl. a blocked-work-thread test proving the heartbeat keeps ticking). Wide regression sweep green: all reconciler_* suites, watcher_core, vault_sync runtime/misc/audit/session/handshake/ipc/restore/remap, daemon_lifecycle_cli, db_* suites, roundtrips; inline reconciler (92) + vault_sync (71) mods.

## Notes
- `QUAID_TEST_SUPERVISOR_TICK_HOLD_MS` is a new test-only timing seam following the repo's existing `QUAID_TEST_*` pattern (the heartbeat-isolation test depends on it).
- `apply_reingest` untouched — conflict surface with #232/#233 kept minimal by design.
- No hard TTL cap on pid-alive sessions (pid recycling could in theory pin a dead row on the same host) — noted for a follow-up if it bites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)