### PR TITLE
fix(daemon): state-aware launchd start, instant SIGKILL recovery, supervisor-death exit (area 18)

### DIFF
--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -162,63 +162,94 @@ async fn run_foreground(db: Connection, http_config: Option<HttpConfig>) -> Resu
         runtime.session_id
     );
 
-    if let Some(config) = http_config {
+    let exit_code = if let Some(config) = http_config {
         let db_path_for_factory = db_path.clone();
         let factory =
             move || crate::core::db::open(&db_path_for_factory).map_err(anyhow::Error::from);
         // Block on the SSE listener; the supervisor + worker run in
-        // their own threads owned by `runtime`.
+        // their own threads owned by `runtime`. A supervisor that dies
+        // without a shutdown request is a zombie daemon — exit non-zero
+        // so the service manager restarts the unit.
         #[cfg(unix)]
-        {
-            tokio::select! {
-                result = crate::mcp::http::run_http(factory, config) => {
-                    if let Err(err) = result {
+        let exit_code = tokio::select! {
+            result = crate::mcp::http::run_http(factory, config) => {
+                match result {
+                    Ok(()) => 0u8,
+                    Err(err) => {
                         eprintln!("daemon_http_transport_failed error={err}");
-                        return Ok(1);
+                        1u8
                     }
                 }
-                () = shutdown_signal.recv() => {}
             }
-        }
+            () = shutdown_signal.recv() => 0u8,
+            exit_code = supervisor_death_watch(&runtime) => exit_code,
+        };
         #[cfg(not(unix))]
-        {
-            tokio::select! {
-                result = crate::mcp::http::run_http(factory, config) => {
-                    if let Err(err) = result {
+        let exit_code = tokio::select! {
+            result = crate::mcp::http::run_http(factory, config) => {
+                match result {
+                    Ok(()) => 0u8,
+                    Err(err) => {
                         eprintln!("daemon_http_transport_failed error={err}");
-                        return Ok(1);
+                        1u8
                     }
                 }
-                () = wait_for_runtime(&runtime) => {}
             }
-        }
+            exit_code = supervisor_death_watch(&runtime) => exit_code,
+        };
+        exit_code
     } else {
-        // No transport: block until the supervisor thread joins (SIGTERM).
+        // No transport: block until a shutdown signal arrives (exit 0)
+        // or the supervisor thread dies without one (exit 1).
         #[cfg(unix)]
-        wait_for_runtime(&runtime, &mut shutdown_signal).await;
+        let exit_code = wait_for_runtime(&runtime, &mut shutdown_signal).await;
         #[cfg(not(unix))]
-        wait_for_runtime(&runtime).await;
-    }
+        let exit_code = wait_for_runtime(&runtime).await;
+        exit_code
+    };
 
     drop(runtime);
-    Ok(0)
+    Ok(exit_code)
 }
 
-/// Block until the supervisor thread exits. Used when no MCP transport
-/// is open and we still need the foreground task to wait for shutdown.
+/// Block until either a shutdown signal arrives (normal stop → exit 0)
+/// or the supervisor thread exits without one (zombie daemon → exit 1
+/// so launchd `KeepAlive` / systemd `Restart=on-failure` restarts the
+/// unit instead of leaving a process whose watchers, heartbeats, and
+/// extraction have silently stopped).
 #[cfg(unix)]
 async fn wait_for_runtime(
-    _runtime: &vault_sync::ServeRuntime,
+    runtime: &vault_sync::ServeRuntime,
     shutdown_signal: &mut ShutdownSignal,
-) {
-    shutdown_signal.recv().await;
+) -> u8 {
+    tokio::select! {
+        () = shutdown_signal.recv() => 0,
+        exit_code = supervisor_death_watch(runtime) => exit_code,
+    }
 }
 
+/// Non-Unix fallback: no signal plumbing, so only the supervisor-death
+/// watch ends the foreground task (Ctrl-C tears the binary down).
 #[cfg(not(unix))]
-async fn wait_for_runtime(_runtime: &vault_sync::ServeRuntime) {
-    // Fallback: block forever on a stalled future (the supervisor
-    // thread keeps the process alive; Ctrl-C tears the binary down).
-    std::future::pending::<()>().await;
+async fn wait_for_runtime(runtime: &vault_sync::ServeRuntime) -> u8 {
+    supervisor_death_watch(runtime).await
+}
+
+/// Polls [`vault_sync::ServeRuntime::supervisor_finished`] every 500 ms
+/// and resolves with exit code 1 once the supervisor thread has exited
+/// without a shutdown request. Never resolves while the supervisor is
+/// healthy (or for transport-only runtimes, which own no supervisor).
+async fn supervisor_death_watch(runtime: &vault_sync::ServeRuntime) -> u8 {
+    loop {
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        if runtime.supervisor_finished() {
+            eprintln!(
+                "daemon_supervisor_exited_unexpectedly session_id={} exit_code=1",
+                runtime.session_id
+            );
+            return 1;
+        }
+    }
 }
 
 fn install_action(

--- a/src/core/vault_sync/mod.rs
+++ b/src/core/vault_sync/mod.rs
@@ -309,8 +309,8 @@ use restore::{
 };
 pub use session::{
     find_active_daemon_session, find_active_runtime_host, heartbeat_session, register_cli_session,
-    register_session, sweep_stale_sessions, try_promote_to_serve_host, unregister_session,
-    ActiveSessionInfo, SessionType,
+    register_session, sweep_stale_sessions, try_claim_daemon_session, try_promote_to_serve_host,
+    unregister_session, ActiveSessionInfo, DaemonSessionClaim, SessionType,
 };
 #[cfg(unix)]
 pub use watcher::WatcherError;
@@ -373,6 +373,21 @@ pub struct ServeRuntime {
     /// the session itself). Drop opens a fresh connection and removes the
     /// row to keep `serve_sessions` bounded.
     transport_only_db_path: Option<String>,
+}
+
+impl ServeRuntime {
+    /// Returns `true` when this handle owns a supervisor thread and
+    /// that thread has exited. The daemon foreground loop polls this to
+    /// detect a dead supervisor (a zombie daemon whose watchers,
+    /// heartbeats, and extraction have silently stopped) and exit
+    /// non-zero so launchd `KeepAlive` / systemd `Restart=on-failure`
+    /// restarts the unit. Always `false` for transport-only handles,
+    /// which own no supervisor thread.
+    pub fn supervisor_finished(&self) -> bool {
+        self.handle
+            .as_ref()
+            .is_some_and(thread::JoinHandle::is_finished)
+    }
 }
 
 impl Drop for ServeRuntime {
@@ -2767,32 +2782,36 @@ pub fn start_serve_runtime(db_path: String) -> Result<ServeRuntime, VaultSyncErr
     start_full_runtime(conn, db_path, session_id)
 }
 
-/// Boots the long-running daemon runtime: registers a `daemon`
-/// session (refusing if another live `daemon` already exists),
-/// publishes the IPC socket, runs the startup recovery sequence, and
-/// spawns watcher and extraction threads. The daemon is the canonical
-/// runtime owner; subsequent `quaid serve` invocations against the
-/// same database will see this `daemon` row and stay transport-only
-/// per [`start_serve_runtime`].
+/// Boots the long-running daemon runtime: claims the unique `daemon`
+/// session slot via [`try_claim_daemon_session`] (a single
+/// `BEGIN IMMEDIATE` transaction that sweeps stale rows, reaps a
+/// same-host `daemon` row whose pid is provably dead — the
+/// fresh-heartbeat leftover of a SIGKILLed daemon — and refuses when a
+/// live `daemon` remains), publishes the IPC socket, runs the startup
+/// recovery sequence, and spawns watcher and extraction threads. The
+/// daemon is the canonical runtime owner; subsequent `quaid serve`
+/// invocations against the same database will see this `daemon` row
+/// and stay transport-only per [`start_serve_runtime`].
 pub fn start_daemon_runtime(db_path: String) -> Result<ServeRuntime, VaultSyncError> {
     init_process_registries()?;
     let conn = db::open_runtime(&db_path)?;
-    sweep_stale_sessions(&conn)?;
 
-    if let Some(existing) = find_active_daemon_session(&conn)? {
-        return Err(VaultSyncError::InvariantViolation {
-            message: format!(
-                "DaemonAlreadyRunningError: another daemon is already running for this database \
-                 (pid={pid} host={host} session_id={sid}). Stop it first via `quaid daemon stop` \
-                 (or `kill {pid}` if it isn't installed as a service) and retry.",
-                pid = existing.pid,
-                host = existing.host,
-                sid = existing.session_id
-            ),
-        });
-    }
+    let session_id = match try_claim_daemon_session(&conn)? {
+        DaemonSessionClaim::Claimed(session_id) => session_id,
+        DaemonSessionClaim::AlreadyRunning(existing) => {
+            return Err(VaultSyncError::InvariantViolation {
+                message: format!(
+                    "DaemonAlreadyRunningError: another daemon is already running for this database \
+                     (pid={pid} host={host} session_id={sid}). Stop it first via `quaid daemon stop` \
+                     (or `kill {pid}` if it isn't installed as a service) and retry.",
+                    pid = existing.pid,
+                    host = existing.host,
+                    sid = existing.session_id
+                ),
+            });
+        }
+    };
 
-    let session_id = register_session(&conn, SessionType::Daemon)?;
     start_full_runtime(conn, db_path, session_id)
 }
 
@@ -2927,7 +2946,12 @@ fn run_supervisor_loop(
         Instant::now() - Duration::from_secs(RAW_IMPORT_TTL_SWEEP_INTERVAL_SECS);
     let mut last_embedding_drain =
         Instant::now() - Duration::from_secs(embedding::drain_interval_secs());
+    let test_exit_deadline = supervisor_test_exit_deadline();
     while !stop_signal.load(Ordering::SeqCst) {
+        if test_exit_deadline.is_some_and(|deadline| Instant::now() >= deadline) {
+            eprintln!("WARN: supervisor_test_exit session_id={session_id_for_thread}");
+            return;
+        }
         maybe_hold_supervisor_tick_for_tests(&stop_signal);
         if let Ok(conn) = db::open_runtime(&db_path) {
             if last_idle_close_sweep.elapsed()
@@ -3122,6 +3146,20 @@ fn maybe_hold_supervisor_tick_for_tests(stop: &AtomicBool) {
     while Instant::now() < deadline && !stop.load(Ordering::SeqCst) {
         thread::sleep(Duration::from_millis(25));
     }
+}
+
+/// Test-only injection point (companion to
+/// [`maybe_hold_supervisor_tick_for_tests`]): when
+/// `QUAID_TEST_SUPERVISOR_EXIT_AFTER_MS` is set, the supervisor thread
+/// returns abruptly that many milliseconds after starting — without
+/// joining the heartbeat thread or unregistering the session, exactly
+/// the shape of a crashed supervisor — so integration tests can prove
+/// the daemon foreground notices the dead supervisor and exits
+/// non-zero for the service manager to restart.
+fn supervisor_test_exit_deadline() -> Option<Instant> {
+    let raw_ms = std::env::var_os("QUAID_TEST_SUPERVISOR_EXIT_AFTER_MS")?;
+    let exit_ms = raw_ms.to_string_lossy().parse::<u64>().ok()?;
+    Some(Instant::now() + Duration::from_millis(exit_ms))
 }
 
 /// CLI entry point that attaches a fresh, empty vault directory to a

--- a/src/core/vault_sync/session.rs
+++ b/src/core/vault_sync/session.rs
@@ -266,20 +266,103 @@ fn try_promote_inner(conn: &Connection, session_id: &str) -> Result<bool, VaultS
     Ok(true)
 }
 
+/// Outcome of [`try_claim_daemon_session`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DaemonSessionClaim {
+    /// The caller now owns the unique `daemon` slot; carries the
+    /// freshly registered `session_id`.
+    Claimed(String),
+    /// A live `daemon` already owns the slot; carries its snapshot so
+    /// the caller can report pid/host in its refusal message.
+    AlreadyRunning(ActiveSessionInfo),
+}
+
+/// Atomically claims the unique `daemon` session slot for this process.
+///
+/// Runs inside a single `BEGIN IMMEDIATE` transaction (mirroring
+/// [`try_promote_to_serve_host`]) that (a) sweeps stale rows via the
+/// pid-aware [`sweep_stale_sessions`], (b) probes any remaining
+/// heartbeat-live `daemon` row — a same-host row whose pid fails the
+/// kill-0 probe is the leftover of a SIGKILLed daemon and is deleted
+/// (together with its lease rows) so the service manager's replacement
+/// can start immediately instead of crash-looping until the row ages
+/// past `SESSION_LIVENESS_SECS` — and (c) registers the caller's
+/// `daemon` row when no live owner remains. The `BEGIN IMMEDIATE`
+/// closes the sweep→probe→register TOCTOU window between two
+/// concurrent daemon starts: exactly one claims, the other observes
+/// the winner's freshly inserted row.
+///
+/// Foreign-host rows are never pid-probed (liveness cannot be checked
+/// across hosts) and keep the pure heartbeat-window behaviour, as do
+/// all rows on platforms without a kill-0 probe.
+pub fn try_claim_daemon_session(conn: &Connection) -> Result<DaemonSessionClaim, VaultSyncError> {
+    conn.execute_batch("BEGIN IMMEDIATE TRANSACTION")?;
+
+    let result = try_claim_daemon_inner(conn);
+
+    match &result {
+        Ok(_) => {
+            if let Err(commit_err) = conn.execute_batch("COMMIT TRANSACTION") {
+                let _ = conn.execute_batch("ROLLBACK TRANSACTION");
+                return Err(VaultSyncError::from(commit_err));
+            }
+        }
+        Err(_) => {
+            let _ = conn.execute_batch("ROLLBACK TRANSACTION");
+        }
+    }
+
+    result
+}
+
+fn try_claim_daemon_inner(conn: &Connection) -> Result<DaemonSessionClaim, VaultSyncError> {
+    sweep_stale_sessions(conn)?;
+
+    if let Some(existing) = find_active_daemon_session(conn)? {
+        if existing.host == current_host() && pid_known_dead(existing.pid) {
+            // Fresh heartbeat but provably dead process: the row a
+            // SIGKILLed daemon leaves behind. Reap it here so the
+            // replacement start succeeds now rather than after the
+            // remainder of the liveness window.
+            eprintln!(
+                "WARN: daemon_session_reaped_dead_pid session_id={} pid={} host={}",
+                existing.session_id, existing.pid, existing.host
+            );
+            delete_session_rows(conn, &existing.session_id)?;
+        } else {
+            return Ok(DaemonSessionClaim::AlreadyRunning(existing));
+        }
+    }
+
+    let session_id = register_session(conn, SessionType::Daemon)?;
+    Ok(DaemonSessionClaim::Claimed(session_id))
+}
+
 /// Atomically removes a session and any owner / lease rows that
 /// referenced it so the session table and the lease columns on
 /// `collections` never drift out of sync.
 pub fn unregister_session(conn: &Connection, session_id: &str) -> Result<(), VaultSyncError> {
     let tx = conn.unchecked_transaction()?;
-    tx.execute(
+    delete_session_rows(&tx, session_id)?;
+    tx.commit()?;
+    Ok(())
+}
+
+/// Deletes a session row together with the owner-lease rows that
+/// reference it. Statement bundle shared by [`unregister_session`]
+/// (which wraps it in its own transaction) and the dead-daemon reap
+/// inside [`try_claim_daemon_session`] (already inside its
+/// `BEGIN IMMEDIATE` transaction).
+fn delete_session_rows(conn: &Connection, session_id: &str) -> Result<(), VaultSyncError> {
+    conn.execute(
         "DELETE FROM collection_owners WHERE session_id = ?1",
         [session_id],
     )?;
-    tx.execute(
+    conn.execute(
         "DELETE FROM serve_sessions WHERE session_id = ?1",
         [session_id],
     )?;
-    tx.execute(
+    conn.execute(
         "UPDATE collections
          SET active_lease_session_id = CASE
                  WHEN active_lease_session_id = ?1 THEN NULL
@@ -293,7 +376,6 @@ pub fn unregister_session(conn: &Connection, session_id: &str) -> Result<(), Vau
          WHERE active_lease_session_id = ?1 OR restore_lease_session_id = ?1",
         [session_id],
     )?;
-    tx.commit()?;
     Ok(())
 }
 
@@ -381,5 +463,22 @@ fn pid_is_alive(pid: i64) -> bool {
 /// behaviour applies to every row.
 #[cfg(not(unix))]
 fn pid_is_alive(_pid: i64) -> bool {
+    false
+}
+
+/// Positive evidence of death, required before the dead-daemon reap in
+/// [`try_claim_daemon_session`] may delete a fresh-heartbeat row: on
+/// Unix the inverse of the kill-0 probe; elsewhere always `false` so a
+/// possibly-live daemon's row is never reaped without proof (unlike the
+/// sweep, which only handles rows that are already stale by time).
+#[cfg(unix)]
+fn pid_known_dead(pid: i64) -> bool {
+    !pid_is_alive(pid)
+}
+
+/// Non-Unix fallback for [`pid_known_dead`]: liveness cannot be probed,
+/// so death is never assumed.
+#[cfg(not(unix))]
+fn pid_known_dead(_pid: i64) -> bool {
     false
 }

--- a/src/platform/launchd.rs
+++ b/src/platform/launchd.rs
@@ -7,7 +7,7 @@
 //! without relying on `os_log` subsystem registration.
 
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use super::{argv, home_dir, PlatformError, UnitArgs, UnitStatus, DAEMON_LABEL};
@@ -127,20 +127,7 @@ pub fn install(args: &UnitArgs) -> Result<(), PlatformError> {
 
     fs::write(&path, plist_text)?;
 
-    let domain = format!("gui/{}", current_uid());
-    let output = Command::new("launchctl")
-        .arg("bootstrap")
-        .arg(&domain)
-        .arg(&path)
-        .output()?;
-    if !output.status.success() {
-        return Err(PlatformError::CommandFailed {
-            command: format!("launchctl bootstrap {} {}", domain, path.display()),
-            status: output.status.code().unwrap_or(-1),
-            stderr: truncate_stderr(&output.stderr),
-        });
-    }
-    Ok(())
+    launchctl_bootstrap(&path)
 }
 
 /// `launchctl bootout` and delete the plist file. Idempotent: returns
@@ -175,9 +162,30 @@ fn launchctl_bootout() -> Result<(), PlatformError> {
     Ok(())
 }
 
-/// `launchctl kickstart -k <gui/uid/Label>`. Fails if the unit isn't
-/// installed (caller should check via [`status`] first).
-pub fn start() -> Result<(), PlatformError> {
+/// `launchctl bootstrap gui/<uid> <plist>` — loads the unit into the
+/// user's launchd domain. Shared by [`install`] (fresh plist) and the
+/// not-loaded branch of [`start`] (re-load after `stop`'s bootout).
+fn launchctl_bootstrap(plist: &Path) -> Result<(), PlatformError> {
+    let domain = format!("gui/{}", current_uid());
+    let output = Command::new("launchctl")
+        .arg("bootstrap")
+        .arg(&domain)
+        .arg(plist)
+        .output()?;
+    if !output.status.success() {
+        return Err(PlatformError::CommandFailed {
+            command: format!("launchctl bootstrap {} {}", domain, plist.display()),
+            status: output.status.code().unwrap_or(-1),
+            stderr: truncate_stderr(&output.stderr),
+        });
+    }
+    Ok(())
+}
+
+/// `launchctl kickstart -k <gui/uid/Label>` — (re)starts a unit that is
+/// already loaded in the domain. Errors on an unloaded unit, which is
+/// why [`start`] probes load state first.
+fn launchctl_kickstart() -> Result<(), PlatformError> {
     let domain = format!("gui/{}", current_uid());
     let target = format!("{}/{}", domain, DAEMON_LABEL);
     let output = Command::new("launchctl")
@@ -193,6 +201,34 @@ pub fn start() -> Result<(), PlatformError> {
         });
     }
     Ok(())
+}
+
+/// Probes whether the unit is loaded in the `gui/<uid>` domain by
+/// branching on the exit status of `launchctl print gui/<uid>/<label>`
+/// (0 iff loaded). Exit-status branching, not error-string parsing:
+/// launchctl's messages vary across macOS versions but the probe's
+/// exit status does not.
+fn service_is_loaded() -> Result<bool, PlatformError> {
+    let target = format!("gui/{}/{}", current_uid(), DAEMON_LABEL);
+    let output = Command::new("launchctl")
+        .arg("print")
+        .arg(&target)
+        .output()?;
+    Ok(output.status.success())
+}
+
+/// Start the daemon, state-aware: when the unit is already loaded,
+/// `launchctl kickstart -k` (re)starts it; when it is not loaded — the
+/// state [`stop`]'s `bootout` leaves behind — `launchctl bootstrap` the
+/// on-disk plist instead. `kickstart` errors with "Could not find
+/// service" on an unloaded unit, which is exactly why the old
+/// kickstart-only `start` failed after every `stop` and made
+/// `daemon restart` (stop + start) fail unconditionally on macOS.
+pub fn start() -> Result<(), PlatformError> {
+    if service_is_loaded()? {
+        return launchctl_kickstart();
+    }
+    launchctl_bootstrap(&plist_path()?)
 }
 
 /// Stop the daemon via `launchctl bootout`. Returns `Ok(())` even if the

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -9,11 +9,13 @@
 //! documented "manual setup" message.
 //!
 //! Module layout:
-//! - `launchd` (macOS only) — plist generator, `launchctl` wrappers
+//! - `launchd` (macOS at runtime; compiled on all Unix so the
+//!   `launchctl` state machine stays covered by PATH-stubbed
+//!   integration tests on Linux CI) — plist generator, `launchctl` wrappers
 //! - `systemd` (Linux only) — unit generator, `systemctl --user` wrappers
 //! - [`UnitArgs`] — the shared argument shape both generators consume
 
-#[cfg(target_os = "macos")]
+#[cfg(unix)]
 pub mod launchd;
 #[cfg(target_os = "linux")]
 pub mod systemd;

--- a/tests/daemon_lifecycle_cli.rs
+++ b/tests/daemon_lifecycle_cli.rs
@@ -18,11 +18,53 @@ use std::process::{Command, Output};
 use quaid::core::db;
 use serde_json::Value;
 
+/// Stateful fake `launchctl`: `bootstrap` marks the unit loaded,
+/// `bootout` marks it unloaded (failing when it already is, like real
+/// launchd), `kickstart -k` fails on an unloaded unit, and `print`'s
+/// exit status reports load state. This is the contract that made the
+/// old kickstart-only `start()` fail after every `stop` — an
+/// unconditional `exit 0` stub could never catch that verb mismatch.
+#[cfg(target_os = "macos")]
+const STATEFUL_LAUNCHCTL_STUB: &str = r#"#!/bin/sh
+printf 'launchctl:%s\n' "$*" >> "$FAKE_PLATFORM_LOG"
+state() { cat "$FAKE_LAUNCHCTL_STATE" 2>/dev/null || echo unloaded; }
+case "$1" in
+  print)
+    [ "$(state)" = "loaded" ] && exit 0
+    echo "Could not find service \"app.quaid.daemon\" in domain for user gui" >&2
+    exit 113
+    ;;
+  bootstrap)
+    if [ "$(state)" = "loaded" ]; then
+      echo "Bootstrap failed: 17: File exists" >&2
+      exit 17
+    fi
+    echo loaded > "$FAKE_LAUNCHCTL_STATE"
+    exit 0
+    ;;
+  bootout)
+    if [ "$(state)" = "loaded" ]; then
+      echo unloaded > "$FAKE_LAUNCHCTL_STATE"
+      exit 0
+    fi
+    echo "Boot-out failed: 3: No such process" >&2
+    exit 3
+    ;;
+  kickstart)
+    [ "$(state)" = "loaded" ] && exit 0
+    echo "Could not find service \"app.quaid.daemon\" in domain for user gui" >&2
+    exit 113
+    ;;
+esac
+exit 0
+"#;
+
 struct FakePlatform {
     _dir: tempfile::TempDir,
     home_dir: PathBuf,
     path_env: OsString,
     log_path: PathBuf,
+    state_path: PathBuf,
 }
 
 impl FakePlatform {
@@ -34,11 +76,9 @@ impl FakePlatform {
         fs::create_dir_all(&bin_dir).unwrap();
 
         let log_path = dir.path().join("platform.log");
+        let state_path = dir.path().join("launchctl.state");
         #[cfg(target_os = "macos")]
-        write_fake_command(
-            &bin_dir.join("launchctl"),
-            "#!/bin/sh\nprintf 'launchctl:%s\\n' \"$*\" >> \"$FAKE_PLATFORM_LOG\"\nexit 0\n",
-        );
+        write_fake_command(&bin_dir.join("launchctl"), STATEFUL_LAUNCHCTL_STUB);
         #[cfg(target_os = "linux")]
         {
             write_fake_command(
@@ -61,6 +101,7 @@ impl FakePlatform {
             home_dir,
             path_env,
             log_path,
+            state_path,
         }
     }
 
@@ -72,6 +113,7 @@ impl FakePlatform {
             .env("USERPROFILE", &self.home_dir)
             .env("PATH", &self.path_env)
             .env("FAKE_PLATFORM_LOG", &self.log_path)
+            .env("FAKE_LAUNCHCTL_STATE", &self.state_path)
             .arg("--db")
             .arg(db_path)
             .args(args);
@@ -216,7 +258,23 @@ fn daemon_start_stop_restart_and_logs_dispatch_to_platform() {
     let log = platform.log();
     #[cfg(target_os = "macos")]
     {
-        assert!(log.contains("launchctl:kickstart -k"));
+        // install loaded the unit (bootstrap #1); `start` saw it loaded
+        // (print) and kickstarted; `stop` booted it out; `restart` =
+        // stop (bootout on an unloaded unit fails and is ignored) +
+        // start, which saw the unit unloaded and bootstrapped again
+        // (#2). The pre-fix kickstart-only start fails that last arm
+        // against this stateful stub, which is the macOS restart bug.
+        assert!(log.contains("launchctl:print"));
+        assert_eq!(
+            log.matches("launchctl:kickstart -k").count(),
+            1,
+            "only the loaded-state start may kickstart"
+        );
+        assert_eq!(
+            log.matches("launchctl:bootstrap").count(),
+            2,
+            "install and the restart-after-stop start must both bootstrap"
+        );
         assert!(log.contains("launchctl:bootout"));
     }
     #[cfg(target_os = "linux")]

--- a/tests/daemon_supervisor_death.rs
+++ b/tests/daemon_supervisor_death.rs
@@ -1,0 +1,89 @@
+#![cfg(unix)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    reason = "integration tests panic on setup failure"
+)]
+
+//! Supervisor-death detection in the daemon foreground task.
+//!
+//! `quaid daemon run` must not keep running as a zombie when the
+//! supervisor thread dies: watchers, heartbeats, and extraction have
+//! silently stopped, yet launchd/systemd would still report the unit
+//! healthy. The foreground task polls `JoinHandle::is_finished()` and
+//! exits with code 1 so `KeepAlive` / `Restart=on-failure` restarts
+//! the unit. The supervisor's death is injected via the
+//! `QUAID_TEST_SUPERVISOR_EXIT_AFTER_MS` seam, which makes the
+//! supervisor thread return abruptly (no heartbeat join, no session
+//! cleanup — the shape of a crash).
+
+mod common;
+#[path = "common/subprocess.rs"]
+mod common_subprocess;
+
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+fn init_db(dir: &tempfile::TempDir) -> std::path::PathBuf {
+    let db_path = dir.path().join("memory.db");
+    let init = Command::new(common::quaid_bin())
+        .arg("init")
+        .arg(&db_path)
+        .output()
+        .unwrap();
+    assert!(
+        init.status.success(),
+        "init failed: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+    db_path
+}
+
+#[test]
+fn daemon_run_exits_nonzero_when_supervisor_thread_dies() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = init_db(&dir);
+
+    let mut command = Command::new(common::quaid_bin());
+    common_subprocess::configure_test_command(&mut command);
+    let mut child = command
+        .arg("--db")
+        .arg(&db_path)
+        .args(["daemon", "run"])
+        .env("QUAID_TEST_SUPERVISOR_EXIT_AFTER_MS", "300")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    // Without the death watch the foreground awaits signals forever, so
+    // bound the wait and fail loudly instead of hanging the suite.
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while child.try_wait().unwrap().is_none() {
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("daemon did not exit after its supervisor thread died");
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+
+    let output = child.wait_with_output().unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "supervisor death must exit 1 for Restart=on-failure/KeepAlive; stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("supervisor_test_exit"),
+        "test seam must have fired; stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("daemon_supervisor_exited_unexpectedly"),
+        "foreground must log the supervisor death; stderr: {stderr}"
+    );
+}

--- a/tests/launchd_state_aware.rs
+++ b/tests/launchd_state_aware.rs
@@ -1,0 +1,177 @@
+#![cfg(unix)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    reason = "integration tests panic on setup failure"
+)]
+
+//! State-aware launchd lifecycle driven through a *stateful*
+//! PATH-stubbed `launchctl` (`bootstrap` loads, `bootout` unloads and
+//! fails when already unloaded, `kickstart -k` fails when unloaded,
+//! `print`'s exit status reports load state — the same contract as
+//! real launchd). Runs on Linux CI because `src/platform/launchd.rs`
+//! is compiled on all Unix targets for exactly this purpose.
+//!
+//! Regression background (review §18): `stop()` boots the unit out,
+//! but the old `start()` ran `kickstart -k` unconditionally, which
+//! errors on an unloaded unit — so on macOS every `stop → start` and
+//! `daemon restart` (stop + start) failed. `start()` must probe load
+//! state via `launchctl print`'s exit status and `bootstrap` the
+//! on-disk plist when the unit is not loaded.
+
+#[path = "common/vault_sync_fixtures.rs"]
+mod fixtures;
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use quaid::platform::{launchd, UnitArgs, UnitStatus};
+
+/// Mirrors real launchctl semantics keyed off a state file:
+/// loaded/unloaded transitions plus per-verb failure modes.
+const STATEFUL_LAUNCHCTL_STUB: &str = r#"#!/bin/sh
+printf 'launchctl:%s\n' "$*" >> "$FAKE_PLATFORM_LOG"
+state() { cat "$FAKE_LAUNCHCTL_STATE" 2>/dev/null || echo unloaded; }
+case "$1" in
+  print)
+    [ "$(state)" = "loaded" ] && exit 0
+    echo "Could not find service \"app.quaid.daemon\" in domain for user gui" >&2
+    exit 113
+    ;;
+  bootstrap)
+    if [ "$(state)" = "loaded" ]; then
+      echo "Bootstrap failed: 17: File exists" >&2
+      exit 17
+    fi
+    echo loaded > "$FAKE_LAUNCHCTL_STATE"
+    exit 0
+    ;;
+  bootout)
+    if [ "$(state)" = "loaded" ]; then
+      echo unloaded > "$FAKE_LAUNCHCTL_STATE"
+      exit 0
+    fi
+    echo "Boot-out failed: 3: No such process" >&2
+    exit 3
+    ;;
+  kickstart)
+    [ "$(state)" = "loaded" ] && exit 0
+    echo "Could not find service \"app.quaid.daemon\" in domain for user gui" >&2
+    exit 113
+    ;;
+esac
+exit 0
+"#;
+
+fn write_stub(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::write(path, STATEFUL_LAUNCHCTL_STUB).unwrap();
+    let mut permissions = fs::metadata(path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).unwrap();
+}
+
+#[test]
+fn launchd_start_is_state_aware_across_stop_and_restart() {
+    let _lock = fixtures::env_mutation_lock().lock().unwrap();
+
+    let dir = tempfile::TempDir::new().unwrap();
+    let home = dir.path().join("home");
+    let bin = dir.path().join("bin");
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(&bin).unwrap();
+    write_stub(&bin.join("launchctl"));
+
+    let log_path = dir.path().join("platform.log");
+    let state_path = dir.path().join("launchctl.state");
+
+    let path_value = format!(
+        "{}:{}",
+        bin.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    let _path = fixtures::EnvVarGuard::set("PATH", &path_value);
+    let _home = fixtures::EnvVarGuard::set("HOME", home.to_str().unwrap());
+    let _log = fixtures::EnvVarGuard::set("FAKE_PLATFORM_LOG", log_path.to_str().unwrap());
+    let _state = fixtures::EnvVarGuard::set("FAKE_LAUNCHCTL_STATE", state_path.to_str().unwrap());
+
+    let read_state = || {
+        fs::read_to_string(&state_path)
+            .map(|s| s.trim().to_string())
+            .unwrap_or_else(|_| "unloaded".to_string())
+    };
+    let read_log = || fs::read_to_string(&log_path).unwrap_or_default();
+
+    // The old verb mix is invalid under a faithful launchctl state
+    // machine: `kickstart -k` on an unloaded service fails — this is
+    // what the pre-fix `start()` ran unconditionally after `stop`'s
+    // bootout, breaking every macOS stop→start and restart.
+    let kickstart_unloaded = Command::new("launchctl")
+        .args(["kickstart", "-k", "gui/501/app.quaid.daemon"])
+        // Separate log so the sanity probe doesn't skew the verb counts
+        // asserted against the production-code invocations below.
+        .env("FAKE_PLATFORM_LOG", dir.path().join("sanity.log"))
+        .output()
+        .unwrap();
+    assert!(
+        !kickstart_unloaded.status.success(),
+        "stub sanity: kickstart on an unloaded service must fail"
+    );
+
+    let args = UnitArgs {
+        binary_path: "/usr/local/bin/quaid".into(),
+        db_path: home.join("memory.db"),
+        http: None,
+    };
+
+    // install: writes the plist and bootstraps the unit (loaded).
+    launchd::install(&args).unwrap();
+    assert_eq!(read_state(), "loaded");
+    assert!(matches!(launchd::status().unwrap(), UnitStatus::Running));
+
+    // start while loaded → print probe + kickstart, no second bootstrap.
+    launchd::start().unwrap();
+    let log = read_log();
+    assert_eq!(log.matches("launchctl:kickstart -k").count(), 1);
+    assert_eq!(log.matches("launchctl:bootstrap").count(), 1);
+
+    // stop boots the unit out; the plist stays on disk for later starts.
+    launchd::stop().unwrap();
+    assert_eq!(read_state(), "unloaded");
+    assert!(matches!(
+        launchd::status().unwrap(),
+        UnitStatus::InstalledStopped
+    ));
+
+    // start after stop must probe-and-bootstrap; the old kickstart-only
+    // start fails exactly here (proven by the stub sanity check above).
+    launchd::start().unwrap();
+    assert_eq!(read_state(), "loaded");
+    let log = read_log();
+    assert_eq!(
+        log.matches("launchctl:bootstrap").count(),
+        2,
+        "start on an unloaded unit must bootstrap the on-disk plist"
+    );
+    assert_eq!(
+        log.matches("launchctl:kickstart -k").count(),
+        1,
+        "the unloaded branch must not attempt kickstart"
+    );
+
+    // The stop + start chain `quaid daemon restart` issues end-to-end:
+    // bootout (unloads) then state-aware start (bootstraps again).
+    launchd::stop().unwrap();
+    launchd::start().unwrap();
+    assert_eq!(read_state(), "loaded");
+    assert!(matches!(launchd::status().unwrap(), UnitStatus::Running));
+    let log = read_log();
+    assert_eq!(log.matches("launchctl:bootstrap").count(), 3);
+    assert!(
+        log.matches("launchctl:print").count() >= 3,
+        "every start and status call must probe load state via print"
+    );
+}

--- a/tests/vault_sync_session_types.rs
+++ b/tests/vault_sync_session_types.rs
@@ -28,9 +28,10 @@ use std::thread;
 use rusqlite::params;
 
 use quaid::core::vault_sync::{
-    find_active_daemon_session, find_active_runtime_host, heartbeat_session, register_cli_session,
-    register_session, start_daemon_runtime, start_serve_runtime, sweep_stale_sessions,
-    try_promote_to_serve_host, SessionType,
+    current_host, find_active_daemon_session, find_active_runtime_host, heartbeat_session,
+    register_cli_session, register_session, start_daemon_runtime, start_serve_runtime,
+    sweep_stale_sessions, try_claim_daemon_session, try_promote_to_serve_host, DaemonSessionClaim,
+    SessionType,
 };
 
 #[test]
@@ -452,6 +453,190 @@ fn start_serve_runtime_returns_transport_only_when_daemon_is_live() {
         .unwrap();
     assert_eq!(remaining_transport_rows, 0);
     assert_eq!(daemon_rows, 1);
+}
+
+/// A `daemon` row with a *fresh* heartbeat but a provably dead pid on
+/// this host is what a SIGKILLed daemon leaves behind. The claim must
+/// reap it and register the caller — otherwise the service manager's
+/// replacement crash-loops until the row ages past the 15s liveness
+/// window.
+#[cfg(unix)]
+#[test]
+fn try_claim_daemon_session_reaps_dead_pid_row_with_fresh_heartbeat() {
+    let conn = open_test_db();
+
+    let mut child = std::process::Command::new("true").spawn().unwrap();
+    let dead_pid = i64::from(child.id());
+    child.wait().unwrap();
+
+    conn.execute(
+        "INSERT INTO serve_sessions (session_id, pid, host, session_type, heartbeat_at)
+         VALUES ('dead-daemon', ?1, ?2, 'daemon', strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))",
+        params![dead_pid, current_host()],
+    )
+    .unwrap();
+
+    let session_id = match try_claim_daemon_session(&conn).unwrap() {
+        DaemonSessionClaim::Claimed(session_id) => session_id,
+        DaemonSessionClaim::AlreadyRunning(info) => {
+            panic!("dead-pid fresh-heartbeat row must be reaped, got AlreadyRunning({info:?})")
+        }
+    };
+
+    let dead_remaining: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM serve_sessions WHERE session_id = 'dead-daemon'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(dead_remaining, 0, "dead daemon's row must be deleted");
+
+    let daemon_rows: Vec<String> = conn
+        .prepare("SELECT session_id FROM serve_sessions WHERE session_type = 'daemon'")
+        .unwrap()
+        .query_map([], |row| row.get(0))
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+    assert_eq!(daemon_rows, vec![session_id]);
+}
+
+/// Rows the claim must *not* reap: a foreign-host row (pid liveness
+/// cannot be probed across hosts) and a live local pid. Both refuse
+/// the claim with the existing row's snapshot.
+#[test]
+fn try_claim_daemon_session_respects_foreign_host_and_live_local_rows() {
+    let conn = open_test_db();
+
+    conn.execute(
+        "INSERT INTO serve_sessions (session_id, pid, host, session_type, heartbeat_at)
+         VALUES ('foreign-daemon', 1, 'definitely-not-this-host', 'daemon',
+                 strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))",
+        [],
+    )
+    .unwrap();
+    match try_claim_daemon_session(&conn).unwrap() {
+        DaemonSessionClaim::AlreadyRunning(info) => {
+            assert_eq!(info.session_id, "foreign-daemon");
+        }
+        DaemonSessionClaim::Claimed(id) => {
+            panic!("foreign-host fresh-heartbeat row must refuse the claim, got Claimed({id})")
+        }
+    }
+    conn.execute(
+        "DELETE FROM serve_sessions WHERE session_id = 'foreign-daemon'",
+        [],
+    )
+    .unwrap();
+
+    conn.execute(
+        "INSERT INTO serve_sessions (session_id, pid, host, session_type, heartbeat_at)
+         VALUES ('live-local', ?1, ?2, 'daemon', strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))",
+        params![i64::from(std::process::id()), current_host()],
+    )
+    .unwrap();
+    match try_claim_daemon_session(&conn).unwrap() {
+        DaemonSessionClaim::AlreadyRunning(info) => {
+            assert_eq!(info.session_id, "live-local");
+        }
+        DaemonSessionClaim::Claimed(id) => {
+            panic!("live local pid must refuse the claim, got Claimed({id})")
+        }
+    }
+}
+
+/// Full-path version of the dead-pid reap: `start_daemon_runtime`
+/// against a database whose `daemon` row points at a dead local pid
+/// with a fresh heartbeat must boot immediately instead of erroring
+/// with DaemonAlreadyRunningError for up to 15s.
+#[cfg(unix)]
+#[test]
+fn start_daemon_runtime_reaps_dead_pid_daemon_row_and_starts() {
+    let (_dir, db_path, conn) = fixtures::open_test_db_file();
+
+    let mut child = std::process::Command::new("true").spawn().unwrap();
+    let dead_pid = i64::from(child.id());
+    child.wait().unwrap();
+
+    conn.execute(
+        "INSERT INTO serve_sessions (session_id, pid, host, session_type, heartbeat_at)
+         VALUES ('sigkilled-daemon', ?1, ?2, 'daemon', strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))",
+        params![dead_pid, current_host()],
+    )
+    .unwrap();
+    drop(conn);
+
+    let runtime = start_daemon_runtime(db_path.clone()).unwrap();
+
+    let conn = quaid::core::db::open(&db_path).unwrap();
+    let dead_remaining: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM serve_sessions WHERE session_id = 'sigkilled-daemon'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(dead_remaining, 0);
+    let daemon_session: String = conn
+        .query_row(
+            "SELECT session_id FROM serve_sessions WHERE session_type = 'daemon'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(daemon_session, runtime.session_id);
+    drop(conn);
+
+    drop(runtime);
+}
+
+/// Two concurrent daemon starts against the same database must elect
+/// exactly one winner: the claim's `BEGIN IMMEDIATE` closes the old
+/// sweep→find→register TOCTOU where both could observe "no live
+/// daemon" and both register.
+#[test]
+fn start_daemon_runtime_concurrent_starts_elect_exactly_one_winner() {
+    let (_dir, db_path, conn) = fixtures::open_test_db_file();
+    drop(conn);
+
+    let barrier = Arc::new(Barrier::new(2));
+    let spawn_start = |path: String, barrier: Arc<Barrier>| {
+        thread::spawn(move || {
+            barrier.wait();
+            start_daemon_runtime(path)
+        })
+    };
+    let t1 = spawn_start(db_path.clone(), Arc::clone(&barrier));
+    let t2 = spawn_start(db_path.clone(), Arc::clone(&barrier));
+
+    let results = [t1.join().unwrap(), t2.join().unwrap()];
+    assert_eq!(
+        results.iter().filter(|result| result.is_ok()).count(),
+        1,
+        "exactly one concurrent daemon start may win"
+    );
+    for result in &results {
+        if let Err(error) = result {
+            assert!(
+                error.to_string().contains("DaemonAlreadyRunningError"),
+                "loser must observe the winner's row, got: {error}"
+            );
+        }
+    }
+
+    let conn = quaid::core::db::open(&db_path).unwrap();
+    let daemon_rows: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM serve_sessions WHERE session_type = 'daemon'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(daemon_rows, 1);
+    drop(conn);
+
+    drop(results);
 }
 
 #[test]


### PR DESCRIPTION
**Stacked on #234** (`fable/w2b-vault-robustness`) — builds on its pid-liveness primitives; auto-retargets as the stack merges. Implements **Area 18 — daemon lifecycle** (all 4 plan steps).

## Changes
- **launchd verb mismatch fixed**: `stop` unloads via `bootout`, but `start` used `kickstart -k` which requires a *loaded* service — so stop→start and every `daemon restart` failed unconditionally on macOS. `start()` now probes `launchctl print` and branches: `bootstrap` when unloaded, `kickstart -k` when loaded (exit-status branching, no error-string parsing). The module gate widened to `cfg(unix)` so the state machine is exercised by Linux CI through a stateful PATH-stubbed `launchctl`.
- **Instant SIGKILL recovery**: new transactional `try_claim_daemon_session` (BEGIN IMMEDIATE, mirroring `try_promote_to_serve_host`) wraps sweep→probe→register; a same-host daemon row whose pid fails the kill-0 probe is deleted even with a fresh heartbeat — the replacement starts immediately instead of crash-looping for up to 15s under KeepAlive/Restart=on-failure.
- **TOCTOU closed**: two concurrent `start_daemon_runtime` calls elect exactly one winner (test-pinned).
- **Zombie daemon detection**: `run_foreground` selects over the shutdown signal AND a 500ms `JoinHandle::is_finished()` poll; unexpected supervisor death exits 1 (logged) so the service manager actually restarts it. Death injectable via a `QUAID_TEST_SUPERVISOR_EXIT_AFTER_MS` seam (companion to the existing tick-hold seam).

## Validation
fmt/clippy/rustdoc gates clean. New `tests/launchd_state_aware.rs` proves the old verb mix fails on a stateful stub and the new stop→start/restart succeed; `daemon_lifecycle_cli.rs` stub made stateful with verb-count assertions; session-claim tests cover dead-pid reap + concurrent single-winner; supervisor-death exit-1 test via the new seam. Real launchd untestable in this container — noted; the stub mirrors documented launchctl semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)