### PR TITLE
test: behavioral conversions, cross-process OCC, proptests, SIGKILL recovery, weekly real-model (area 23)

### DIFF
--- a/.github/workflows/weekly-real-model.yml
+++ b/.github/workflows/weekly-real-model.yml
@@ -1,0 +1,125 @@
+# Weekly, non-PR-gating smoke that exercises the REAL embedding models (no
+# QUAID_FORCE_HASH_SHIM) so the 768d/1024d vec-table code paths actually run,
+# plus a Windows `cargo check` so the non-Unix `#[cfg(not(unix))]` branches keep
+# compiling. Both jobs are intentionally scheduled-only (never block a PR);
+# see docs/fable-review.md §23.
+name: Weekly real-model + Windows check
+
+on:
+  schedule:
+    # 07:00 UTC every Monday.
+    - cron: "0 7 * * 1"
+  # Allow maintainers to trigger it on demand without waiting for the cron.
+  workflow_dispatch:
+
+# Never let two scheduled runs overlap; the latest wins.
+concurrency:
+  group: weekly-real-model
+  cancel-in-progress: true
+
+jobs:
+  real-model-smoke:
+    name: Real-model embed+search (${{ matrix.alias }} / ${{ matrix.dim }}d)
+    runs-on: ubuntu-latest
+    # Non-blocking: a HuggingFace outage must not page anyone.
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - alias: small
+            dim: 384
+          - alias: base
+            dim: 768
+          - alias: large
+            dim: 1024
+          - alias: m3
+            dim: 1024
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo + model artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.cache/huggingface
+            ~/.quaid/models
+            target
+          key: ${{ runner.os }}-weekly-real-model-${{ matrix.alias }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-weekly-real-model-${{ matrix.alias }}-
+
+      - name: Build online-model binary (no hash shim)
+        run: cargo build --locked --no-default-features --features bundled,online-model
+
+      - name: Real-model embed + search round-trip
+        # NOTE: QUAID_FORCE_HASH_SHIM is deliberately NOT set — this is the
+        # whole point of the weekly job: download and run the real BGE model so
+        # the per-dimension page_embeddings_vec_<dim> table is created and
+        # populated, which the PR-gating online-channel test lane (which forces
+        # the hash shim) never exercises.
+        env:
+          QUAID_MODEL: ${{ matrix.alias }}
+        run: |
+          set -euo pipefail
+          BIN="target/debug/quaid"
+          WORK="$(mktemp -d)"
+          DB="$WORK/memory.db"
+          VAULT="$WORK/vault"
+          mkdir -p "$VAULT"
+
+          "$BIN" --db "$DB" --model "${{ matrix.alias }}" init
+
+          # Route the default write-target at our scratch vault.
+          sqlite3 "$DB" "UPDATE collections SET root_path='$VAULT', writable=1, is_write_target=1, state='active' WHERE id=1;"
+
+          printf '%s\n' '---' 'title: Rust Engineer' 'type: person' '---' \
+            'Alice is a Rust engineer who builds SQLite-backed vector search with FTS5.' \
+            | "$BIN" --db "$DB" --model "${{ matrix.alias }}" put people/alice
+
+          "$BIN" --db "$DB" --model "${{ matrix.alias }}" embed --all
+
+          # The per-dimension vec table must exist AND hold at least one row.
+          VEC_ROWS="$(sqlite3 "$DB" "SELECT COUNT(*) FROM page_embeddings_vec_${{ matrix.dim }};")"
+          echo "page_embeddings_vec_${{ matrix.dim }} rows: $VEC_ROWS"
+          if [ "$VEC_ROWS" -lt 1 ]; then
+            echo "::error::expected at least one row in page_embeddings_vec_${{ matrix.dim }} for alias ${{ matrix.alias }}"
+            exit 1
+          fi
+
+          # Semantic search must return the seeded page via the real model.
+          OUT="$("$BIN" --db "$DB" --model "${{ matrix.alias }}" search 'who writes vector search in rust' --json)"
+          echo "$OUT"
+          echo "$OUT" | grep -q 'people/alice' \
+            || { echo "::error::real-model search did not return the seeded page for ${{ matrix.alias }}"; exit 1; }
+
+  windows-check:
+    name: Windows cargo check (x86_64-pc-windows-msvc)
+    # Cross-compile from Linux so the non-Unix branches keep compiling. This is
+    # `cargo check` only — no Windows runtime behaviour is asserted.
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust stable + Windows target
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-windows-check-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-windows-check-
+
+      - name: cargo check (windows target)
+        run: cargo check --locked --target x86_64-pc-windows-msvc --no-default-features --features bundled,online-model

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -193,6 +202,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -706,7 +721,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
 dependencies = [
- "bit-set",
+ "bit-set 0.5.3",
  "regex-automata",
  "regex-syntax",
 ]
@@ -2089,6 +2104,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
+ "bitflags 2.11.0",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "pulldown-cmark"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2149,6 +2183,7 @@ dependencies = [
  "ignore",
  "libc",
  "notify",
+ "proptest",
  "pulldown-cmark",
  "regex",
  "reqwest",
@@ -2169,6 +2204,12 @@ dependencies = [
  "tokio",
  "uuid",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
@@ -2313,6 +2354,15 @@ checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
  "rand 0.9.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2603,6 +2653,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -3283,6 +3345,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3385,6 +3453,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ rustix = { version = "0.38", features = ["fs", "process"] }
 filetime = "0.2"
 tempfile = "3"
 serial_test = "3"
+proptest = "1"
 
 [build-dependencies]
 reqwest = { version = "0.12", default-features = false, features = [

--- a/src/commands/ingest.rs
+++ b/src/commands/ingest.rs
@@ -297,7 +297,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "blocked on task 5.4d/5.4g: ingest write path does not rotate raw_imports yet"]
     fn ingest_force_reingest_keeps_exactly_one_active_raw_import_row_for_latest_bytes() {
         let conn = open_test_db();
         let dir = tempfile::TempDir::new().unwrap();

--- a/src/core/reconciler.rs
+++ b/src/core/reconciler.rs
@@ -1197,7 +1197,14 @@ fn uuid_migration_preflight(
     })
 }
 
+// The read-only-mount verifier is retained for its behavioural inline tests
+// (`verify_read_only_mount_rejects_writable_mounts` and the Windows fail-closed
+// path); its only former production caller — the unused
+// `run_restore_remap_safety_pipeline` wrapper — was deleted, so flag it
+// `allow(dead_code)` outside test builds rather than re-introducing dead public
+// surface just to keep a caller.
 #[cfg(unix)]
+#[cfg_attr(not(test), allow(dead_code))]
 fn verify_read_only_mount(collection: &Collection) -> Result<(), ReconcileError> {
     use rustix::fs::{fstatvfs, StatVfsMountFlags};
 
@@ -1218,6 +1225,7 @@ fn verify_read_only_mount(collection: &Collection) -> Result<(), ReconcileError>
 }
 
 #[cfg(not(unix))]
+#[cfg_attr(not(test), allow(dead_code))]
 fn verify_read_only_mount(collection: &Collection) -> Result<(), ReconcileError> {
     Err(ReconcileError::Other(format!(
         "restore/remap safety checks are not supported on Windows for collection={}",
@@ -1425,16 +1433,6 @@ where
         stability_retries: retries,
         final_snapshot_files: stable_snapshot.len(),
     })
-}
-
-/// Run the drift-capture and stability-proof pipeline that gates a restore
-/// or remap-root, verifying the recovery root is mounted read-only and that
-/// two consecutive walks observe identical state before reporting success.
-pub fn run_restore_remap_safety_pipeline(
-    conn: &Connection,
-    request: &RestoreRemapSafetyRequest<'_>,
-) -> Result<RestoreRemapSafetyOutcome, ReconcileError> {
-    run_restore_remap_safety_pipeline_inner(conn, request, verify_read_only_mount, || Ok(()))
 }
 
 pub(crate) fn run_restore_remap_safety_pipeline_without_mount_check(

--- a/tests/cli_put_source_invariants.rs
+++ b/tests/cli_put_source_invariants.rs
@@ -26,6 +26,17 @@
 //! * Duplicate `insert_write_dedup` failures are fail-closed and do
 //!   not erase the pre-existing dedup entry or unrelated self-write
 //!   tracking state.
+//!
+//! PIN JUSTIFICATION: every invariant here is a kernel-level
+//! syscall-ordering or peer-credential seam — `renameat`-before-commit
+//! fd ordering, `NOFOLLOW`/fd-relative parent creation, and SO_PEERCRED
+//! socket-mode/uid/pid verification before `WhoAmI`. The *outcomes*
+//! (durable atomic writes, rejected spoofed peers, fail-closed dedup) are
+//! covered by the behavioural put/IPC tests, but the relative ordering of
+//! the syscalls and the choice of `NOFOLLOW` cannot be observed from any
+//! public API without winning a TOCTOU race against the live writer. These
+//! stay source pins by design — they are the canonical "behaviour is
+//! impractical to drive" case the test-effectiveness review carves out.
 
 use std::fs as stdfs;
 use std::path::Path;

--- a/tests/concurrency_cross_process.rs
+++ b/tests/concurrency_cross_process.rs
@@ -1,0 +1,267 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::print_stdout,
+    reason = "test fixtures legitimately panic on setup failure and print diagnostics; per-site #[expect] would generate noise across thousands of test sites"
+)]
+
+//! Cross-process optimistic-concurrency race against the *production* write
+//! path. Unlike `tests/concurrency_stress.rs` (which hand-rolls the OCC
+//! `UPDATE` in-process), this test spawns the real `quaid` binary: N
+//! concurrent `quaid put <slug> --expected-version 1` subprocesses all racing
+//! to update the same page. The production guarantee this pins is
+//! **exactly-one-winner via the `ConflictError` surface**: no matter how the
+//! writers interleave, exactly one commits (version 1 → 2) and every other
+//! writer is rejected, never silently clobbering the winner.
+//!
+//! SQLITE_BUSY caveat: the CLI write path serialises same-slug writers with an
+//! *in-process* mutex (`with_write_slug_lock`), which does not span separate
+//! processes, and it opens its write transaction with `BEGIN DEFERRED`
+//! (`unchecked_transaction`). A losing writer that has already taken the read
+//! lock can therefore observe a transient `SQLITE_BUSY` on the
+//! deferred→write upgrade that the 5s busy timeout cannot retry from inside an
+//! open transaction. That is a *loser* outcome — it never produces a second
+//! winner or a corrupt row — so this test treats a BUSY loser as one valid
+//! (if suboptimal) way to lose, and counts it separately. Converting the put
+//! write transaction to `BEGIN IMMEDIATE` (the `db::with_immediate_transaction`
+//! hygiene from the connection-hygiene workstream) would let every loser fail
+//! cleanly via `ConflictError`; that is a production-path change outside this
+//! test slice. See the assertions below for the exact invariant that holds
+//! unconditionally today.
+//!
+//! The contention barrier is filesystem-free: every child is spawned with its
+//! stdin held open first, and the parent only writes-and-closes the stdins
+//! once all children exist. `quaid put` reads stdin to EOF before touching the
+//! DB, so closing all stdins in a tight loop releases the writers into the
+//! commit window together. Generous timeouts plus `#[serial]` keep CI stable.
+
+#[path = "common/mod.rs"]
+mod common;
+#[path = "common/subprocess.rs"]
+mod common_subprocess;
+#[path = "common/truth_fixtures.rs"]
+mod truth_fixtures;
+
+use std::io::Write;
+use std::process::{Child, Command, Stdio};
+
+use serial_test::serial;
+use truth_fixtures::{open_test_db, run_quaid_with_stdin, test_db_path};
+
+#[cfg(unix)]
+fn spawn_put_child(db_path: &std::path::Path, slug: &str, expected_version: i64) -> Child {
+    let mut command = Command::new(common::quaid_bin());
+    common_subprocess::configure_test_command(&mut command);
+    command
+        .arg("--db")
+        .arg(db_path)
+        .args([
+            "put",
+            slug,
+            "--expected-version",
+            &expected_version.to_string(),
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    command.spawn().expect("spawn quaid put child")
+}
+
+#[cfg(unix)]
+#[test]
+#[serial]
+fn concurrent_cli_put_yields_exactly_one_winner_via_conflict_error() {
+    const WRITERS: usize = 6;
+
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let db_path = test_db_path(&dir, "cross-process-occ.db");
+    let root = dir.path().join("vault");
+    std::fs::create_dir_all(&root).expect("create vault root");
+    let conn = open_test_db(&db_path);
+    // Point the seeded default write-target collection (id=1) at our vault.
+    // `is_write_target` is UNIQUE, so we reuse the default rather than insert a
+    // second write-target.
+    conn.execute(
+        "UPDATE collections
+         SET root_path = ?1, writable = 1, is_write_target = 1, state = 'active'
+         WHERE id = 1",
+        [root.display().to_string()],
+    )
+    .expect("point default collection at vault");
+    drop(conn);
+
+    // Create the page at version 1 through the production path so the file,
+    // raw_imports, and DB row are all coherent before the race.
+    let create = run_quaid_with_stdin(
+        &db_path,
+        &["put", "notes/race"],
+        "---\ntitle: Race\ntype: note\n---\nseed body for the OCC race.\n",
+    );
+    assert!(
+        create.status.success(),
+        "seed create must succeed: stdout={} stderr={}",
+        String::from_utf8_lossy(&create.stdout),
+        String::from_utf8_lossy(&create.stderr)
+    );
+
+    // Spawn every writer first (stdin held open), so none can reach the commit
+    // window until the parent releases them together below.
+    let mut children: Vec<Child> = (0..WRITERS)
+        .map(|_| spawn_put_child(&db_path, "notes/race", 1))
+        .collect();
+
+    // Release: write each child's update body and close its stdin. `quaid put`
+    // blocks on stdin EOF before the DB write, so the writers fan into the
+    // commit window here.
+    for (index, child) in children.iter_mut().enumerate() {
+        let body = format!("---\ntitle: Race\ntype: note\n---\nwriter {index} body.\n");
+        child
+            .stdin
+            .take()
+            .expect("child stdin pipe")
+            .write_all(body.as_bytes())
+            .expect("write child stdin");
+    }
+
+    let mut winners = 0usize;
+    let mut conflicts = 0usize;
+    let mut busy_losers = 0usize;
+    let mut other_failures = Vec::new();
+    for (index, child) in children.into_iter().enumerate() {
+        let output = child.wait_with_output().expect("wait for child");
+        let combined = format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        if output.status.success() {
+            winners += 1;
+        } else if combined.contains("ConflictError") && combined.contains("StaleExpectedVersion") {
+            // The production conflict surface: another writer won the CAS.
+            conflicts += 1;
+        } else if combined.contains("database is locked")
+            || combined.contains("SQLITE_BUSY")
+            || combined.contains("database table is locked")
+        {
+            // Tolerated loser outcome (see module docs): a deferred-transaction
+            // upgrade lost the write lock. Still a loser, never a second winner.
+            busy_losers += 1;
+        } else {
+            other_failures.push(format!("writer {index}: {combined}"));
+        }
+    }
+
+    assert!(
+        other_failures.is_empty(),
+        "every non-winner must lose cleanly (ConflictError or transient busy); unexpected failures: {other_failures:?}"
+    );
+    // The load-bearing invariant: exactly one writer commits, full stop.
+    assert_eq!(
+        winners, 1,
+        "exactly one concurrent writer may win the OCC race \
+         (winners={winners}, conflicts={conflicts}, busy_losers={busy_losers})"
+    );
+    assert_eq!(
+        conflicts + busy_losers,
+        WRITERS - 1,
+        "every non-winner must lose (conflicts={conflicts}, busy_losers={busy_losers})"
+    );
+
+    // The single winner advanced the version to 2 and its body is on disk.
+    let verify = open_test_db(&db_path);
+    let (version, truth): (i64, String) = verify
+        .query_row(
+            "SELECT version, compiled_truth FROM pages WHERE slug = 'notes/race'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("winner row present");
+    assert_eq!(version, 2, "exactly one increment from the seed version");
+    assert!(
+        truth.contains("writer "),
+        "winning body must be one of the racing writers: {truth}"
+    );
+}
+
+/// Deterministic companion to the race above: a stale `--expected-version`
+/// against a page that has already advanced MUST fail with the production
+/// `StaleExpectedVersion` `ConflictError` and a non-zero exit, with no
+/// contention involved. This pins the conflict *surface* itself so the race
+/// test's exactly-one-winner guarantee rests on a verified error path.
+#[cfg(unix)]
+#[test]
+#[serial]
+fn stale_expected_version_put_fails_with_production_conflict_error() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let db_path = test_db_path(&dir, "cross-process-stale.db");
+    let root = dir.path().join("vault");
+    std::fs::create_dir_all(&root).expect("create vault root");
+    let conn = open_test_db(&db_path);
+    conn.execute(
+        "UPDATE collections
+         SET root_path = ?1, writable = 1, is_write_target = 1, state = 'active'
+         WHERE id = 1",
+        [root.display().to_string()],
+    )
+    .expect("point default collection at vault");
+    drop(conn);
+
+    let create = run_quaid_with_stdin(
+        &db_path,
+        &["put", "notes/stale"],
+        "---\ntitle: Stale\ntype: note\n---\nseed.\n",
+    );
+    assert!(
+        create.status.success(),
+        "seed create must succeed: {create:?}"
+    );
+
+    // Advance to version 2 with the correct expected version.
+    let advance = run_quaid_with_stdin(
+        &db_path,
+        &["put", "notes/stale", "--expected-version", "1"],
+        "---\ntitle: Stale\ntype: note\n---\nadvanced to v2.\n",
+    );
+    assert!(
+        advance.status.success(),
+        "advance to v2 must succeed: {advance:?}"
+    );
+
+    // Now a stale write at expected-version 1 must fail with the conflict.
+    let stale = run_quaid_with_stdin(
+        &db_path,
+        &["put", "notes/stale", "--expected-version", "1"],
+        "---\ntitle: Stale\ntype: note\n---\nthis must be rejected.\n",
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&stale.stdout),
+        String::from_utf8_lossy(&stale.stderr)
+    );
+    assert!(!stale.status.success(), "stale put must fail: {combined}");
+    assert!(
+        combined.contains("ConflictError") && combined.contains("StaleExpectedVersion"),
+        "stale put must surface the production StaleExpectedVersion ConflictError: {combined}"
+    );
+    assert!(
+        combined.contains("current version: 2"),
+        "conflict must report the current version the caller must refresh to: {combined}"
+    );
+
+    // The rejected write left the page at v2 with the advanced body intact.
+    let verify = open_test_db(&db_path);
+    let (version, truth): (i64, String) = verify
+        .query_row(
+            "SELECT version, compiled_truth FROM pages WHERE slug = 'notes/stale'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("page row present");
+    assert_eq!(version, 2, "rejected write must not advance the version");
+    assert!(
+        truth.contains("advanced to v2"),
+        "rejected write must not clobber the winning body: {truth}"
+    );
+}

--- a/tests/conversation_format_proptest.rs
+++ b/tests/conversation_format_proptest.rs
@@ -1,0 +1,239 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::print_stdout,
+    reason = "test fixtures legitimately panic on setup failure and print diagnostics; per-site #[expect] would generate noise across thousands of test sites"
+)]
+
+//! Property test for the documented conversation-format round-trip invariant
+//! `render(parse(x)) == x` (see `src/core/conversation/format.rs`).
+//!
+//! The proptest drives the canonical direction: build an arbitrary
+//! [`ConversationFile`], render it, parse the rendered text back, and assert
+//! `render(parse_str(render(file))) == render(file)`. Rendering is the
+//! canonical normal form, so this is the strongest stable statement of the
+//! round-trip that does not depend on whatever non-canonical whitespace a
+//! generator happens to emit.
+//!
+//! GENERATOR CAP / TODO(#226): on this branch the format does **not** escape
+//! turn content that contains the structural markers — the turn-boundary
+//! comment (`<!-- quaid-turn-boundary -->`), a `## Turn ` heading, a leading
+//! legacy `---` boundary, or a ```` ```json turn-metadata ```` fence. Feeding
+//! such content through `render` produces bytes that `parse_str` re-segments
+//! into a *different* turn structure, so the round-trip genuinely fails for
+//! that adversarial input. Format-v2 escaping (PR #226, not on this branch)
+//! is the fix; until it lands, the content generator below deliberately
+//! excludes those marker shapes rather than reimplementing escaping here. The
+//! `round_trip_breaks_on_unescaped_turn_boundary` test pins the *known* break
+//! so #226 has a regression target to flip green.
+
+use proptest::prelude::*;
+
+use quaid::core::conversation::format::{parse_str, render};
+use quaid::core::types::{
+    ConversationFile, ConversationFrontmatter, ConversationStatus, Turn, TurnRole,
+};
+
+const TURN_BOUNDARY: &str = "<!-- quaid-turn-boundary -->";
+const METADATA_FENCE_OPEN: &str = "```json turn-metadata";
+
+/// A single content line that `render`/`parse_str` round-trips losslessly:
+/// no trailing whitespace, no carriage return, and not a structural marker
+/// the unescaped format would mis-segment.
+fn safe_content_line() -> impl Strategy<Value = String> {
+    // A small alphabet of letters, digits, punctuation, whitespace, and a few
+    // multibyte code points to exercise the Unicode-char path without tripping
+    // the structural markers.
+    "[a-zA-Z0-9 .,?!:;@#%&*()/'\u{00e9}\u{4e2d}\u{1f600}-]{0,40}".prop_filter(
+        "no marker-shaped or trailing-whitespace lines",
+        |line: &String| {
+            let trimmed = line.trim_end();
+            trimmed == line.as_str()
+                && !line.starts_with("## Turn ")
+                && !line.starts_with("---")
+                && !line.starts_with("```")
+                && !line.starts_with("~~~")
+                && line.trim() != METADATA_FENCE_OPEN
+                && line.trim() != "```"
+                && !line.contains(TURN_BOUNDARY)
+                && !line.contains('\u{2028}')
+                && !line.contains('\u{2029}')
+        },
+    )
+}
+
+/// Multi-line content with safe interior lines. The first and last lines are
+/// non-blank so `render`'s content-boundary trimming is a no-op (blank
+/// boundary lines are collapsed by `parse_str`, which is a separate,
+/// documented normalization rather than a round-trip property).
+fn safe_content() -> impl Strategy<Value = String> {
+    proptest::collection::vec(safe_content_line(), 1..6).prop_map(|mut lines| {
+        if lines.first().map(|l| l.trim().is_empty()).unwrap_or(true) {
+            lines[0] = "x".to_owned();
+        }
+        let last = lines.len() - 1;
+        if lines[last].trim().is_empty() {
+            lines[last] = "y".to_owned();
+        }
+        lines.join("\n")
+    })
+}
+
+/// RFC-3339-ish timestamp; only the textual shape matters for the round-trip,
+/// and it must not contain the ` · ` heading separator or a newline.
+fn safe_timestamp() -> impl Strategy<Value = String> {
+    (
+        2020i32..2030,
+        1u32..13,
+        1u32..28,
+        0u32..24,
+        0u32..60,
+        0u32..60,
+    )
+        .prop_map(|(y, mo, d, h, mi, s)| format!("{y:04}-{mo:02}-{d:02}T{h:02}:{mi:02}:{s:02}Z"))
+}
+
+fn turn_role() -> impl Strategy<Value = TurnRole> {
+    prop_oneof![
+        Just(TurnRole::User),
+        Just(TurnRole::Assistant),
+        Just(TurnRole::System),
+        Just(TurnRole::Tool),
+    ]
+}
+
+/// A turn with no metadata (the ordinal is assigned by the file strategy so
+/// the sequence is 1..=N, which `parse_str` re-derives from the headings).
+fn turn_body() -> impl Strategy<Value = (TurnRole, String, String, Option<serde_json::Value>)> {
+    let metadata = prop_oneof![
+        Just(None),
+        any::<u8>().prop_map(|n| Some(serde_json::json!({ "importance": n }))),
+    ];
+    (turn_role(), safe_timestamp(), safe_content(), metadata)
+}
+
+fn conversation_file() -> impl Strategy<Value = ConversationFile> {
+    let frontmatter = (
+        "[a-z0-9-]{1,20}",
+        safe_timestamp(),
+        prop_oneof![
+            Just(ConversationStatus::Open),
+            Just(ConversationStatus::Closed)
+        ],
+        0i64..50,
+    )
+        .prop_map(|(session_id, started_at, status, last_turn)| {
+            let date = started_at.get(..10).unwrap_or("2026-01-01").to_owned();
+            let closed_at = if matches!(status, ConversationStatus::Closed) {
+                Some(started_at.clone())
+            } else {
+                None
+            };
+            ConversationFrontmatter {
+                file_type: "conversation".to_owned(),
+                session_id,
+                date,
+                started_at,
+                status,
+                closed_at,
+                last_extracted_at: None,
+                last_extracted_turn: last_turn,
+            }
+        });
+
+    (frontmatter, proptest::collection::vec(turn_body(), 0..6)).prop_map(|(frontmatter, bodies)| {
+        let turns = bodies
+            .into_iter()
+            .enumerate()
+            .map(|(index, (role, timestamp, content, metadata))| Turn {
+                ordinal: i64::try_from(index + 1).expect("ordinal fits i64"),
+                role,
+                timestamp,
+                content,
+                metadata,
+            })
+            .collect();
+        ConversationFile { frontmatter, turns }
+    })
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(512))]
+
+    /// The canonical round-trip: rendered bytes parse back to a file that
+    /// renders identically. `render` is the normal form, so a stable fixed
+    /// point here is exactly the `render(parse(x)) == x` invariant for any
+    /// `x` that is itself canonical output.
+    #[test]
+    fn render_parse_render_is_a_fixed_point(file in conversation_file()) {
+        let rendered = render(&file);
+        let parsed = parse_str(&rendered)
+            .unwrap_or_else(|err| panic!("parse_str rejected canonical render: {err}\n---\n{rendered}"));
+        prop_assert_eq!(render(&parsed), rendered);
+    }
+
+    /// Stronger: every structural field survives the round-trip, not just the
+    /// rendered bytes.
+    #[test]
+    fn round_trip_preserves_turn_structure(file in conversation_file()) {
+        let parsed = parse_str(&render(&file)).expect("parse canonical render");
+        prop_assert_eq!(parsed.turns.len(), file.turns.len());
+        for (original, round_tripped) in file.turns.iter().zip(parsed.turns.iter()) {
+            prop_assert_eq!(original.ordinal, round_tripped.ordinal);
+            prop_assert_eq!(&original.role, &round_tripped.role);
+            prop_assert_eq!(&original.timestamp, &round_tripped.timestamp);
+            prop_assert_eq!(&original.content, &round_tripped.content);
+            prop_assert_eq!(&original.metadata, &round_tripped.metadata);
+        }
+    }
+}
+
+/// Pins the KNOWN round-trip break that the generator caps out: a turn whose
+/// content embeds the literal turn-boundary marker is re-segmented into an
+/// extra turn on parse. This is the exact case format-v2 escaping (#226) must
+/// fix; when it lands, this test should be inverted to assert the round-trip
+/// holds. Keeping it as an explicit `!=` assertion documents the limitation
+/// instead of silently excluding it.
+#[test]
+fn round_trip_breaks_on_unescaped_turn_boundary() {
+    let file = ConversationFile {
+        frontmatter: ConversationFrontmatter {
+            file_type: "conversation".to_owned(),
+            session_id: "s1".to_owned(),
+            date: "2026-01-01".to_owned(),
+            started_at: "2026-01-01T00:00:00Z".to_owned(),
+            status: ConversationStatus::Open,
+            closed_at: None,
+            last_extracted_at: None,
+            last_extracted_turn: 0,
+        },
+        turns: vec![Turn {
+            ordinal: 1,
+            role: TurnRole::User,
+            timestamp: "2026-01-01T00:00:00Z".to_owned(),
+            // Embedding the boundary marker mid-content is the adversarial case.
+            content: format!("before\n{TURN_BOUNDARY}\nafter"),
+            metadata: None,
+        }],
+    };
+
+    let rendered = render(&file);
+    let original_content = file.turns[0].content.clone();
+    // On this branch the embedded boundary is NOT escaped, so the round-trip
+    // is lossy: parse either errors (the post-boundary text has no `## Turn`
+    // heading) or yields a turn whose content lost the boundary segment.
+    let faithfully_round_tripped = matches!(
+        parse_str(&rendered),
+        Ok(ref parsed)
+            if parsed.turns.len() == 1 && parsed.turns[0].content == original_content
+    );
+    // TODO(#226): when format-v2 escaping lands, invert this to
+    // `assert!(faithfully_round_tripped)` and drop the generator cap above.
+    assert!(
+        !faithfully_round_tripped,
+        "unexpected: embedded turn-boundary round-tripped faithfully — \
+         format-v2 escaping (#226) may have landed; invert this test and lift \
+         the generator cap in this file"
+    );
+}

--- a/tests/fts_sanitizer_proptest.rs
+++ b/tests/fts_sanitizer_proptest.rs
@@ -1,0 +1,118 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::print_stdout,
+    reason = "test fixtures legitimately panic on setup failure and print diagnostics; per-site #[expect] would generate noise across thousands of test sites"
+)]
+
+//! Property test for the FTS5 query-sanitization invariant: for *any* input
+//! string, the natural-language search path must never surface an FTS5
+//! `MATCH` syntax error (which would arrive as `SearchError::Sqlite`) and must
+//! never panic.
+//!
+//! `sanitize_fts_query` is `pub(crate)`, so this drives the invariant through
+//! the public production entry point `hybrid_search`, which sanitizes the
+//! query internally before handing it to FTS5. That is the stronger, more
+//! behavioural statement of the guarantee: it is not enough that the sanitizer
+//! returns *some* string — that string must be a syntactically valid FTS5
+//! `MATCH` expression that SQLite accepts.
+//!
+//! The DB is seeded with one page but no embeddings, so
+//! `search_vec_*` short-circuits to an empty result before touching the
+//! embedding model (see `inference.rs`: it returns early when
+//! `page_embeddings` is empty for the active model). The proptest therefore
+//! exercises the full FTS sanitize-and-match path without loading a model.
+
+use proptest::prelude::*;
+use rusqlite::Connection;
+
+use quaid::core::db;
+use quaid::core::search::{hybrid_search, HybridSearch};
+
+fn seeded_db() -> Connection {
+    let conn = db::open(":memory:").expect("open in-memory DB");
+    conn.execute(
+        "INSERT INTO pages \
+         (slug, type, title, summary, compiled_truth, timeline, frontmatter, \
+          wing, room, version, created_at, updated_at, truth_updated_at, timeline_updated_at) \
+         VALUES ('people/alice', 'person', 'Alice', 'an engineer', \
+                 'Alice is a rust engineer who likes SQLite and FTS5.', '', '{}', \
+                 'people', '', 1, \
+                 strftime('%Y-%m-%dT%H:%M:%SZ','now'), \
+                 strftime('%Y-%m-%dT%H:%M:%SZ','now'), \
+                 strftime('%Y-%m-%dT%H:%M:%SZ','now'), \
+                 strftime('%Y-%m-%dT%H:%M:%SZ','now'))",
+        [],
+    )
+    .expect("seed page");
+    conn
+}
+
+fn assert_no_fts_syntax_error(conn: &Connection, query: &str) {
+    match hybrid_search(
+        conn,
+        HybridSearch {
+            query,
+            limit: 10,
+            ..Default::default()
+        },
+    ) {
+        Ok(_) => {}
+        // The *only* acceptable failure mode for arbitrary natural-language
+        // input is none — an FTS5 MATCH syntax error would arrive here as
+        // `SearchError::Sqlite` and is exactly what sanitization must prevent.
+        Err(err) => panic!("hybrid_search errored on query {query:?}: {err}"),
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(1024))]
+
+    /// Arbitrary UTF-8 strings (including FTS5 operators, quotes, parentheses,
+    /// CJK, emoji, combining marks, and the boolean keywords) must never
+    /// produce an FTS5 syntax error or panic.
+    #[test]
+    fn arbitrary_unicode_query_never_errors(query in any::<String>()) {
+        let conn = seeded_db();
+        assert_no_fts_syntax_error(&conn, &query);
+    }
+
+    /// Targeted adversarial shapes: dense runs of FTS5 metacharacters and the
+    /// case-sensitive boolean keywords interleaved with junk, which is where a
+    /// naive sanitizer leaves a dangling operator.
+    #[test]
+    fn adversarial_operator_soup_never_errors(
+        query in r#"[?*+":()^.\-/@#=, ANDORNTearx]{0,64}"#
+    ) {
+        let conn = seeded_db();
+        assert_no_fts_syntax_error(&conn, &query);
+    }
+}
+
+/// A regression net of the specific shapes the unit tests in `fts.rs` cover,
+/// plus a few that have historically broken naive FTS sanitizers, exercised
+/// through the same public path.
+#[test]
+fn known_fts_breakers_do_not_error() {
+    let conn = seeded_db();
+    for query in [
+        "AND",
+        "OR NOT NEAR",
+        "\"unterminated",
+        "rust AND",
+        "(((",
+        ")))",
+        "* prefix",
+        "NEAR(a b)",
+        "foo: bar",
+        "a^b",
+        "\u{4e2d}\u{6587} AND \u{1f600}",
+        "   ",
+        "",
+        "???***",
+        "col:val AND NOT \"x",
+    ] {
+        assert_no_fts_syntax_error(&conn, query);
+    }
+}

--- a/tests/put_sigkill_recovery.rs
+++ b/tests/put_sigkill_recovery.rs
@@ -1,0 +1,259 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::print_stdout,
+    reason = "test fixtures legitimately panic on setup failure and print diagnostics; per-site #[expect] would generate noise across thousands of test sites"
+)]
+
+//! SIGKILL-mid-write recovery harness.
+//!
+//! A `quaid put` writes its target file under a `*.needs_full_sync` recovery
+//! sentinel and only removes the sentinel after the SQLite commit succeeds (see
+//! `src/commands/put.rs` and `src/core/vault_sync/recovery.rs`). If the process
+//! dies between the rename and the commit, the sentinel survives, and the next
+//! daemon startup (`start_serve_runtime` → `recover_owned_collection_sentinels`)
+//! must flag the collection `needs_full_sync`, run a full-hash recovery that
+//! reconciles the DB to whatever bytes are on disk, then delete the sentinel.
+//!
+//! This file pins that recovery two ways:
+//!
+//! 1. `sigkill_mid_put_leaves_db_and_file_coherent_after_recovery` does a *real*
+//!    `kill -9` of a `quaid put` subprocess and asserts that after a recovery
+//!    pass the DB row and the on-disk file agree, whatever phase the kill hit.
+//! 2. `startup_recovery_reconciles_db_to_disk_and_clears_sentinel` reconstructs
+//!    the exact on-disk state a SIGKILL leaves between rename and commit (a
+//!    leftover sentinel plus a file newer than the DB row) and drives the
+//!    production `start_serve_runtime` recovery deterministically.
+//!
+//! NB: the prompt's `PutTestHooks` blocking hooks are `#[cfg(all(test, unix))]`
+//! and live in an in-process static map, so they are NOT compiled into the
+//! `quaid` binary and cannot park a *subprocess* put at the staged point.
+//! Test (2) therefore reconstructs the staged-crash artifacts directly, which
+//! exercises the identical production recovery code (`start_serve_runtime`)
+//! that an in-crate hook-driven crash would.
+
+#[path = "common/mod.rs"]
+mod common;
+#[path = "common/subprocess.rs"]
+mod common_subprocess;
+#[path = "common/vault_sync_fixtures.rs"]
+mod fixtures;
+
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use rusqlite::Connection;
+
+#[cfg(target_os = "linux")]
+use fixtures::EnvVarGuard;
+use fixtures::{
+    create_startup_recovery_sentinel, env_mutation_lock, insert_collection,
+    insert_page_with_raw_import, open_test_db_file, write_restore_file,
+};
+use quaid::core::vault_sync::{recovery_root_for_db_path, start_serve_runtime};
+
+fn poll<T>(timeout: Duration, mut probe: impl FnMut() -> Option<T>) -> Option<T> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Some(value) = probe() {
+            return Some(value);
+        }
+        if Instant::now() >= deadline {
+            return None;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+fn page_row(db_path: &str, slug: &str) -> Option<(String, i64)> {
+    let conn = Connection::open(db_path).ok()?;
+    conn.query_row(
+        "SELECT compiled_truth, version FROM pages WHERE slug = ?1",
+        [slug],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )
+    .ok()
+}
+
+#[cfg(unix)]
+#[test]
+fn sigkill_mid_put_leaves_db_and_file_coherent_after_recovery() {
+    let _lock = env_mutation_lock().lock().unwrap();
+    #[cfg(target_os = "linux")]
+    let _runtime_root = fixtures::secure_runtime_root();
+    #[cfg(target_os = "linux")]
+    let _xdg = EnvVarGuard::set("XDG_RUNTIME_DIR", _runtime_root.path().to_str().unwrap());
+
+    let (dir, db_path, conn) = open_test_db_file();
+    let root = tempfile::TempDir::new().unwrap();
+    let collection_id = insert_collection(&conn, "work", root.path());
+    let canonical_root = std::fs::canonicalize(root.path()).unwrap();
+    // Make the default write-target point elsewhere so the bare-slug create
+    // routes to our "work" collection unambiguously by using an explicit slug.
+    let uuid = "01969f11-9448-7d79-8d3f-c68f54760001";
+    let seed = format!(
+        "---\nmemory_id: {uuid}\nslug: notes/kill\ntitle: Kill\ntype: concept\n---\nseed body before the crash.\n"
+    );
+    insert_page_with_raw_import(
+        &conn,
+        collection_id,
+        "notes/kill",
+        uuid,
+        "seed body before the crash.",
+        seed.as_bytes(),
+        "notes/kill.md",
+    );
+    write_restore_file(&canonical_root, "notes/kill.md", seed.as_bytes());
+    drop(conn);
+
+    // Spawn a real put and SIGKILL it. Whatever phase the kill catches, the
+    // DB+file must end coherent after a recovery pass — never a torn row.
+    let mut command = Command::new(common::quaid_bin());
+    common_subprocess::configure_test_command(&mut command);
+    command
+        .arg("--db")
+        .arg(&db_path)
+        .args(["put", "work::notes/kill", "--expected-version", "1"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let mut child = command.spawn().expect("spawn quaid put");
+    child
+        .stdin
+        .take()
+        .expect("child stdin")
+        .write_all(
+            format!(
+                "---\nmemory_id: {uuid}\nslug: notes/kill\ntitle: Kill\ntype: concept\n---\nbody written just before SIGKILL.\n"
+            )
+            .as_bytes(),
+        )
+        .expect("write child stdin");
+    // kill() is SIGKILL on Unix — the writer cannot run any cleanup.
+    child.kill().expect("kill -9 the put");
+    let _ = child.wait();
+
+    // Drive production recovery: a fresh serve runtime reconciles the DB to the
+    // on-disk file and consumes any leftover sentinel.
+    let runtime = start_serve_runtime(db_path.clone()).expect("start serve runtime");
+
+    let on_disk = std::fs::read_to_string(canonical_root.join("notes").join("kill.md"))
+        .expect("file on disk");
+    let coherent = poll(Duration::from_secs(8), || {
+        let (truth, _version) = page_row(&db_path, "notes/kill")?;
+        // Coherence: the compiled_truth the DB holds must match the body bytes
+        // currently on disk (recovery reconciles DB → disk).
+        on_disk.contains(truth.trim()).then_some(())
+    });
+    drop(runtime);
+
+    assert!(
+        coherent.is_some(),
+        "after SIGKILL + recovery, the DB row and the on-disk file must agree.\non disk:\n{on_disk}"
+    );
+    // The recovery sentinel directory must not retain a dangling sentinel.
+    assert_eq!(
+        leftover_sentinels(&db_path, collection_id),
+        0,
+        "recovery must consume any leftover put sentinel"
+    );
+
+    drop(dir);
+}
+
+#[cfg(unix)]
+#[test]
+fn startup_recovery_reconciles_db_to_disk_and_clears_sentinel() {
+    let _lock = env_mutation_lock().lock().unwrap();
+    #[cfg(target_os = "linux")]
+    let _runtime_root = fixtures::secure_runtime_root();
+    #[cfg(target_os = "linux")]
+    let _xdg = EnvVarGuard::set("XDG_RUNTIME_DIR", _runtime_root.path().to_str().unwrap());
+
+    let (dir, db_path, conn) = open_test_db_file();
+    let root = tempfile::TempDir::new().unwrap();
+    let collection_id = insert_collection(&conn, "work", root.path());
+    let canonical_root = std::fs::canonicalize(root.path()).unwrap();
+    let uuid = "01969f11-9448-7d79-8d3f-c68f54760002";
+
+    // DB row + raw_import hold the OLD body (the commit never landed).
+    let old = format!(
+        "---\nmemory_id: {uuid}\nslug: notes/staged\ntitle: Staged\ntype: concept\n---\nold body still in the database.\n"
+    );
+    insert_page_with_raw_import(
+        &conn,
+        collection_id,
+        "notes/staged",
+        uuid,
+        "old body still in the database.",
+        old.as_bytes(),
+        "notes/staged.md",
+    );
+
+    // On disk: the NEW body the renamed-but-uncommitted put left behind.
+    let new = format!(
+        "---\nmemory_id: {uuid}\nslug: notes/staged\ntitle: Staged\ntype: concept\n---\nnew body the crashed put renamed into place.\n"
+    );
+    write_restore_file(&canonical_root, "notes/staged.md", new.as_bytes());
+
+    // The leftover recovery sentinel a SIGKILL between rename and commit leaves.
+    let recovery_root = recovery_root_for_db_path(Path::new(&db_path));
+    create_startup_recovery_sentinel(
+        &recovery_root,
+        collection_id,
+        "crashed-write.needs_full_sync",
+    );
+    drop(conn);
+
+    let runtime = start_serve_runtime(db_path.clone()).expect("start serve runtime");
+
+    let recovered = poll(Duration::from_secs(8), || {
+        let conn = Connection::open(&db_path).ok()?;
+        let (state, needs_full_sync, truth): (String, i64, String) = conn
+            .query_row(
+                "SELECT c.state, c.needs_full_sync, p.compiled_truth
+                 FROM collections c
+                 JOIN pages p ON p.collection_id = c.id AND p.slug = 'notes/staged'
+                 WHERE c.id = ?1",
+                [collection_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .ok()?;
+        (state == "active"
+            && needs_full_sync == 0
+            && truth == "new body the crashed put renamed into place."
+            && leftover_sentinels(&db_path, collection_id) == 0)
+            .then_some(truth)
+    });
+    drop(runtime);
+
+    assert!(
+        recovered.is_some(),
+        "startup recovery must reconcile the DB to the on-disk file, clear needs_full_sync, \
+         and delete the sentinel"
+    );
+
+    drop(dir);
+}
+
+#[cfg(unix)]
+fn leftover_sentinels(db_path: &str, collection_id: i64) -> usize {
+    let recovery_root = recovery_root_for_db_path(Path::new(db_path));
+    let dir = quaid::core::vault_sync::collection_recovery_dir(&recovery_root, collection_id);
+    std::fs::read_dir(dir)
+        .map(|entries| {
+            entries
+                .filter_map(Result::ok)
+                .filter(|entry| {
+                    entry
+                        .file_name()
+                        .to_string_lossy()
+                        .ends_with(".needs_full_sync")
+                })
+                .count()
+        })
+        .unwrap_or(0)
+}

--- a/tests/reconciler_source_audit.rs
+++ b/tests/reconciler_source_audit.rs
@@ -13,6 +13,16 @@ mod common_reconciler_fixtures;
 
 use common_reconciler_fixtures::*;
 
+// PIN JUSTIFICATION: the safety pipeline's *internal* phase ordering (drift
+// capture → stability proof → pre-destruction fence → fresh-connection dirty
+// recheck) and the no-mount wrapper's closure wiring are fd/mount-verifier
+// seams that cannot be observed from the public restore/remap API — the
+// behavioural restore/remap tests (`tests/vault_sync_restore.rs`,
+// `tests/vault_sync_remap.rs`) prove the *outcome* (drift refusal, new-root
+// verification, fail-closed halts) but not the relative ordering of these
+// private phases. These two source pins guard that ordering against a silent
+// refactor that would reorder the fence after the dirty recheck.
+
 #[test]
 fn remap_safety_pipeline_wrapper_source_skips_mount_verifier_only() {
     let source = production_reconciler_source();
@@ -26,8 +36,10 @@ fn remap_safety_pipeline_wrapper_source_skips_mount_verifier_only() {
     let snippet = &source[start..end];
 
     assert!(
-        snippet.contains("run_restore_remap_safety_pipeline_inner(conn, request, |_| Ok(()), || Ok(()))"),
-        "the no-mount wrapper must reuse the shared safety pipeline and only skip the mount verifier"
+        snippet.contains(
+            "run_restore_remap_safety_pipeline_inner(conn, request, |_| Ok(()), || Ok(()))"
+        ),
+        "the no-mount wrapper must reuse the shared safety pipeline with a no-op mount verifier"
     );
 }
 
@@ -38,7 +50,7 @@ fn remap_safety_pipeline_source_keeps_phase_order_before_dirty_recheck() {
         .find("fn run_restore_remap_safety_pipeline_inner")
         .expect("shared restore/remap safety pipeline must remain present");
     let end = source[start..]
-        .find("pub fn run_restore_remap_safety_pipeline(")
+        .find("pub(crate) fn run_restore_remap_safety_pipeline_without_mount_check(")
         .map(|offset| start + offset)
         .expect("shared restore/remap safety wrapper must remain present");
     let snippet = &source[start..end];
@@ -60,6 +72,13 @@ fn remap_safety_pipeline_source_keeps_phase_order_before_dirty_recheck() {
     );
 }
 
+// PIN JUSTIFICATION: this pins the *symlink-safety mechanism* — fd-relative
+// NOFOLLOW reads (`OFlags::NOFOLLOW`, `stat_at_nofollow`, `walk_to_parent`)
+// rather than path-based stat/hash that follows symlinks. The security
+// property (a symlinked audit path is not followed) is impossible to assert
+// from a unit test without racing a TOCTOU symlink swap against the live
+// audit; the flag choice itself is the load-bearing invariant, so it stays a
+// source pin per the established `tests/cli_put_source_invariants.rs` pattern.
 #[test]
 fn scheduled_full_hash_audit_source_uses_nofollow_fd_relative_reads() {
     let source = production_reconciler_source();
@@ -93,24 +112,19 @@ fn scheduled_full_hash_audit_source_uses_nofollow_fd_relative_reads() {
     );
 }
 
-#[test]
-fn capture_phase1_drift_source_refuses_remap_on_material_changes() {
-    let source = production_reconciler_source();
-    let start = source.find("fn capture_phase1_drift(").unwrap();
-    let end = source[start..]
-        .find("fn run_phase2_stability_check")
-        .map(|offset| start + offset)
-        .unwrap();
-    let snippet = &source[start..end];
+// NOTE: the remap-drift-refusal source pin that used to live here was deleted.
+// Its property — Phase 1 fails closed with `RemapDriftConflictError` when
+// old-root drift would otherwise be silently lost — is now fully driven
+// behaviourally by `remap_collection_refuses_phase1_drift_until_new_root_catches_up`
+// in `tests/vault_sync_remap.rs`, which mutates the old root mid-remap and
+// asserts the typed error plus the preserved drift in `raw_imports`.
 
-    assert!(
-        snippet.contains("RestoreRemapOperation::Remap if summary.has_material_changes()")
-            && snippet.contains("ERROR: remap_drift_refused")
-            && snippet.contains("ReconcileError::RemapDriftConflictError"),
-        "Phase 1 remap capture must fail closed when old-root drift would otherwise be lost"
-    );
-}
-
+// PIN JUSTIFICATION: the *restore* branch of Phase 1 (as opposed to remap)
+// adopts old-root drift rather than refusing it, and the only externally
+// observable signal of that decision is a `WARN: restore_drift_captured` log
+// line (the page contents converge either way, so a behavioural assert cannot
+// distinguish "captured" from "no drift"). This pin guards that the restore
+// branch keeps capturing-without-refusing.
 #[test]
 fn capture_phase1_drift_source_logs_restore_capture_without_refusal() {
     let source = production_reconciler_source();
@@ -128,6 +142,11 @@ fn capture_phase1_drift_source_logs_restore_capture_without_refusal() {
     );
 }
 
+// PIN JUSTIFICATION: the authorization match arms bind both remap full-hash
+// modes to an active owner lease. Driving the *negative* case behaviourally
+// (a remap full-hash attempted without the active lease) would require
+// fabricating an inconsistent owner-lease/state combination that the rest of
+// the runtime refuses to produce, so the binding stays a source pin.
 #[test]
 fn authorize_full_hash_source_requires_active_lease_for_remap_modes() {
     let source = production_reconciler_source();

--- a/tests/vault_sync_remap.rs
+++ b/tests/vault_sync_remap.rs
@@ -74,6 +74,13 @@ fn verify_remap_root_rejects_invalid_quaidignore_in_new_root() {
 }
 
 #[cfg(unix)]
+// PIN JUSTIFICATION: online remap must *not* run the attach/full-hash pass
+// inline (it only flips DB state + resets `file_state` under the acked owner
+// lease) and must hand the attach off to exactly one RCRT arm. This is a
+// cross-function handoff between `remap_collection` and `run_rcrt_pass` driven
+// by a live serve runtime; reproducing it behaviourally needs a full
+// daemon-owned online remap with watcher acks, which the offline behavioural
+// remap tests cannot exercise. The pin guards the inline/deferred split.
 #[test]
 fn remap_online_source_defers_attach_to_rcrt_and_remap_attach_reason_appears_once() {
     let source = production_vault_sync_source();
@@ -622,6 +629,11 @@ fn verify_remap_root_reports_mismatched_count_for_duplicate_uuid_candidates() {
     ));
 }
 
+// PIN JUSTIFICATION: `verify_remap_root` fences the new-root tree before and
+// after matching and fails closed with `NewRootUnstableError` if the fence
+// changed mid-flight. Like `take_tree_fence_source_uses_full_stat_tuple`, the
+// guarded property is a TOCTOU window with no public injection seam, so the
+// before/after fence wiring stays a source pin.
 #[test]
 fn verify_remap_root_source_uses_before_and_after_tree_fences() {
     let source = production_vault_sync_source();
@@ -643,30 +655,22 @@ fn verify_remap_root_source_uses_before_and_after_tree_fences() {
     );
 }
 
-#[test]
-fn load_new_root_files_source_applies_new_root_ignore_matcher() {
-    let source = production_vault_sync_source();
-    let start = source.find("fn load_new_root_files(").unwrap();
-    let end = source[start..]
-        .find("fn resolve_page_matches(")
-        .map(|offset| start + offset)
-        .unwrap();
-    let snippet = &source[start..end];
+// NOTE: two source pins were deleted from here —
+// `load_new_root_files_source_applies_new_root_ignore_matcher` and
+// `walk_tree_source_skips_symlinked_entries`. Both properties are now driven
+// end-to-end through the public `verify_remap_root` API:
+// `verify_remap_root_uses_unique_hash_fallback_and_ignores_quaidignore_patterns`
+// proves `.quaidignore`-matched files are excluded from the extra-file count,
+// `verify_remap_root_ignores_non_markdown_files` proves the Markdown gate, and
+// `verify_remap_root_skips_symlinked_entries_in_new_root` proves the symlink
+// skip — each asserting `extra_files == 0`, which only holds if the source
+// invariants hold.
 
-    assert!(
-        snippet.contains("let ignore_globset = build_new_root_ignore_globset(root)?;"),
-        "load_new_root_files must build a fresh ignore matcher from the remap root before counting files"
-    );
-    assert!(
-        snippet.contains("if ignore_globset.is_match(relative_path) {"),
-        "load_new_root_files must exclude .quaidignore-matched files from remap verification counts"
-    );
-    assert!(
-        snippet.contains("if !is_markdown_file(relative_path) {"),
-        "load_new_root_files must reuse the reconciler's Markdown gate so Phase 4 extra counts stay in parity"
-    );
-}
-
+// PIN JUSTIFICATION: `resolve_page_matches` must funnel through the shared
+// `resolve_page_identity` helper (uuid-then-hash) rather than re-implementing
+// matching. The behavioural remap tests prove correct *resolution*, but not
+// that it reuses the canonical helper; this pin guards against a divergent
+// bespoke matcher drifting from the reconciler's identity rules.
 #[test]
 fn resolve_page_matches_source_uses_canonical_resolver_helper() {
     let source = production_vault_sync_source();
@@ -683,6 +687,12 @@ fn resolve_page_matches_source_uses_canonical_resolver_helper() {
     );
 }
 
+// PIN JUSTIFICATION: the tree fence must capture mtime+ctime+inode (the full
+// stat tuple), not just size, so a same-size atomic-replace mid-verification
+// is detected. Asserting this behaviourally would require winning a race to
+// swap a file between the two fence walks within `verify_remap_root` — a
+// TOCTOU window with no public injection seam — so the stat-tuple composition
+// stays a source pin.
 #[test]
 fn take_tree_fence_source_uses_full_stat_tuple() {
     let source = production_vault_sync_source();
@@ -694,23 +704,16 @@ fn take_tree_fence_source_uses_full_stat_tuple() {
     );
 }
 
-#[test]
-fn walk_tree_source_skips_symlinked_entries() {
-    let source = production_vault_sync_source();
-    let start = source.find("fn walk_tree(").unwrap();
-    let end = source[start..]
-        .find("fn path_string(")
-        .map(|offset| start + offset)
-        .unwrap();
-    let snippet = &source[start..end];
-
-    assert!(
-        snippet.contains("let file_type = entry.file_type()?;")
-            && snippet.contains("if file_type.is_symlink() {"),
-        "Phase 4 tree walks must inspect entry file types without following symlinks"
-    );
-}
-
+// PIN JUSTIFICATION: the following four pins guard the *relative ordering* of
+// private phases inside `remap_collection` — safety pipeline before new-root
+// verification, exact-ack before the safety pipeline (online), new-root
+// verification before the `root_path` UPDATE, and inline short-lived-lease
+// attach (offline). Each ordering is a fail-closed safety boundary (capture
+// drift under the owner lease before trusting the new tree), but the steps
+// share inputs and converge on the same end state, so the public remap API
+// cannot observe their interleaving. They remain source pins per the
+// `tests/cli_put_source_invariants.rs` ordering-seam pattern; the behavioural
+// remap tests above prove the end-to-end outcomes.
 #[test]
 fn remap_source_runs_safety_pipeline_before_new_root_verification() {
     let source = production_vault_sync_source();

--- a/tests/vault_sync_runtime.rs
+++ b/tests/vault_sync_runtime.rs
@@ -91,6 +91,18 @@ fn start_serve_runtime_watcher_reconciles_external_edit_after_debounce() {
     drop(runtime);
 }
 
+// PIN JUSTIFICATION (the four source-introspection tests below):
+// `start_serve_runtime` spins up background threads (scheduled full-hash
+// audit, janitor sweep, raw-import TTL sweep, extraction worker) and stores
+// their join handles on `ServeRuntime` for an orderly shutdown. The guarded
+// properties are: (1) every maintenance tick logs its failure instead of
+// silently discarding it, (2) the extraction worker is spawned and its handle
+// retained, (3) the worker honours the stop signal and logs init/run
+// failures, and (4) `Drop` joins the worker handle. Triggering a maintenance
+// *failure* on demand, or asserting a thread was joined, has no public
+// injection seam — and the worker's queue-drain semantics are already covered
+// behaviourally in `tests/extraction_worker.rs`. These pins guard the
+// thread-lifecycle and fail-loud wiring that the behavioural tests cannot see.
 #[test]
 fn start_serve_runtime_logs_scheduled_maintenance_failures() {
     let source = production_vault_sync_source();

--- a/tests/vault_sync_watcher.rs
+++ b/tests/vault_sync_watcher.rs
@@ -43,6 +43,20 @@ use quaid::core::markdown;
 use quaid::core::raw_imports;
 use quaid::core::vault_sync::*;
 
+// PIN JUSTIFICATION (the four source-introspection tests below):
+// `sync_collection_watchers`, `run_overflow_recovery_pass`,
+// `start_collection_watcher`, and `mark_watcher_crashed` are all private
+// supervisor internals whose triggers — a `notify` backend init failure
+// (poll-mode fallback), a channel-overflow recovery pass, and a watcher crash
+// with exponential backoff — cannot be injected through the public vault-sync
+// API without a live OS file-watcher and a forced backend failure. The
+// behavioural `plain_sync_*` tests below prove the reconcile *outcomes*; these
+// four pins guard the active-only gating, lease authorization, poll fallback,
+// and crash-state transitions that have no public injection seam. The
+// crash → `needs_full_sync` recovery property is additionally pinned in
+// `tests/vault_sync_robustness.rs`
+// (`sync_collection_watchers_flags_full_sync_when_rearming_after_crash`).
+
 #[test]
 fn sync_collection_watchers_production_logic_stays_active_only_and_generation_aware() {
     let source = production_vault_sync_source();


### PR DESCRIPTION
**Stacked on #234** (`fable/w2b-vault-robustness`). Implements **Area 23 — test suite effectiveness** (steps 1–5).

## Changes
1. **Text-pin → behavioral sweep**: deleted the dead `run_restore_remap_safety_pipeline` mount-check variant (zero production callers) and the source-pins now fully covered behaviorally (remap drift-refusal, ignore-matcher, symlink-skip). Remaining pins (NOFOLLOW/fd-ordering, lease-auth, peer-cred, private-supervisor seams) keep an explicit PIN-JUSTIFICATION comment explaining why behavior is impractical to drive. Net: reconciler_source_audit 6→5, vault_sync_remap 23→20, others justified.
2. **`tests/concurrency_cross_process.rs`** (new): real binary, 6 concurrent `put --expected-version` subprocesses on one slug — asserts exactly-one-winner via production `ConflictError`, plus a deterministic StaleExpectedVersion companion.
3. **proptest** dev-dep + two property tests: `render(parse(x)) == x` over generated content (cap excludes the unescaped marker shapes with a pinned known-break + `TODO(#226)` since format-v2 escaping lands there), and `sanitize_fts_query` never errors over arbitrary unicode (driven through `hybrid_search`).
4. **`tests/put_sigkill_recovery.rs`** (new): real `kill -9` of a `quaid put` + deterministic staged-crash reconstruction, both driving production sentinel recovery and asserting DB/file coherence.
5. **`weekly-real-model.yml`** (new, scheduled, non-blocking): real-model embed+search round-trip per BGE alias (no hash shim) asserting the per-dim `page_embeddings_vec_<dim>` table populates, plus a Windows `cargo check` job.

Also re-enabled the stale `ingest.rs` rotation `#[ignore]` (rotation is implemented now).

## Production gap surfaced (left for a follow-up, documented)
The new cross-process test revealed that CLI `put` serializes same-slug writers with an **in-process** mutex and opens its write txn with `BEGIN DEFERRED`, so a *losing* cross-process writer can hit a transient SQLITE_BUSY the 5s busy_timeout can't retry from inside an open txn. **Exactly-one-winner OCC still holds — no second winner, no corruption** — a BUSY is just a suboptimal way to lose. Fix (convert put's write txn to `BEGIN IMMEDIATE` via `db::with_immediate_transaction`) is in the same hot path #230/#234 own, so it's scoped out of this test PR — tracked for the write-path unification (Area 16).

## Validation
fmt/clippy/rustdoc clean. All converted/new suites pass; effectiveness demonstrated per pin (temporarily broke the guarded property, observed the behavioral test fail, reverted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)