### PR TITLE
feat(db): versioned migration ladder + quaid migrate, real v9→v10 step (area 17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to Quaid are tracked here. Pre-1.0, schema and
 response-shape changes may break compatibility between minor versions —
 each entry below calls out the migration implications.
 
+## Unreleased
+
+### Added
+
+- **Versioned schema migration ladder + `quaid migrate`.** New explicit
+  `quaid migrate [path]` command upgrades older databases in place by walking
+  a versioned migration registry in `src/core/db.rs`. The first registered
+  rung migrates schema v9 (v0.20.x / v0.21.x) databases to v10: `links`
+  table rebuild (extended `source_kind` CHECK plus the `edge_weight` column),
+  derived-edge dedup with the `idx_links_unique_derived_edge` partial unique
+  index, and the v10 graph config seeds. The run writes a `<db>.bak` backup
+  first, applies each step in its own transaction (bumping
+  `quaid_config.schema_version` and the legacy `config.version` mirror per
+  step), and verifies `PRAGMA integrity_check` plus row-count sanity
+  afterwards. Plain opens remain fail-closed on any schema-version mismatch.
+
+### Changed
+
+- The formerly scattered open-time `ensure_*` schema patches are consolidated
+  into one idempotent current-version maintenance step shared by `open` and
+  `quaid migrate`. Future DDL changes must land as new migration-registry
+  rungs with a `SCHEMA_VERSION` bump, not as unversioned open-time patches.
+
+### Migration
+
+- Schema v9 databases (v0.20.x / v0.21.x) can now be upgraded in place with
+  `quaid migrate` instead of export + re-ingest. v0.22.x (v10) databases are
+  unaffected; running `quaid migrate` on them is a no-op.
+
 ## v0.22.3 — post-release bug fixes
 
 ### Fixed

--- a/openspec/specs/schema-migration/spec.md
+++ b/openspec/specs/schema-migration/spec.md
@@ -29,7 +29,7 @@ The `dirs::home_dir()` lookup in `src/core/db.rs` (or wherever the default path 
 
 ## Migration policy
 
-**No automatic migration.** Existing databases created with a previous binary version are incompatible with `quaid`. On detecting a `SCHEMA_VERSION` mismatch (including detecting the old schema without a `quaid_config` table), the binary must return a clear, non-zero error:
+**No automatic migration on open.** Existing databases at a different schema version are never upgraded implicitly. On detecting a `SCHEMA_VERSION` mismatch (including detecting the old schema without a `quaid_config` table), a plain open must return a clear, non-zero error:
 
 ```
 Error: database schema version mismatch.
@@ -39,7 +39,25 @@ Error: database schema version mismatch.
     quaid collection add migrated <export-directory>
 ```
 
-No fallback, no silent upgrade, no legacy configuration table alias reading.
+No fallback, no silent upgrade on open, no legacy configuration table alias reading. The only supported in-place upgrade path is the explicit `quaid migrate` command below.
+
+## Explicit migration: `quaid migrate`
+
+`quaid migrate [path]` (path defaults to `--db` / `QUAID_DB` / `~/.quaid/memory.db`) upgrades an existing database in place by walking the versioned migration registry in `src/core/db.rs`:
+
+- The registry (`MIGRATIONS`) maps each target schema version to a step function; a step upgrades a database from `target - 1` to `target`. New DDL changes MUST land as a new registry rung together with a `SCHEMA_VERSION` bump — never as unversioned open-time patches.
+- Before the first rung runs, a byte copy of the database file is written to `<path>.bak` (after a WAL checkpoint). In-memory databases cannot be migrated.
+- Each rung runs inside its own transaction and bumps both `quaid_config.schema_version` and the legacy `config.version` mirror to the rung's target version; a `PRAGMA foreign_key_check` runs after each rung commits.
+- After the ladder, the idempotent current-version maintenance step runs (the consolidated former `ensure_*` patches: `pages_au` trigger repair, namespace schema, collection owner columns, serve-session columns, collection name guards, raw-import hash backfill), then `PRAGMA integrity_check` and row-count sanity assertions must pass (`pages` count unchanged; `links` may only shrink via derived-edge dedup). On failure the command exits non-zero and names the `.bak` backup.
+- An already-current database is a no-op: maintenance still runs, no backup is written, exit code 0.
+- A database whose stored version is newer than the binary's `SCHEMA_VERSION` is refused with the version-mismatch error; the remediation is upgrading the binary.
+- A database whose version has no contiguous registered ladder path (anything below v9) is refused with the export/re-ingest guidance above.
+
+### Registered ladder rungs
+
+| Target version | Delta |
+|----------------|-------|
+| 10 | `links` table rebuild (12-step): `source_kind` CHECK extended with `'frontmatter'`/`'entity_pattern'`, new `edge_weight REAL NOT NULL DEFAULT 1.0`; derived-edge dedup then partial unique index `idx_links_unique_derived_edge`; v10 graph config seeds (`graph_depth`, `graph_distance_decay`, `graph_expansion_max`, `edge_weight_frontmatter`, `edge_weight_entity_pattern`, `edge_weight_wikilink`) |
 
 ## Invariants
 
@@ -48,6 +66,7 @@ No fallback, no silent upgrade, no legacy configuration table alias reading.
 3. The DDL change, `SCHEMA_VERSION` bump, and all test fixture updates must land in a single atomic commit.
 4. `cargo test` must pass in that commit with no schema-related failures.
 5. The default DB path used when no `--db` / `QUAID_DB` is provided must be `~/.quaid/memory.db`.
+6. Every schema change to `src/schema.sql` ships with a matching rung in the `MIGRATIONS` registry (or an explicit, documented decision that no in-place path is supported for that bump).
 
 ## Validation
 

--- a/src/commands/migrate_db.rs
+++ b/src/commands/migrate_db.rs
@@ -1,0 +1,70 @@
+#![expect(
+    clippy::print_stdout,
+    reason = "CLI command prints user-facing output to stdout by design"
+)]
+
+//! `quaid migrate` — explicit, opt-in schema migration. Walks the versioned
+//! migration ladder in [`crate::core::db::migrate_database`] after writing a
+//! `.bak` backup, then reports integrity and row-count results. Named
+//! `migrate_db` to avoid colliding with [`crate::core::migrate`], the
+//! export/import module.
+
+use anyhow::Result;
+use serde_json::json;
+
+use crate::core::db;
+
+/// Migrate the database at `path` to the current schema version and print a
+/// report (human-readable, or JSON when `json_output` is set).
+pub fn run(path: &str, json_output: bool) -> Result<()> {
+    let report = db::migrate_database(path)?;
+
+    if json_output {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({
+                "from_version": report.from_version,
+                "to_version": report.to_version,
+                "steps_applied": report.steps_applied,
+                "backup_path": report.backup_path,
+                "integrity_check": "ok",
+                "pages": { "before": report.pages_before, "after": report.pages_after },
+                "links": { "before": report.links_before, "after": report.links_after },
+            }))?
+        );
+        return Ok(());
+    }
+
+    if report.steps_applied.is_empty() {
+        println!(
+            "Database at {path} is already at schema version {}; nothing to migrate.",
+            report.to_version
+        );
+        return Ok(());
+    }
+
+    let steps = report
+        .steps_applied
+        .iter()
+        .map(|version| format!("v{version}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    println!(
+        "Migrated {path} from schema version {} to {}.",
+        report.from_version, report.to_version
+    );
+    if let Some(backup) = &report.backup_path {
+        println!("  Pre-migration backup: {backup}");
+    }
+    println!("  Steps applied: {steps}");
+    println!("  Integrity check: ok");
+    println!(
+        "  Pages: {} before, {} after",
+        report.pages_before, report.pages_after
+    );
+    println!(
+        "  Links: {} before, {} after",
+        report.links_before, report.links_after
+    );
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -15,6 +15,7 @@ pub mod ingest;
 pub mod init;
 pub mod link;
 pub mod list;
+pub mod migrate_db;
 pub mod model;
 pub mod namespace;
 pub mod pipe;

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -3,6 +3,11 @@
 //! version checks, and crash-partial bootstrap recovery so the rest of the
 //! crate can assume an open `Connection` is at the current schema version.
 //!
+//! Plain opens stay fail-closed on schema-version mismatches; the explicit
+//! `quaid migrate` command drives `migrate_database`, which walks the
+//! versioned migration ladder (`MIGRATIONS`) with a pre-migration backup,
+//! per-step transactions, and post-migration integrity checks.
+//!
 //! See also: `inference` for the `ModelConfig` values persisted here, `types`
 //! for `DbError`, and `migrate` for export/import round-trips.
 
@@ -282,16 +287,320 @@ fn open_connection(path: &str) -> Result<Connection, DbError> {
     conn.busy_timeout(Duration::from_secs(5))?;
     ensure_namespace_schema(&conn)?;
     conn.execute_batch(include_str!("../schema.sql"))?;
-    ensure_pages_update_trigger_handles_quarantine(&conn)?;
-    ensure_namespace_schema(&conn)?;
-    ensure_collection_owner_columns(&conn)?;
-    ensure_serve_session_columns(&conn)?;
-    ensure_collection_name_guards(&conn)?;
-    ensure_raw_import_hash_schema(&conn)?;
+    apply_current_version_maintenance(&conn)?;
     set_version(&conn)?;
     ensure_default_collection(&conn)?;
 
     Ok(conn)
+}
+
+/// One rung of the versioned migration ladder: upgrades a database whose
+/// stored schema version is `target - 1` to `target`. Step functions run
+/// inside a transaction opened by [`migrate_database`] (with foreign keys
+/// disabled for table rebuilds) and must not begin or commit transactions
+/// themselves; the runner bumps the stored schema version after each step.
+type MigrationStep = fn(&Connection) -> Result<(), DbError>;
+
+/// Versioned migration ladder, keyed by target schema version. Plain `open`
+/// stays fail-closed on any schema-version mismatch; only the explicit
+/// `quaid migrate` command ([`migrate_database`]) walks these rungs. New DDL
+/// changes must be added here as a new rung with a `SCHEMA_VERSION` bump,
+/// not as silent open-time patches.
+const MIGRATIONS: &[(i64, MigrationStep)] = &[(10, migrate_v9_to_v10_links_graph)];
+
+/// Idempotent same-version maintenance: the registry's current-version step,
+/// applied on every open and at the end of every `migrate_database` run.
+///
+/// This folds the formerly scattered unversioned `ensure_*` patches —
+/// `ensure_pages_update_trigger_handles_quarantine`, `ensure_namespace_schema`,
+/// `ensure_collection_owner_columns`, `ensure_serve_session_columns`,
+/// `ensure_collection_name_guards`, and `ensure_raw_import_hash_schema` —
+/// into one place so current-version databases converge on one shape and
+/// future DDL changes land as new [`MIGRATIONS`] rungs instead of silent
+/// per-release drift.
+fn apply_current_version_maintenance(conn: &Connection) -> Result<(), DbError> {
+    ensure_pages_update_trigger_handles_quarantine(conn)?;
+    ensure_namespace_schema(conn)?;
+    ensure_collection_owner_columns(conn)?;
+    ensure_serve_session_columns(conn)?;
+    ensure_collection_name_guards(conn)?;
+    ensure_raw_import_hash_schema(conn)?;
+    Ok(())
+}
+
+/// v9 → v10: the knowledge-graph layer on `links`.
+///
+/// Implements exactly the `src/schema.sql` delta between v0.21.x (schema v9)
+/// and v0.22.x (schema v10):
+/// - extends the `source_kind` CHECK with `'frontmatter'` and
+///   `'entity_pattern'` and adds `edge_weight REAL NOT NULL DEFAULT 1.0` via
+///   the documented 12-step table rebuild (CHECK constraints cannot be
+///   altered in place);
+/// - dedupes derived edges (keeping the oldest row per
+///   `(from, to, relationship, source_kind)`; the next sync refreshes its
+///   temporal fields anyway), then creates the partial unique index
+///   `idx_links_unique_derived_edge`;
+/// - seeds the v10 graph config defaults.
+fn migrate_v9_to_v10_links_graph(conn: &Connection) -> Result<(), DbError> {
+    conn.execute_batch(
+        "DELETE FROM links
+          WHERE source_kind IN ('wiki_link', 'frontmatter', 'entity_pattern')
+            AND id NOT IN (
+                SELECT MIN(id)
+                  FROM links
+                 WHERE source_kind IN ('wiki_link', 'frontmatter', 'entity_pattern')
+                 GROUP BY from_page_id, to_page_id, relationship, source_kind
+            );
+
+         CREATE TABLE links_new (
+             id              INTEGER PRIMARY KEY AUTOINCREMENT,
+             from_page_id    INTEGER NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
+             to_page_id      INTEGER NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
+             relationship    TEXT    NOT NULL DEFAULT 'related',
+             context         TEXT    NOT NULL DEFAULT '',
+             source_kind     TEXT    NOT NULL DEFAULT 'programmatic' CHECK(source_kind IN ('wiki_link', 'programmatic', 'frontmatter', 'entity_pattern')),
+             edge_weight     REAL    NOT NULL DEFAULT 1.0,
+             valid_from      TEXT    DEFAULT NULL,
+             valid_until     TEXT    DEFAULT NULL,
+             created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+             CHECK (valid_from IS NULL OR valid_until IS NULL OR valid_until >= valid_from)
+         );
+         INSERT INTO links_new
+             (id, from_page_id, to_page_id, relationship, context, source_kind,
+              edge_weight, valid_from, valid_until, created_at)
+         SELECT id, from_page_id, to_page_id, relationship, context, source_kind,
+                1.0, valid_from, valid_until, created_at
+           FROM links;
+         DROP TABLE links;
+         ALTER TABLE links_new RENAME TO links;
+
+         CREATE INDEX IF NOT EXISTS idx_links_from    ON links(from_page_id);
+         CREATE INDEX IF NOT EXISTS idx_links_to      ON links(to_page_id);
+         CREATE INDEX IF NOT EXISTS idx_links_current ON links(valid_until);
+         CREATE INDEX IF NOT EXISTS idx_links_source  ON links(source_kind);
+         CREATE UNIQUE INDEX IF NOT EXISTS idx_links_unique_derived_edge
+             ON links(from_page_id, to_page_id, relationship, source_kind)
+             WHERE source_kind IN ('wiki_link', 'frontmatter', 'entity_pattern');
+
+         INSERT OR IGNORE INTO config (key, value) VALUES
+             ('graph_depth',                  '0'),
+             ('graph_distance_decay',         '0.5'),
+             ('graph_expansion_max',          '50'),
+             ('edge_weight_frontmatter',      '1.0'),
+             ('edge_weight_entity_pattern',   '0.7'),
+             ('edge_weight_wikilink',         '0.5');",
+    )?;
+    Ok(())
+}
+
+/// Result of a [`migrate_database`] run: versions, applied ladder rungs,
+/// backup location, and row-count sanity figures.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MigrationReport {
+    /// Schema version stored in the database before the run.
+    pub from_version: i64,
+    /// Schema version after the run (the binary's current schema version).
+    pub to_version: i64,
+    /// Target versions of the ladder rungs that were applied, in order.
+    /// Empty when the database was already current.
+    pub steps_applied: Vec<i64>,
+    /// Path of the pre-migration `.bak` copy, written before the first rung.
+    /// `None` when no rungs were applied.
+    pub backup_path: Option<String>,
+    /// `pages` row count before the ladder ran.
+    pub pages_before: i64,
+    /// `pages` row count after the ladder ran (must equal `pages_before`).
+    pub pages_after: i64,
+    /// `links` row count before the ladder ran.
+    pub links_before: i64,
+    /// `links` row count after the ladder ran (may shrink: duplicate derived
+    /// edges are collapsed by the v9 → v10 rung).
+    pub links_after: i64,
+}
+
+/// Upgrades the database at `path` to the current schema version by walking
+/// the versioned `MIGRATIONS` ladder. Backs the CLI's explicit
+/// `quaid migrate` command; plain opens stay fail-closed on mismatches.
+///
+/// Order of operations:
+/// 1. refuse databases newer than this binary or with no registered path;
+/// 2. write a `<path>.bak` copy (after a WAL checkpoint) before the first
+///    rung;
+/// 3. run each rung in its own transaction, bumping
+///    `quaid_config.schema_version` and the legacy `config.version` mirror
+///    per step, with a `foreign_key_check` after each commit;
+/// 4. apply current-version maintenance, then verify
+///    `PRAGMA integrity_check` and row-count sanity.
+///
+/// An already-current database is a no-op (maintenance still runs and no
+/// backup is written).
+pub fn migrate_database(path: &str) -> Result<MigrationReport, DbError> {
+    if path == ":memory:" {
+        return Err(DbError::Schema {
+            message: "in-memory databases cannot be migrated".to_owned(),
+        });
+    }
+    if !Path::new(path).exists() {
+        return Err(DbError::PathNotFound {
+            path: path.to_owned(),
+        });
+    }
+
+    ensure_sqlite_vec();
+    let conn = Connection::open(path)?;
+    conn.busy_timeout(Duration::from_secs(5))?;
+
+    let Some(from_version) = read_existing_schema_version(&conn)? else {
+        return Err(DbError::Schema {
+            message: format_schema_reinit_message(0, path),
+        });
+    };
+    if from_version > SCHEMA_VERSION {
+        return Err(DbError::Schema {
+            message: format_schema_reinit_message(from_version, path),
+        });
+    }
+
+    // Verify a complete ladder exists before touching anything.
+    let pending: Vec<(i64, MigrationStep)> = ((from_version + 1)..=SCHEMA_VERSION)
+        .map(|target| {
+            MIGRATIONS
+                .iter()
+                .find(|(version, _)| *version == target)
+                .copied()
+                .ok_or_else(|| DbError::Schema {
+                    message: format!(
+                        "no migration step is registered for schema version {target}; this database cannot be migrated in place.\n{}",
+                        format_schema_reinit_message(from_version, path)
+                    ),
+                })
+        })
+        .collect::<Result<_, _>>()?;
+
+    let pages_before = count_table_rows(&conn, "pages")?;
+    let links_before = count_table_rows(&conn, "links")?;
+
+    let mut backup_path = None;
+    let mut steps_applied = Vec::with_capacity(pending.len());
+    if !pending.is_empty() {
+        backup_path = Some(write_pre_migration_backup(&conn, path)?);
+        for (target, step) in pending {
+            apply_migration_step(&conn, target, step)?;
+            steps_applied.push(target);
+        }
+    }
+
+    apply_current_version_maintenance(&conn)?;
+    set_version(&conn)?;
+
+    let backup_note = backup_path
+        .as_deref()
+        .unwrap_or("none (no migration steps were applied)");
+
+    let integrity: String = conn.query_row("PRAGMA integrity_check", [], |row| row.get(0))?;
+    if integrity != "ok" {
+        return Err(DbError::Schema {
+            message: format!(
+                "integrity_check failed after migration: {integrity}\n  Pre-migration backup: {backup_note}"
+            ),
+        });
+    }
+
+    let pages_after = count_table_rows(&conn, "pages")?;
+    let links_after = count_table_rows(&conn, "links")?;
+    if pages_after != pages_before || links_after > links_before {
+        return Err(DbError::Schema {
+            message: format!(
+                "row-count sanity check failed after migration (pages {pages_before} -> {pages_after}, links {links_before} -> {links_after})\n  Pre-migration backup: {backup_note}"
+            ),
+        });
+    }
+
+    Ok(MigrationReport {
+        from_version,
+        to_version: SCHEMA_VERSION,
+        steps_applied,
+        backup_path,
+        pages_before,
+        pages_after,
+        links_before,
+        links_after,
+    })
+}
+
+fn count_table_rows(conn: &Connection, table: &str) -> Result<i64, DbError> {
+    if !table_exists(conn, table)? {
+        return Ok(0);
+    }
+    conn.query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |row| {
+        row.get(0)
+    })
+    .map_err(DbError::from)
+}
+
+fn write_pre_migration_backup(conn: &Connection, path: &str) -> Result<String, DbError> {
+    // Fold the WAL into the main file so the copy is a complete snapshot.
+    conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")?;
+    let backup = format!("{path}.bak");
+    std::fs::copy(path, &backup).map_err(|error| DbError::Schema {
+        message: format!("failed to write pre-migration backup at {backup}: {error}"),
+    })?;
+    Ok(backup)
+}
+
+fn apply_migration_step(
+    conn: &Connection,
+    target: i64,
+    step: MigrationStep,
+) -> Result<(), DbError> {
+    let foreign_keys_enabled: i64 = conn.query_row("PRAGMA foreign_keys", [], |row| row.get(0))?;
+    conn.execute_batch("PRAGMA foreign_keys = OFF;")?;
+
+    let applied: Result<(), DbError> = (|| {
+        let tx = conn.unchecked_transaction()?;
+        step(&tx)?;
+        bump_stored_schema_version(&tx, target)?;
+        tx.commit()?;
+        Ok(())
+    })();
+
+    if foreign_keys_enabled != 0 {
+        conn.execute_batch("PRAGMA foreign_keys = ON;")?;
+    }
+    applied?;
+
+    let violation: Option<String> = conn
+        .query_row("PRAGMA foreign_key_check", [], |row| row.get(0))
+        .optional()?;
+    if let Some(table) = violation {
+        return Err(DbError::Schema {
+            message: format!(
+                "foreign_key_check failed after migrating to schema version {target} (first violation in table {table})"
+            ),
+        });
+    }
+    Ok(())
+}
+
+/// Bumps the stored schema version in both places it is written today:
+/// `quaid_config.schema_version` (upsert, mirroring `write_quaid_config`)
+/// and the legacy `config.version` mirror (`INSERT OR REPLACE`, mirroring
+/// `sync_legacy_config`).
+fn bump_stored_schema_version(conn: &Connection, version: i64) -> Result<(), DbError> {
+    if table_exists(conn, "quaid_config")? {
+        conn.execute(
+            "INSERT INTO quaid_config (key, value) VALUES ('schema_version', ?1) \
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            [version.to_string()],
+        )?;
+    }
+    if table_exists(conn, "config")? {
+        conn.execute(
+            "INSERT OR REPLACE INTO config (key, value) VALUES ('version', ?1)",
+            [version.to_string()],
+        )?;
+    }
+    Ok(())
 }
 
 fn ensure_namespace_schema(conn: &Connection) -> Result<(), DbError> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -312,6 +312,11 @@ enum Commands {
     },
     /// JSONL pipe mode (one JSON object per line)
     Pipe,
+    /// Upgrade an existing database to the current schema version (writes a .bak backup first)
+    Migrate {
+        /// Path to the database to migrate [default: --db / QUAID_DB / ~/.quaid/memory.db]
+        path: Option<String>,
+    },
     /// Print version information
     Version,
 }
@@ -320,6 +325,7 @@ enum Commands {
 enum EarlyCommand {
     None,
     Init(String),
+    Migrate(String),
     Model(commands::model::ModelAction),
     Version,
 }
@@ -331,6 +337,11 @@ fn early_command(cli: &Cli) -> EarlyCommand {
             let default_path = core::db::default_db_path_string();
             let db_path = cli.db.as_deref().unwrap_or(default_path.as_str());
             EarlyCommand::Init(path.clone().unwrap_or_else(|| db_path.to_owned()))
+        }
+        Commands::Migrate { path } => {
+            let default_path = core::db::default_db_path_string();
+            let db_path = cli.db.as_deref().unwrap_or(default_path.as_str());
+            EarlyCommand::Migrate(path.clone().unwrap_or_else(|| db_path.to_owned()))
         }
         Commands::Model { action } => EarlyCommand::Model(action.clone()),
         _ => EarlyCommand::None,
@@ -364,6 +375,7 @@ async fn main() -> Result<()> {
     match early_command(&cli) {
         EarlyCommand::Version => return commands::version::run(),
         EarlyCommand::Init(path) => return commands::init::run(&path, &requested_model),
+        EarlyCommand::Migrate(path) => return commands::migrate_db::run(&path, cli.json),
         EarlyCommand::Model(action) => return commands::model::run(action),
         EarlyCommand::None => {}
     }
@@ -374,7 +386,10 @@ async fn main() -> Result<()> {
     let db = opened.conn;
 
     match cli.command {
-        Commands::Init { .. } | Commands::Model { .. } | Commands::Version => unreachable!(),
+        Commands::Init { .. }
+        | Commands::Migrate { .. }
+        | Commands::Model { .. }
+        | Commands::Version => unreachable!(),
         Commands::Get { slug, namespace } => {
             commands::get::run(&db, &slug, namespace.as_deref().or(Some("")), cli.json)
         }

--- a/tests/cli_migrate_db.rs
+++ b/tests/cli_migrate_db.rs
@@ -1,0 +1,341 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::print_stdout,
+    reason = "test fixtures legitimately panic on setup failure and print diagnostics; per-site #[expect] would generate noise across thousands of test sites"
+)]
+
+//! Subprocess tests for `quaid migrate`: the explicit schema-migration
+//! ladder. Fixtures are real v9 databases built from the v0.21.0 DDL
+//! (`tests/fixtures/schema_v9.sql`, captured via
+//! `git show v0.21.0:src/schema.sql`).
+
+mod common;
+#[path = "common/subprocess.rs"]
+mod common_subprocess;
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use rusqlite::Connection;
+use serde_json::Value;
+
+const SCHEMA_V9: &str = include_str!("fixtures/schema_v9.sql");
+
+fn run_quaid(home: &Path, args: &[&str]) -> Output {
+    let mut command = Command::new(common::quaid_bin());
+    common_subprocess::configure_test_command(&mut command);
+    command
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .args(args)
+        .output()
+        .expect("run quaid")
+}
+
+fn assert_success(output: &Output) {
+    assert!(
+        output.status.success(),
+        "command failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// Builds a populated schema-v9 database: three pages, a duplicated
+/// `programmatic` link (must survive), a duplicated `wiki_link` derived edge
+/// (must collapse to one row), and one distinct `wiki_link` edge.
+fn build_v9_fixture(db_path: &Path, vault_root: &Path) {
+    fs::create_dir_all(vault_root).unwrap();
+    let conn = Connection::open(db_path).unwrap();
+    conn.execute_batch(SCHEMA_V9).unwrap();
+    conn.execute_batch("PRAGMA user_version = 9;").unwrap();
+
+    conn.execute_batch(
+        "INSERT INTO quaid_config (key, value) VALUES
+             ('model_id',       'BAAI/bge-small-en-v1.5'),
+             ('model_alias',    'small'),
+             ('embedding_dim',  '384'),
+             ('schema_version', '9');",
+    )
+    .unwrap();
+
+    conn.execute(
+        "INSERT INTO collections (id, name, root_path, state, writable, is_write_target)
+         VALUES (1, 'default', ?1, 'active', 1, 1)",
+        [vault_root.to_str().unwrap()],
+    )
+    .unwrap();
+
+    conn.execute_batch(
+        "INSERT INTO pages (id, collection_id, slug, uuid, type, title, compiled_truth, wing) VALUES
+             (1, 1, 'people/alice',   '018f0000-0000-7000-8000-000000000001', 'person',  'Alice',   'Alice runs ops.', 'people'),
+             (2, 1, 'people/bob',     '018f0000-0000-7000-8000-000000000002', 'person',  'Bob',     'Bob writes Rust.', 'people'),
+             (3, 1, 'projects/quaid', '018f0000-0000-7000-8000-000000000003', 'project', 'Quaid',   'Personal memory.', 'projects');
+
+         INSERT INTO links (id, from_page_id, to_page_id, relationship, source_kind) VALUES
+             (1, 1, 2, 'related',  'programmatic'),
+             (2, 1, 2, 'related',  'programmatic'),
+             (3, 1, 3, 'related',  'wiki_link'),
+             (4, 1, 3, 'related',  'wiki_link'),
+             (5, 2, 3, 'mentions', 'wiki_link');",
+    )
+    .unwrap();
+}
+
+fn stored_versions(db_path: &Path) -> (String, String) {
+    let conn = Connection::open(db_path).unwrap();
+    let quaid_config: String = conn
+        .query_row(
+            "SELECT value FROM quaid_config WHERE key = 'schema_version'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let legacy: String = conn
+        .query_row(
+            "SELECT value FROM config WHERE key = 'version'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    (quaid_config, legacy)
+}
+
+fn temp_layout(dir: &tempfile::TempDir) -> (PathBuf, PathBuf, PathBuf) {
+    let home = dir.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let db_path = dir.path().join("memory.db");
+    let vault_root = dir.path().join("vault");
+    (home, db_path, vault_root)
+}
+
+#[test]
+fn plain_open_fail_closes_on_v9_database() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let (home, db_path, vault_root) = temp_layout(&dir);
+    build_v9_fixture(&db_path, &vault_root);
+
+    let output = run_quaid(&home, &["--db", db_path.to_str().unwrap(), "list"]);
+
+    assert!(
+        !output.status.success(),
+        "plain open of a v9 database must fail closed\nstdout:\n{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Found version 9, expected 10"),
+        "stderr should name the version mismatch, got:\n{stderr}"
+    );
+
+    // Fail-closed means untouched: still v9, no backup written.
+    let (quaid_config, legacy) = stored_versions(&db_path);
+    assert_eq!(quaid_config, "9");
+    assert_eq!(legacy, "9");
+    assert!(!PathBuf::from(format!("{}.bak", db_path.display())).exists());
+}
+
+#[test]
+fn migrate_upgrades_v9_database_to_current_schema_with_data_intact() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let (home, db_path, vault_root) = temp_layout(&dir);
+    build_v9_fixture(&db_path, &vault_root);
+    let db = db_path.to_str().unwrap();
+
+    let output = run_quaid(&home, &["--db", db, "migrate"]);
+    assert_success(&output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("from schema version 9 to 10"),
+        "report should describe the ladder run, got:\n{stdout}"
+    );
+    assert!(stdout.contains("Integrity check: ok"));
+
+    // Backup written before the first step.
+    let backup = PathBuf::from(format!("{db}.bak"));
+    assert!(backup.exists(), "pre-migration backup must exist");
+    let backup_conn = Connection::open(&backup).unwrap();
+    let backup_version: String = backup_conn
+        .query_row(
+            "SELECT value FROM quaid_config WHERE key = 'schema_version'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(backup_version, "9", "backup must remain a v9 snapshot");
+
+    let (quaid_config, legacy) = stored_versions(&db_path);
+    assert_eq!(quaid_config, "10");
+    assert_eq!(legacy, "10");
+
+    let conn = Connection::open(&db_path).unwrap();
+    let integrity: String = conn
+        .query_row("PRAGMA integrity_check", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(integrity, "ok");
+
+    // links gained the edge_weight column and the partial unique index.
+    let has_edge_weight: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM pragma_table_info('links') WHERE name = 'edge_weight'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(has_edge_weight, 1);
+    let has_unique_index: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master
+             WHERE type = 'index' AND name = 'idx_links_unique_derived_edge'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(has_unique_index, 1);
+
+    // The extended CHECK accepts the new derived source kinds.
+    conn.execute(
+        "INSERT INTO links (from_page_id, to_page_id, relationship, source_kind, edge_weight)
+         VALUES (3, 1, 'related', 'frontmatter', 1.0)",
+        [],
+    )
+    .unwrap();
+    conn.execute("DELETE FROM links WHERE source_kind = 'frontmatter'", [])
+        .unwrap();
+
+    // Data intact: pages untouched, programmatic duplicates preserved,
+    // wiki_link duplicates collapsed to the oldest row.
+    let pages: i64 = conn
+        .query_row("SELECT COUNT(*) FROM pages", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(pages, 3);
+    let programmatic: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM links WHERE source_kind = 'programmatic'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(programmatic, 2);
+    let wiki_rows: Vec<i64> = conn
+        .prepare("SELECT id FROM links WHERE source_kind = 'wiki_link' ORDER BY id")
+        .unwrap()
+        .query_map([], |row| row.get(0))
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+    assert_eq!(wiki_rows, vec![3, 5]);
+
+    // v10 graph config defaults are seeded.
+    let graph_depth: String = conn
+        .query_row(
+            "SELECT value FROM config WHERE key = 'graph_depth'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(graph_depth, "0");
+    drop(conn);
+
+    // The migrated database opens and works with the current binary.
+    let list = run_quaid(&home, &["--db", db, "list"]);
+    assert_success(&list);
+    let listed = String::from_utf8_lossy(&list.stdout);
+    assert!(
+        listed.contains("people/alice"),
+        "migrated data should be listable, got:\n{listed}"
+    );
+}
+
+#[test]
+fn migrate_reports_json_when_requested() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let (home, db_path, vault_root) = temp_layout(&dir);
+    build_v9_fixture(&db_path, &vault_root);
+    let db = db_path.to_str().unwrap();
+
+    let output = run_quaid(&home, &["--json", "--db", db, "migrate"]);
+    assert_success(&output);
+
+    let report: Value = serde_json::from_slice(&output.stdout).expect("valid JSON report");
+    assert_eq!(report["from_version"], 9);
+    assert_eq!(report["to_version"], 10);
+    assert_eq!(report["steps_applied"], serde_json::json!([10]));
+    assert_eq!(report["integrity_check"], "ok");
+    assert_eq!(report["backup_path"], format!("{db}.bak"));
+    assert_eq!(report["pages"]["before"], 3);
+    assert_eq!(report["pages"]["after"], 3);
+    assert_eq!(report["links"]["before"], 5);
+    assert_eq!(report["links"]["after"], 4);
+}
+
+#[test]
+fn migrate_is_noop_on_already_current_database() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let (home, db_path, _vault_root) = temp_layout(&dir);
+    let db = db_path.to_str().unwrap();
+
+    assert_success(&run_quaid(&home, &["init", db]));
+    let (quaid_config_before, legacy_before) = stored_versions(&db_path);
+
+    let output = run_quaid(&home, &["--db", db, "migrate"]);
+    assert_success(&output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("already at schema version 10"),
+        "no-op run should say so, got:\n{stdout}"
+    );
+
+    assert!(
+        !PathBuf::from(format!("{db}.bak")).exists(),
+        "no backup should be written for a no-op migration"
+    );
+    let (quaid_config_after, legacy_after) = stored_versions(&db_path);
+    assert_eq!(quaid_config_after, quaid_config_before);
+    assert_eq!(legacy_after, legacy_before);
+}
+
+#[test]
+fn migrate_refuses_database_newer_than_binary() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let (home, db_path, _vault_root) = temp_layout(&dir);
+    let db = db_path.to_str().unwrap();
+
+    let conn = Connection::open(&db_path).unwrap();
+    conn.execute_batch(
+        "CREATE TABLE quaid_config (key TEXT PRIMARY KEY NOT NULL, value TEXT NOT NULL) STRICT;
+         CREATE TABLE config (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+         INSERT INTO quaid_config (key, value) VALUES
+             ('model_id',       'BAAI/bge-small-en-v1.5'),
+             ('model_alias',    'small'),
+             ('embedding_dim',  '384'),
+             ('schema_version', '11');
+         INSERT INTO config (key, value) VALUES ('version', '11');",
+    )
+    .unwrap();
+    drop(conn);
+
+    // Positional-path form of the command.
+    let output = run_quaid(&home, &["migrate", db]);
+    assert!(
+        !output.status.success(),
+        "future-version databases must be refused\nstdout:\n{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Found version 11, expected 10"),
+        "stderr should name the newer version, got:\n{stderr}"
+    );
+
+    assert!(
+        !PathBuf::from(format!("{db}.bak")).exists(),
+        "no backup should be written when migration is refused"
+    );
+    let (quaid_config, legacy) = stored_versions(&db_path);
+    assert_eq!(quaid_config, "11");
+    assert_eq!(legacy, "11");
+}

--- a/tests/fixtures/schema_v9.sql
+++ b/tests/fixtures/schema_v9.sql
@@ -1,0 +1,498 @@
+-- memory.db schema — Quaid v9
+-- Embedded in binary via include_str!("schema.sql") in src/core/db.rs
+-- Standalone copy for reference and tooling.
+
+PRAGMA journal_mode = WAL;
+PRAGMA foreign_keys = ON;
+
+-- ============================================================
+-- quaid_config: persisted embedding model metadata
+-- ============================================================
+CREATE TABLE IF NOT EXISTS quaid_config (
+    key   TEXT PRIMARY KEY NOT NULL,
+    value TEXT NOT NULL
+) STRICT;
+
+-- ============================================================
+-- collections: named groupings with their own root, ignore patterns
+-- ============================================================
+CREATE TABLE IF NOT EXISTS collections (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    name                TEXT    NOT NULL UNIQUE CHECK(instr(name, '::') = 0),
+    root_path           TEXT    NOT NULL,
+    state               TEXT    NOT NULL DEFAULT 'active' CHECK(state IN ('active', 'detached', 'restoring')),
+    writable            INTEGER NOT NULL DEFAULT 1,
+    is_write_target     INTEGER NOT NULL DEFAULT 0,
+    ignore_patterns     TEXT    DEFAULT NULL,
+    ignore_parse_errors TEXT    DEFAULT NULL,
+    needs_full_sync     INTEGER NOT NULL DEFAULT 0,
+    last_sync_at        TEXT    DEFAULT NULL,
+    active_lease_session_id   TEXT DEFAULT NULL,
+    restore_command_id        TEXT DEFAULT NULL,
+    restore_lease_session_id  TEXT DEFAULT NULL,
+    reload_generation         INTEGER NOT NULL DEFAULT 0,
+    watcher_released_session_id TEXT DEFAULT NULL,
+    watcher_released_generation INTEGER DEFAULT NULL,
+    watcher_released_at         TEXT DEFAULT NULL,
+    pending_command_heartbeat_at TEXT DEFAULT NULL,
+    pending_root_path           TEXT DEFAULT NULL,
+    pending_restore_manifest    TEXT DEFAULT NULL,
+    restore_command_pid         INTEGER DEFAULT NULL,
+    restore_command_host        TEXT DEFAULT NULL,
+    integrity_failed_at         TEXT DEFAULT NULL,
+    pending_manifest_incomplete_at TEXT DEFAULT NULL,
+    reconcile_halted_at         TEXT DEFAULT NULL,
+    reconcile_halt_reason       TEXT DEFAULT NULL,
+    created_at          TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at          TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_collections_write_target
+    ON collections(is_write_target) WHERE is_write_target = 1;
+CREATE INDEX IF NOT EXISTS idx_collections_restore_state
+    ON collections(state, needs_full_sync, reload_generation);
+CREATE INDEX IF NOT EXISTS idx_collections_reconcile_halt
+    ON collections(reconcile_halted_at) WHERE reconcile_halted_at IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS serve_sessions (
+    session_id    TEXT PRIMARY KEY,
+    pid           INTEGER NOT NULL,
+    host          TEXT    NOT NULL,
+    started_at    TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    heartbeat_at  TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    ipc_path      TEXT    DEFAULT NULL,
+    session_type  TEXT    NOT NULL DEFAULT 'serve'
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_serve_sessions_heartbeat
+    ON serve_sessions(heartbeat_at);
+
+CREATE TABLE IF NOT EXISTS collection_owners (
+    collection_id INTEGER PRIMARY KEY REFERENCES collections(id) ON DELETE CASCADE,
+    session_id    TEXT NOT NULL REFERENCES serve_sessions(session_id) ON DELETE CASCADE,
+    claimed_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_collection_owners_session
+    ON collection_owners(session_id);
+
+-- ============================================================
+-- pages: the core content table
+-- ============================================================
+CREATE TABLE IF NOT EXISTS pages (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    -- DEFAULT 1 routes legacy inserts to the default collection (id=1).
+    -- A matching ensure_default_collection() call in db.rs guarantees the row exists.
+    collection_id   INTEGER NOT NULL DEFAULT 1 REFERENCES collections(id) ON DELETE CASCADE,
+    namespace       TEXT    NOT NULL DEFAULT '',
+    slug            TEXT    NOT NULL,
+    -- NULL until UUID lifecycle (tasks 5a.*) is fully wired; allows NULL so
+    -- legacy INSERT helpers that omit uuid continue to work.
+    uuid            TEXT    DEFAULT NULL,
+    type            TEXT    NOT NULL,
+    -- Valid types: person, company, deal, yc, civic, project, concept, original,
+    --              source, media, decision, commitment, action_item
+    title           TEXT    NOT NULL,
+    summary         TEXT    NOT NULL DEFAULT '',
+    compiled_truth  TEXT    NOT NULL DEFAULT '',
+    timeline        TEXT    NOT NULL DEFAULT '',
+    frontmatter     TEXT    NOT NULL DEFAULT '{}',
+    wing            TEXT    NOT NULL DEFAULT '',
+    room            TEXT    NOT NULL DEFAULT '',
+    superseded_by   INTEGER DEFAULT NULL REFERENCES pages(id),
+    version         INTEGER NOT NULL DEFAULT 1,
+    quarantined_at  TEXT    DEFAULT NULL,
+    created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    truth_updated_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    timeline_updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    UNIQUE(collection_id, namespace, slug)
+);
+
+CREATE INDEX IF NOT EXISTS idx_pages_namespace ON pages(namespace);
+-- Partial index: SQLite allows multiple NULLs in unique indexes, but being
+-- explicit here avoids confusion when uuid is still unset.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_pages_uuid ON pages(uuid) WHERE uuid IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_pages_collection ON pages(collection_id);
+CREATE INDEX IF NOT EXISTS idx_pages_type     ON pages(type);
+CREATE INDEX IF NOT EXISTS idx_pages_slug     ON pages(collection_id, slug);
+CREATE INDEX IF NOT EXISTS idx_pages_updated  ON pages(updated_at);
+CREATE INDEX IF NOT EXISTS idx_pages_wing     ON pages(wing);
+CREATE INDEX IF NOT EXISTS idx_pages_wing_room ON pages(wing, room);
+CREATE INDEX IF NOT EXISTS idx_pages_quarantined ON pages(quarantined_at) WHERE quarantined_at IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_pages_supersede_head
+    ON pages(type, superseded_by) WHERE superseded_by IS NULL;
+CREATE INDEX IF NOT EXISTS idx_pages_session
+    ON pages(json_extract(IIF(json_valid(frontmatter), frontmatter, '{}'), '$.session_id'))
+    WHERE json_valid(frontmatter)
+      AND json_extract(IIF(json_valid(frontmatter), frontmatter, '{}'), '$.session_id') IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS namespaces (
+    id         TEXT PRIMARY KEY,
+    ttl_hours  REAL DEFAULT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS quarantine_exports (
+    page_id         INTEGER NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
+    quarantined_at  TEXT    NOT NULL,
+    exported_at     TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    output_path     TEXT    NOT NULL,
+    PRIMARY KEY (page_id, quarantined_at)
+);
+
+CREATE INDEX IF NOT EXISTS idx_quarantine_exports_exported
+    ON quarantine_exports(exported_at);
+
+-- ============================================================
+-- page_fts: full-text search over compiled_truth + timeline
+-- ============================================================
+CREATE VIRTUAL TABLE IF NOT EXISTS page_fts USING fts5(
+    title,
+    slug,
+    compiled_truth,
+    timeline,
+    content='pages',
+    content_rowid='id',
+    tokenize='porter unicode61'
+);
+
+CREATE TRIGGER IF NOT EXISTS pages_ai AFTER INSERT ON pages BEGIN
+    INSERT INTO page_fts(rowid, title, slug, compiled_truth, timeline)
+    SELECT new.id, new.title, new.slug, new.compiled_truth, new.timeline
+    WHERE new.quarantined_at IS NULL;
+END;
+
+CREATE TRIGGER IF NOT EXISTS pages_ad AFTER DELETE ON pages BEGIN
+    INSERT INTO page_fts(page_fts, rowid, title, slug, compiled_truth, timeline)
+    SELECT 'delete', old.id, old.title, old.slug, old.compiled_truth, old.timeline
+    WHERE old.quarantined_at IS NULL;
+END;
+
+CREATE TRIGGER IF NOT EXISTS pages_au AFTER UPDATE ON pages BEGIN
+    INSERT INTO page_fts(page_fts, rowid, title, slug, compiled_truth, timeline)
+    SELECT 'delete', old.id, old.title, old.slug, old.compiled_truth, old.timeline
+    WHERE old.quarantined_at IS NULL;
+    INSERT INTO page_fts(rowid, title, slug, compiled_truth, timeline)
+    SELECT new.id, new.title, new.slug, new.compiled_truth, new.timeline
+    WHERE new.quarantined_at IS NULL;
+END;
+
+-- ============================================================
+-- embedding_models: registry — one active model at all times
+-- ============================================================
+CREATE TABLE IF NOT EXISTS embedding_models (
+    name        TEXT    PRIMARY KEY,
+    dimensions  INTEGER NOT NULL,
+    vec_table   TEXT    NOT NULL UNIQUE,
+    active      INTEGER NOT NULL DEFAULT 0,
+    created_at  TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+-- Exactly one active model enforced via partial unique index.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_embedding_models_one_active
+    ON embedding_models(active) WHERE active = 1;
+
+-- Seed default model at init:
+--   INSERT INTO embedding_models (name, dimensions, vec_table, active)
+--   VALUES ('BAAI/bge-small-en-v1.5', 384, 'page_embeddings_vec_384', 1);
+-- Vec table created dynamically in db.rs:
+--   CREATE VIRTUAL TABLE IF NOT EXISTS page_embeddings_vec_384 USING vec0(embedding float[384]);
+
+-- ============================================================
+-- page_embeddings: chunk metadata for vector search
+-- ============================================================
+CREATE TABLE IF NOT EXISTS page_embeddings (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    page_id         INTEGER NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
+    model           TEXT    NOT NULL DEFAULT 'BAAI/bge-small-en-v1.5'
+                            REFERENCES embedding_models(name),
+    vec_rowid       INTEGER NOT NULL,
+    chunk_type      TEXT    NOT NULL,   -- 'truth_section' | 'timeline_entry'
+    chunk_index     INTEGER NOT NULL,
+    chunk_text      TEXT    NOT NULL,
+    content_hash    TEXT    NOT NULL,   -- SHA-256 of chunk_text
+    token_count     INTEGER NOT NULL,
+    heading_path    TEXT    NOT NULL DEFAULT '',
+    last_embedded_at TEXT   NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    UNIQUE(model, vec_rowid)
+);
+
+CREATE INDEX IF NOT EXISTS idx_embeddings_page   ON page_embeddings(page_id);
+CREATE INDEX IF NOT EXISTS idx_embeddings_model  ON page_embeddings(model);
+CREATE INDEX IF NOT EXISTS idx_embeddings_lookup ON page_embeddings(model, page_id, chunk_index);
+
+-- ============================================================
+-- links: typed temporal cross-references between pages
+-- ============================================================
+CREATE TABLE IF NOT EXISTS links (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    from_page_id    INTEGER NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
+    to_page_id      INTEGER NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
+    relationship    TEXT    NOT NULL DEFAULT 'related',
+    context         TEXT    NOT NULL DEFAULT '',
+    source_kind     TEXT    NOT NULL DEFAULT 'programmatic' CHECK(source_kind IN ('wiki_link', 'programmatic')),
+    valid_from      TEXT    DEFAULT NULL,
+    valid_until     TEXT    DEFAULT NULL,
+    created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    CHECK (valid_from IS NULL OR valid_until IS NULL OR valid_until >= valid_from)
+);
+
+CREATE INDEX IF NOT EXISTS idx_links_from    ON links(from_page_id);
+CREATE INDEX IF NOT EXISTS idx_links_to      ON links(to_page_id);
+CREATE INDEX IF NOT EXISTS idx_links_current ON links(valid_until);
+CREATE INDEX IF NOT EXISTS idx_links_source  ON links(source_kind);
+
+-- ============================================================
+-- assertions: heuristic contradiction detection
+-- ============================================================
+CREATE TABLE IF NOT EXISTS assertions (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    page_id         INTEGER NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
+    subject         TEXT    NOT NULL,
+    predicate       TEXT    NOT NULL,
+    object          TEXT    NOT NULL,
+    valid_from      TEXT    DEFAULT NULL,
+    valid_until     TEXT    DEFAULT NULL,
+    supersedes_id   INTEGER DEFAULT NULL REFERENCES assertions(id),
+    confidence      REAL    DEFAULT 1.0,
+    asserted_by     TEXT    NOT NULL DEFAULT 'agent',
+    source_ref      TEXT    NOT NULL DEFAULT '',
+    evidence_text   TEXT    NOT NULL DEFAULT '',
+    created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    CHECK (valid_from IS NULL OR valid_until IS NULL OR valid_until >= valid_from),
+    CHECK (asserted_by IN ('agent', 'manual', 'import', 'enrichment'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_assertions_subj ON assertions(subject);
+CREATE INDEX IF NOT EXISTS idx_assertions_pred ON assertions(predicate);
+
+-- ============================================================
+-- tags
+-- ============================================================
+CREATE TABLE IF NOT EXISTS tags (
+    id      INTEGER PRIMARY KEY AUTOINCREMENT,
+    page_id INTEGER NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
+    tag     TEXT    NOT NULL,
+    UNIQUE(page_id, tag)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tags_tag     ON tags(tag);
+CREATE INDEX IF NOT EXISTS idx_tags_page_id ON tags(page_id);
+
+-- ============================================================
+-- raw_data: sidecar data (replaces .raw/ JSON files)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS raw_data (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    page_id     INTEGER NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
+    source      TEXT    NOT NULL,
+    data        TEXT    NOT NULL,
+    fetched_at  TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    UNIQUE(page_id, source)
+);
+
+CREATE INDEX IF NOT EXISTS idx_raw_data_page ON raw_data(page_id);
+
+-- ============================================================
+-- timeline_entries: structured timeline rows
+-- ============================================================
+CREATE TABLE IF NOT EXISTS timeline_entries (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    page_id      INTEGER NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
+    date         TEXT    NOT NULL,
+    source       TEXT    NOT NULL DEFAULT '',
+    summary      TEXT    NOT NULL,
+    summary_hash TEXT    NOT NULL DEFAULT '',
+    detail       TEXT    NOT NULL DEFAULT '',
+    created_at   TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    UNIQUE(page_id, date, summary_hash)
+);
+
+CREATE INDEX IF NOT EXISTS idx_timeline_page ON timeline_entries(page_id);
+CREATE INDEX IF NOT EXISTS idx_timeline_date ON timeline_entries(date);
+
+-- ============================================================
+-- raw_imports: original file bytes for byte-exact round-trip
+-- ============================================================
+CREATE TABLE IF NOT EXISTS raw_imports (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    page_id    INTEGER NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
+    import_id  TEXT    NOT NULL,
+    is_active  INTEGER NOT NULL DEFAULT 1,
+    content_hash TEXT  NOT NULL DEFAULT '',
+    raw_bytes  BLOB    NOT NULL,
+    file_path  TEXT    NOT NULL,
+    created_at TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    UNIQUE(page_id, import_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_raw_imports_page   ON raw_imports(page_id);
+CREATE INDEX IF NOT EXISTS idx_raw_imports_active ON raw_imports(page_id, is_active)
+    WHERE is_active = 1;
+
+CREATE TABLE IF NOT EXISTS import_manifest (
+    import_id   TEXT    PRIMARY KEY,
+    source_dir  TEXT    NOT NULL,
+    page_count  INTEGER NOT NULL,
+    created_at  TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+-- ============================================================
+-- file_state: stat-based change detection for vault sync
+-- ============================================================
+CREATE TABLE IF NOT EXISTS file_state (
+    collection_id   INTEGER NOT NULL REFERENCES collections(id) ON DELETE CASCADE,
+    relative_path   TEXT    NOT NULL,
+    page_id         INTEGER NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
+    mtime_ns        INTEGER NOT NULL,
+    ctime_ns        INTEGER DEFAULT NULL,
+    size_bytes      INTEGER NOT NULL,
+    inode           INTEGER DEFAULT NULL,
+    sha256          TEXT    NOT NULL,
+    last_seen_at    TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    last_full_hash_at TEXT  NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    PRIMARY KEY (collection_id, relative_path)
+);
+
+CREATE INDEX IF NOT EXISTS idx_file_state_sha256 ON file_state(sha256);
+CREATE INDEX IF NOT EXISTS idx_file_state_audit ON file_state(last_full_hash_at);
+CREATE INDEX IF NOT EXISTS idx_file_state_page ON file_state(page_id);
+
+-- ============================================================
+-- embedding_jobs: persistent queue for async embedding work
+-- ============================================================
+CREATE TABLE IF NOT EXISTS embedding_jobs (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    page_id     INTEGER NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
+    chunk_index INTEGER NOT NULL DEFAULT 0,
+    priority    INTEGER NOT NULL DEFAULT 0,
+    job_state   TEXT    NOT NULL DEFAULT 'pending'
+                        CHECK(job_state IN ('pending', 'running', 'failed')),
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    last_error  TEXT    DEFAULT NULL,
+    created_at  TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    enqueued_at TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    started_at  TEXT    DEFAULT NULL,
+    UNIQUE(page_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_embedding_jobs_queue
+    ON embedding_jobs(job_state, priority DESC, enqueued_at);
+
+-- ============================================================
+-- extraction_queue: queued conversation extraction jobs
+-- ============================================================
+CREATE TABLE IF NOT EXISTS extraction_queue (
+    id                INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id        TEXT    NOT NULL,
+    conversation_path TEXT    NOT NULL,
+    trigger_kind      TEXT    NOT NULL CHECK(trigger_kind IN ('debounce', 'session_close', 'manual')),
+    enqueued_at       TEXT    NOT NULL,
+    scheduled_for     TEXT    NOT NULL,
+    attempts          INTEGER NOT NULL DEFAULT 0,
+    last_error        TEXT    DEFAULT NULL,
+    status            TEXT    NOT NULL DEFAULT 'pending'
+                            CHECK(status IN ('pending', 'running', 'done', 'failed'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_extraction_queue_pending
+    ON extraction_queue(status, scheduled_for) WHERE status = 'pending';
+
+-- ============================================================
+-- correction_sessions: bounded fact-correction dialogues
+-- ============================================================
+CREATE TABLE IF NOT EXISTS correction_sessions (
+    correction_id TEXT PRIMARY KEY,
+    fact_slug     TEXT    NOT NULL,
+    exchange_log  TEXT    NOT NULL CHECK(json_valid(exchange_log) AND json_type(exchange_log) = 'array'),
+    turns_used    INTEGER NOT NULL DEFAULT 0 CHECK(turns_used >= 0),
+    status        TEXT    NOT NULL DEFAULT 'open'
+                          CHECK(status IN ('open', 'committed', 'abandoned', 'expired')),
+    created_at    TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    expires_at    TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '+1 hour'))
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_correction_open
+    ON correction_sessions(status, expires_at) WHERE status = 'open';
+
+-- ============================================================
+-- config: mutable runtime defaults
+-- ============================================================
+CREATE TABLE IF NOT EXISTS config (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+INSERT OR IGNORE INTO config (key, value) VALUES
+    ('version',               '9'),
+    ('embedding_model',       'BAAI/bge-small-en-v1.5'),
+    ('embedding_dimensions',  '384'),
+    ('chunk_strategy',        'section'),
+    ('search_merge_strategy', 'set-union'),
+    ('default_token_budget',  '4000'),
+    ('memory.location',       'vault-subdir'),
+    ('corrections.history_on_disk', 'false'),
+    ('extraction.max_retries', '3'),
+    ('extraction.enabled', 'false'),
+    ('extraction.model_alias', 'phi-3.5-mini'),
+    ('extraction.window_turns', '5'),
+    ('extraction.debounce_ms', '5000'),
+    ('extraction.idle_close_ms', '60000'),
+    ('extraction.retention_days', '30'),
+    ('fact_resolution.dedup_cosine_min', '0.92'),
+    ('fact_resolution.supersede_cosine_min', '0.4'),
+    ('daemon.http.enabled', 'false'),
+    ('daemon.http.port', '3112'),
+    ('daemon.http.bind', '127.0.0.1'),
+    ('daemon.http.trusted_loopback', 'false');
+
+-- ============================================================
+-- contradictions: detected inconsistencies
+-- ============================================================
+CREATE TABLE IF NOT EXISTS contradictions (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    page_id       INTEGER NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
+    other_page_id INTEGER REFERENCES pages(id) ON DELETE CASCADE,
+    type          TEXT    NOT NULL,
+    description   TEXT    NOT NULL,
+    detected_at   TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    resolved_at   TEXT    DEFAULT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_contradictions_page       ON contradictions(page_id);
+CREATE INDEX IF NOT EXISTS idx_contradictions_other_page ON contradictions(other_page_id);
+CREATE INDEX IF NOT EXISTS idx_contradictions_unresolved ON contradictions(resolved_at)
+    WHERE resolved_at IS NULL;
+
+-- ============================================================
+-- knowledge_gaps: queries the memory engine couldn't answer well
+-- Privacy-safe by default: raw query text is NOT retained
+-- unless explicitly approved.  Only query_hash is stored on
+-- detection; query_text is populated post-approval.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS knowledge_gaps (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    page_id          INTEGER DEFAULT NULL REFERENCES pages(id) ON DELETE CASCADE,
+    query_hash       TEXT    NOT NULL,   -- SHA-256 of original query, always stored
+    query_text       TEXT    DEFAULT NULL,  -- raw text retained only after approval
+    context          TEXT    NOT NULL DEFAULT '',
+    confidence_score REAL    DEFAULT NULL,
+    sensitivity      TEXT    NOT NULL DEFAULT 'internal',
+    approved_by      TEXT    DEFAULT NULL,
+    approved_at      TEXT    DEFAULT NULL,
+    redacted_query   TEXT    DEFAULT NULL,
+    resolved_at      TEXT    DEFAULT NULL,
+    resolved_by_slug TEXT    DEFAULT NULL,
+    detected_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    CHECK (sensitivity IN ('internal', 'external', 'redacted')),
+    CHECK (query_text IS NULL OR (approved_by IS NOT NULL AND approved_at IS NOT NULL)),
+    CHECK (sensitivity = 'internal' OR (approved_by IS NOT NULL AND approved_at IS NOT NULL))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_gaps_query_hash ON knowledge_gaps(query_hash);
+CREATE INDEX IF NOT EXISTS idx_gaps_page ON knowledge_gaps(page_id) WHERE page_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_gaps_unresolved ON knowledge_gaps(resolved_at)
+    WHERE resolved_at IS NULL;


### PR DESCRIPTION
Implements **Area 17 (steps 2–4)** of the codebase review — the message rewrite (step 1) already shipped in #225; this PR scopes strictly to the migration machinery.

## Why
Quaid hard-refuses any schema-version mismatch while *also* running unversioned in-place `ensure_*` patches on every open — "no migrations" as policy theater, with v10 schemas silently drifting across v0.22.x releases and v0.20/v0.21 users dead-ended.

## Changes
- **Versioned registry**: `MIGRATIONS: &[(i64, MigrationStep)]` keyed by target version; each rung in its own transaction (`foreign_key_check` after commit), bumping `quaid_config.schema_version` + the legacy `config.version` mirror exactly as the bootstrap writes them. A `<path>.bak` (after WAL truncate-checkpoint) is written before the first rung.
- **`ensure_*` consolidation**: the six unversioned patch functions folded into one registry-documented `apply_current_version_maintenance` step (still run at open — existing repair/backfill behavior preserved; future DDL ships as new rungs per the updated spec invariant).
- **Real v9→v10 rung**: derived exactly from `git show v0.21.0:src/schema.sql` vs current — derived-edge dedup, 12-step `links` rebuild adding `edge_weight` + extended CHECK, four indexes + the partial unique index, six graph config seeds.
- **`quaid migrate [path]`** (new `commands/migrate_db.rs`, early-command so it bypasses the fail-closed open): backup → ladder → `PRAGMA integrity_check` → row-count sanity (pages equal, links may only shrink) → report, with `--json`. Plain open stays fail-closed; current DB is a no-op; newer-than-binary refuses.
- openspec schema-migration spec updated (ladder + explicit-migrate flow, rung table, new invariant); CHANGELOG Unreleased entry.

## Validation
fmt/clippy/rustdoc gates clean. `tests/cli_migrate_db.rs` 5/5 against a byte-exact v9 fixture (from `git show v0.21.0:src/schema.sql`): fail-closed open leaves DB untouched; full migrate preserves data (programmatic duplicate links kept, wiki-link dupes collapsed to oldest, seeds present, `.bak` still v9, integrity ok, `quaid list` works after); no-op on current; future-version refusal. Affected suites green: db_schema_migrations, db_open, db_schema_v10, db_quaid_config, cli_init_defaults, command_surface_coverage, lib core::db.

🤖 Generated with [Claude Code](https://claude.com/claude-code)