### PR TITLE
perf(vector): two-phase vec0 KNN, vector cleanup + janitor, CLI queue drain (area 10, #134)

### DIFF
--- a/src/commands/call.rs
+++ b/src/commands/call.rs
@@ -277,7 +277,8 @@ mod tests {
         let server = make_server();
         let result = dispatch_tool(&server, "memory_search", json!({"query": "anything"}))
             .expect("dispatch memory_search");
-        assert!(result.as_array().is_some());
+        // memory_search now returns a {results, pending_embedding_jobs?} envelope.
+        assert!(result["results"].as_array().is_some());
     }
 
     #[test]
@@ -418,7 +419,8 @@ mod tests {
         let server = make_server();
         let result = dispatch_tool(&server, "memory_query", json!({"query": "anything"}))
             .expect("memory_query should succeed");
-        assert!(result.is_array() || result.is_string());
+        // memory_query now returns a {results, pending_embedding_jobs?} envelope.
+        assert!(result["results"].is_array() || result.is_string());
     }
 
     #[test]

--- a/src/commands/collection.rs
+++ b/src/commands/collection.rs
@@ -114,6 +114,10 @@ pub struct CollectionSyncArgs {
     pub finalize_pending: bool,
     #[arg(long)]
     pub online: bool,
+    /// Skip the inline embedding-queue drain, leaving newly-synced pages
+    /// pending until a daemon (or a later sync) embeds them.
+    #[arg(long = "no-embed")]
+    pub no_embed: bool,
 }
 
 #[derive(Args, Debug)]
@@ -668,6 +672,11 @@ fn remove(db: &Connection, name: &str, purge: bool, confirm: bool, json: bool) -
             [collection.id],
         )?;
         let purged_pages = if purge {
+            // Drop backing vec0 rows before the pages: vec0 tables do not
+            // cascade with the FK delete, so otherwise they orphan (item #10).
+            let page_ids = collect_page_ids_for_collection(&tx, collection.id)?;
+            crate::core::inference::delete_page_vec_rows(&tx, &page_ids)
+                .map_err(|err| anyhow!(err.to_string()))?;
             tx.execute(
                 "DELETE FROM pages WHERE collection_id = ?1",
                 [collection.id],
@@ -699,6 +708,16 @@ fn remove(db: &Connection, name: &str, purge: bool, confirm: bool, json: bool) -
             "purged_page_rows": purged_pages
         }),
     )
+}
+
+fn collect_page_ids_for_collection(conn: &Connection, collection_id: i64) -> Result<Vec<i64>> {
+    let mut stmt = conn.prepare("SELECT id FROM pages WHERE collection_id = ?1")?;
+    let rows = stmt.query_map([collection_id], |row| row.get::<_, i64>(0))?;
+    let mut page_ids = Vec::new();
+    for row in rows {
+        page_ids.push(row?);
+    }
+    Ok(page_ids)
 }
 
 fn build_collection_info_output(
@@ -1347,6 +1366,20 @@ fn sync(db: &Connection, args: CollectionSyncArgs, json: bool) -> Result<()> {
         );
     }
     let stats = vault_sync::sync_collection(db, &args.name)?;
+    // Drain the embedding queue inline so a CLI-only `sync` (no running daemon)
+    // produces semantic results for the pages it just reconciled. Gated by
+    // --no-embed for callers who want to defer embedding work (review #10).
+    let drained_embedding_jobs = if args.no_embed {
+        0
+    } else {
+        match vault_sync::drain_embedding_queue(db) {
+            Ok(drained) => drained,
+            Err(error) => {
+                eprintln!("WARN: cli_sync_embedding_drain_failed error={error}");
+                0
+            }
+        }
+    };
     render_success(
         json,
         serde_json::json!({
@@ -1360,7 +1393,8 @@ fn sync(db: &Connection, args: CollectionSyncArgs, json: bool) -> Result<()> {
             "new": stats.new,
             "missing": stats.missing,
             "uuid_renamed": stats.uuid_renamed,
-            "hash_renamed": stats.hash_renamed
+            "hash_renamed": stats.hash_renamed,
+            "embedded": drained_embedding_jobs
         }),
     )
 }
@@ -3052,6 +3086,7 @@ mod tests {
                 remap_root: None,
                 finalize_pending: true,
                 online: false,
+                no_embed: false,
             },
             false,
         )
@@ -3082,6 +3117,7 @@ mod tests {
                 remap_root: None,
                 finalize_pending: true,
                 online: false,
+                no_embed: false,
             },
             true,
         )
@@ -3113,6 +3149,7 @@ mod tests {
                 remap_root: None,
                 finalize_pending: true,
                 online: false,
+                no_embed: false,
             },
             true,
         )
@@ -3158,6 +3195,7 @@ mod tests {
                 remap_root: Some(remapped_root.path().to_path_buf()),
                 finalize_pending: false,
                 online: false,
+                no_embed: false,
             },
             false,
         )
@@ -3208,6 +3246,7 @@ mod tests {
                 remap_root: Some(remapped_root.path().to_path_buf()),
                 finalize_pending: false,
                 online: false,
+                no_embed: false,
             },
             true,
         )
@@ -3244,6 +3283,7 @@ mod tests {
                 remap_root: Some(remapped_root.path().to_path_buf()),
                 finalize_pending: false,
                 online: false,
+                no_embed: false,
             },
             true,
         )
@@ -3366,6 +3406,7 @@ mod tests {
                 remap_root: None,
                 finalize_pending: false,
                 online: false,
+                no_embed: false,
             },
             true,
         )

--- a/src/commands/put.rs
+++ b/src/commands/put.rs
@@ -160,7 +160,20 @@ fn put_from_cli_string(
     }
     let _lease = vault_sync::start_short_lived_owner_lease_for_root_path(db, &collection.root_path)
         .map_err(anyhow::Error::new)?;
-    put_from_string_with_namespace(db, &canonical_slug, content, namespace, expected_version)
+    put_from_string_with_namespace(db, &canonical_slug, content, namespace, expected_version)?;
+    // Drain the embedding queue inline so CLI-only users (no running daemon)
+    // get semantic results for the page they just wrote. Job claiming is
+    // transactional, so this is safe even if a daemon races us (review #10).
+    match vault_sync::drain_embedding_queue(db) {
+        Ok(drained) if drained > 0 => {
+            println!("Embedded {drained} pending page(s)");
+        }
+        Ok(_) => {}
+        Err(error) => {
+            eprintln!("WARN: cli_put_embedding_drain_failed error={error}");
+        }
+    }
+    Ok(())
 }
 
 #[cfg(not(unix))]

--- a/src/commands/validate.rs
+++ b/src/commands/validate.rs
@@ -370,6 +370,25 @@ fn check_embeddings(db: &Connection, violations: &mut Vec<Violation>) -> Result<
         });
     }
 
+    // 5. Orphaned vec rows: vec0 entries with no backing page_embeddings join
+    // row. These accumulate when a page is deleted without dropping its vectors
+    // (the vec0 table does not cascade with the FK page delete — review #10).
+    let orphan_sql = format!(
+        "SELECT COUNT(*) FROM {vec_table} v \
+         WHERE NOT EXISTS (SELECT 1 FROM page_embeddings pe WHERE pe.vec_rowid = v.rowid)"
+    );
+    let vec_orphan_count: i64 = db.query_row(&orphan_sql, [], |row| row.get(0))?;
+    if vec_orphan_count > 0 {
+        violations.push(Violation {
+            check: "embeddings".into(),
+            violation_type: "vec_orphans".into(),
+            details: serde_json::json!({
+                "orphan_count": vec_orphan_count,
+                "vec_table": vec_table.as_str(),
+            }),
+        });
+    }
+
     Ok(())
 }
 

--- a/src/core/inference.rs
+++ b/src/core/inference.rs
@@ -1434,6 +1434,135 @@ fn search_vec_internal(
     } else {
         ""
     };
+
+    let filters = VecSearchFilters {
+        wing_filter,
+        collection_filter,
+        namespace_filter,
+        include_superseded,
+    };
+
+    // Two-phase KNN retrieval (review item #10). Phase 1 over-fetches a
+    // candidate set from the vec0 SIMD top-k heap via the `MATCH ... k = ?`
+    // form; phase 2 joins those candidate rowids back to `page_embeddings` /
+    // `pages` and applies every business filter, recomputing the cosine score
+    // so it lands on the exact `1.0 - vec_distance_cosine` scale the merge
+    // layer expects. If a selective filter under-fills the candidate set we
+    // escalate the over-fetch (capped) and finally fall back to the original
+    // full-scan query, so results are always identical to brute force.
+    let mut overfetch = std::cmp::max(
+        k.saturating_mul(VEC_KNN_OVERFETCH_MULTIPLIER),
+        VEC_KNN_MIN_OVERFETCH,
+    );
+    loop {
+        if overfetch as i64 >= embedding_count {
+            // Candidate set already spans the whole table; a KNN pass would be
+            // strictly equivalent to the full scan, so just run the full scan.
+            break;
+        }
+
+        let candidate_rowids = knn_candidate_rowids(conn, &vec_table, &query_blob, overfetch)?;
+        let results = run_filtered_vec_query(
+            conn,
+            &vec_table,
+            slug_expr,
+            collection_join,
+            &query_blob,
+            &model_name,
+            &filters,
+            Some(&candidate_rowids),
+            k,
+        )?;
+
+        if results.len() >= k || candidate_rowids.len() < overfetch {
+            // Either we filled the page (the common case) or phase 1 returned
+            // fewer rows than requested, meaning the index is exhausted and a
+            // larger `k` cannot surface more candidates.
+            return Ok(results);
+        }
+
+        let next = overfetch.saturating_mul(VEC_KNN_ESCALATION_MULTIPLIER);
+        if next > VEC_KNN_MAX_OVERFETCH || next <= overfetch {
+            break;
+        }
+        overfetch = next;
+    }
+
+    // Full-scan fallback: no candidate restriction.
+    run_filtered_vec_query(
+        conn,
+        &vec_table,
+        slug_expr,
+        collection_join,
+        &query_blob,
+        &model_name,
+        &filters,
+        None,
+        k,
+    )
+}
+
+/// Initial over-fetch multiplier applied to the requested `k` for the phase-1
+/// KNN candidate set.
+const VEC_KNN_OVERFETCH_MULTIPLIER: usize = 8;
+/// Floor for the phase-1 candidate set so small `k` values still pull a useful
+/// candidate pool through selective filters.
+const VEC_KNN_MIN_OVERFETCH: usize = 256;
+/// Factor by which the over-fetch grows on each escalation when filters
+/// under-fill the requested page.
+const VEC_KNN_ESCALATION_MULTIPLIER: usize = 4;
+/// Cap on the escalated over-fetch before falling back to the full scan.
+const VEC_KNN_MAX_OVERFETCH: usize = 65_536;
+
+/// Business filters shared between the two-phase KNN path and the full-scan
+/// fallback. Bundled so the SQL builder stays a single function.
+struct VecSearchFilters<'a> {
+    wing_filter: Option<&'a str>,
+    collection_filter: Option<i64>,
+    namespace_filter: Option<&'a str>,
+    include_superseded: bool,
+}
+
+/// Phase 1: pull the `k` nearest candidate rowids from the vec0 table via its
+/// SIMD top-k heap. Returns rowids only; the cosine score is recomputed in
+/// phase 2 to guarantee bit-for-bit parity with the full-scan path.
+fn knn_candidate_rowids(
+    conn: &Connection,
+    vec_table: &str,
+    query_blob: &[u8],
+    k: usize,
+) -> Result<Vec<i64>, SearchError> {
+    let sql =
+        format!("SELECT rowid, distance FROM {vec_table} WHERE embedding MATCH ?1 AND k = ?2");
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(rusqlite::params![query_blob, k as i64], |row| {
+        row.get::<_, i64>(0)
+    })?;
+    let mut rowids = Vec::new();
+    for row in rows {
+        rowids.push(row?);
+    }
+    Ok(rowids)
+}
+
+/// Phase 2 (and the full-scan fallback): join candidate rowids — or, when
+/// `candidate_rowids` is `None`, the whole table — back to `page_embeddings` /
+/// `pages`, apply every business filter, and rank by recomputed cosine score.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "this is the single SQL-building seam shared by both retrieval phases; the public wrappers are the right grouping boundary"
+)]
+fn run_filtered_vec_query(
+    conn: &Connection,
+    vec_table: &str,
+    slug_expr: &str,
+    collection_join: &str,
+    query_blob: &[u8],
+    model_name: &str,
+    filters: &VecSearchFilters<'_>,
+    candidate_rowids: Option<&[i64]>,
+    k: usize,
+) -> Result<Vec<SearchResult>, SearchError> {
     let mut sql = format!(
         "SELECT {slug_expr}, p.title, p.summary, \
                 MAX(1.0 - vec_distance_cosine(pev.embedding, ?1)) AS score, \
@@ -1445,20 +1574,23 @@ fn search_vec_internal(
            AND p.quarantined_at IS NULL"
     );
 
-    let mut params: Vec<Box<dyn ToSql>> = vec![Box::new(query_blob), Box::new(model_name)];
+    let mut params: Vec<Box<dyn ToSql>> = vec![
+        Box::new(query_blob.to_vec()),
+        Box::new(model_name.to_owned()),
+    ];
 
-    if let Some(wing) = wing_filter {
+    if let Some(wing) = filters.wing_filter {
         sql.push_str(" AND p.wing = ?3");
         params.push(Box::new(wing.to_owned()));
     }
 
-    if let Some(collection_id) = collection_filter {
+    if let Some(collection_id) = filters.collection_filter {
         sql.push_str(" AND p.collection_id = ?");
         sql.push_str(&(params.len() + 1).to_string());
         params.push(Box::new(collection_id));
     }
 
-    if let Some(namespace) = namespace_filter {
+    if let Some(namespace) = filters.namespace_filter {
         if namespace.is_empty() {
             sql.push_str(" AND p.namespace = ?");
             sql.push_str(&(params.len() + 1).to_string());
@@ -1471,8 +1603,29 @@ fn search_vec_internal(
         }
     }
 
-    if !include_superseded {
+    if !filters.include_superseded {
         sql.push_str(" AND p.superseded_by IS NULL");
+    }
+
+    if let Some(rowids) = candidate_rowids {
+        if rowids.is_empty() {
+            return Ok(Vec::new());
+        }
+        // Rowids are trusted i64s read from `page_embeddings.vec_rowid`, so we
+        // inline them as integer literals rather than binding one parameter
+        // each: the over-fetched candidate set can far exceed SQLite's bound
+        // variable limit (`SQLITE_MAX_VARIABLE_NUMBER`).
+        use std::fmt::Write as _;
+        sql.push_str(" AND pev.rowid IN (");
+        for (index, rowid) in rowids.iter().enumerate() {
+            if index > 0 {
+                sql.push(',');
+            }
+            // i64 Display only ever emits digits and a leading '-', so this is
+            // injection-safe by construction.
+            let _ = write!(sql, "{rowid}");
+        }
+        sql.push(')');
     }
 
     let limit_index = params.len() + 1;
@@ -1616,6 +1769,107 @@ fn existing_vec_rowids(
         rowids.push(row?);
     }
     Ok(rowids)
+}
+
+/// Deletes every `page_embeddings_vec_*` row backing the given pages, across
+/// all registered embedding models, **before** the pages themselves are
+/// deleted. vec0 virtual tables do not participate in SQLite foreign-key
+/// cascades, so bulk page deletes (namespace destroy, collection purge,
+/// reconciler hard-delete, quarantine discard) would otherwise orphan their
+/// vectors permanently (review item #10). Call this inside the same
+/// transaction as the page delete and while the `page_embeddings` rows still
+/// exist, since the vec rowids are resolved through them. Returns the number
+/// of vec rows deleted.
+pub fn delete_page_vec_rows(conn: &Connection, page_ids: &[i64]) -> Result<usize, SearchError> {
+    if page_ids.is_empty() {
+        return Ok(0);
+    }
+
+    // Resolve every (vec_table, vec_rowid) pair the pages reference, grouped by
+    // the model's vec table so we issue one DELETE per table.
+    let mut stmt = conn.prepare(
+        "SELECT em.vec_table, pe.vec_rowid \
+         FROM page_embeddings pe \
+         JOIN embedding_models em ON em.name = pe.model \
+         WHERE pe.page_id = ?1",
+    )?;
+
+    let mut by_table: std::collections::BTreeMap<String, Vec<i64>> =
+        std::collections::BTreeMap::new();
+    for page_id in page_ids {
+        let rows = stmt.query_map([page_id], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+        })?;
+        for row in rows {
+            let (vec_table, vec_rowid) = row?;
+            by_table.entry(vec_table).or_default().push(vec_rowid);
+        }
+    }
+    drop(stmt);
+
+    let mut deleted = 0usize;
+    for (vec_table, rowids) in by_table {
+        if !is_safe_identifier(&vec_table) {
+            return Err(SearchError::Internal {
+                message: format!("unsafe vec table name: {vec_table}"),
+            });
+        }
+        let delete_sql = format!("DELETE FROM {vec_table} WHERE rowid = ?1");
+        for rowid in rowids {
+            deleted += conn.execute(&delete_sql, [rowid])?;
+        }
+    }
+
+    Ok(deleted)
+}
+
+/// Sweeps `page_embeddings_vec_*` rows whose backing `page_embeddings` join row
+/// no longer exists, across every registered embedding model's vec table. This
+/// is the janitor counterpart to [`delete_page_vec_rows`]: it reclaims vectors
+/// that predate the vec-aware delete paths (or were orphaned by a crash between
+/// the `page_embeddings` cascade and a vec delete). Returns the number of
+/// orphaned vec rows removed.
+pub fn sweep_orphaned_vec_rows(conn: &Connection) -> Result<usize, SearchError> {
+    let vec_tables: Vec<String> = {
+        let mut stmt = conn.prepare("SELECT vec_table FROM embedding_models")?;
+        let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
+        let mut tables = Vec::new();
+        for row in rows {
+            tables.push(row?);
+        }
+        tables
+    };
+
+    let mut deleted = 0usize;
+    for vec_table in vec_tables {
+        if !is_safe_identifier(&vec_table) {
+            return Err(SearchError::Internal {
+                message: format!("unsafe vec table name: {vec_table}"),
+            });
+        }
+        // vec0 virtual tables do not support correlated DELETE subqueries
+        // against arbitrary tables on every build, so collect the orphan
+        // rowids first, then delete them by rowid.
+        let select_sql = format!(
+            "SELECT v.rowid FROM {vec_table} v \
+             WHERE NOT EXISTS (SELECT 1 FROM page_embeddings pe WHERE pe.vec_rowid = v.rowid)"
+        );
+        let orphan_rowids: Vec<i64> = {
+            let mut stmt = conn.prepare(&select_sql)?;
+            let rows = stmt.query_map([], |row| row.get::<_, i64>(0))?;
+            let mut ids = Vec::new();
+            for row in rows {
+                ids.push(row?);
+            }
+            ids
+        };
+        let delete_sql = format!("DELETE FROM {vec_table} WHERE rowid = ?1");
+        for rowid in orphan_rowids {
+            deleted += conn.execute(&delete_sql, [rowid])?;
+        }
+    }
+
+    Ok(deleted)
 }
 
 fn normalize(values: &mut [f32]) -> Result<(), InferenceError> {

--- a/src/core/namespace.rs
+++ b/src/core/namespace.rs
@@ -118,6 +118,12 @@ pub fn list_namespaces(conn: &Connection) -> Result<Vec<Namespace>, NamespaceErr
 pub fn destroy_namespace(conn: &Connection, id: &str) -> Result<usize, NamespaceError> {
     validate_namespace_id(id)?;
     let tx = conn.unchecked_transaction()?;
+    // Drop the backing vec0 rows first: they do not cascade with the page
+    // delete, so without this they orphan permanently (review item #10).
+    let page_ids = page_ids_in_namespace(&tx, id)?;
+    crate::core::inference::delete_page_vec_rows(&tx, &page_ids).map_err(|err| {
+        NamespaceError::Sqlite(rusqlite::Error::InvalidParameterName(err.to_string()))
+    })?;
     let deleted_pages = tx.execute("DELETE FROM pages WHERE namespace = ?1", [id])?;
     let deleted_namespaces = tx.execute("DELETE FROM namespaces WHERE id = ?1", [id])?;
     tx.commit()?;
@@ -126,6 +132,16 @@ pub fn destroy_namespace(conn: &Connection, id: &str) -> Result<usize, Namespace
         return Err(NamespaceError::NotFound { id: id.to_owned() });
     }
     Ok(deleted_pages)
+}
+
+fn page_ids_in_namespace(conn: &Connection, id: &str) -> Result<Vec<i64>, NamespaceError> {
+    let mut stmt = conn.prepare("SELECT id FROM pages WHERE namespace = ?1")?;
+    let rows = stmt.query_map([id], |row| row.get::<_, i64>(0))?;
+    let mut page_ids = Vec::new();
+    for row in rows {
+        page_ids.push(row?);
+    }
+    Ok(page_ids)
 }
 
 fn get_namespace(conn: &Connection, id: &str) -> Result<Option<Namespace>, NamespaceError> {

--- a/src/core/quarantine.rs
+++ b/src/core/quarantine.rs
@@ -488,6 +488,11 @@ pub fn discard_quarantined_page(
             counts,
         });
     }
+    // Drop backing vec0 rows before the page delete (they do not cascade with
+    // the FK delete, so otherwise they orphan — review item #10).
+    crate::core::inference::delete_page_vec_rows(conn, &[page.page_id]).map_err(|err| {
+        QuarantineError::Sqlite(rusqlite::Error::InvalidParameterName(err.to_string()))
+    })?;
     conn.execute("DELETE FROM pages WHERE id = ?1", [page.page_id])?;
     eprintln!(
         "INFO: quarantine_discarded collection={} slug={} forced={} exported_before_discard={}",
@@ -706,6 +711,10 @@ pub fn sweep_expired_quarantined_pages(
             );
             continue;
         }
+        // Drop backing vec0 rows before the page delete (item #10).
+        crate::core::inference::delete_page_vec_rows(conn, &[page_id]).map_err(|err| {
+            QuarantineError::Sqlite(rusqlite::Error::InvalidParameterName(err.to_string()))
+        })?;
         conn.execute("DELETE FROM pages WHERE id = ?1", [page_id])?;
         summary.discarded += 1;
         eprintln!(

--- a/src/core/reconciler.rs
+++ b/src/core/reconciler.rs
@@ -2727,6 +2727,11 @@ fn apply_delete_or_quarantine(
         return Ok(());
     }
 
+    // vec0 rows do not cascade with the FK page delete; drop them first so the
+    // hard delete does not orphan the page's vectors (review item #10).
+    crate::core::inference::delete_page_vec_rows(&tx, &[page_id]).map_err(|err| {
+        ReconcileError::DbError(rusqlite::Error::InvalidParameterName(err.to_string()))
+    })?;
     tx.execute("DELETE FROM pages WHERE id = ?1", [page_id])?;
     tx.commit()?;
     summary.hard_deleted += 1;

--- a/src/core/vault_sync/embedding.rs
+++ b/src/core/vault_sync/embedding.rs
@@ -68,7 +68,10 @@ pub(crate) fn resume_orphaned_embedding_jobs(conn: &Connection) -> Result<usize,
 /// failed `run_once` calls so a transient extractor error does not
 /// hot-loop the CPU.
 pub(super) fn run_extraction_worker(db_path: String, stop: Arc<AtomicBool>, session_id: String) {
-    let conn = match Connection::open(&db_path) {
+    // Route through `db::open` so the worker inherits the 5s busy_timeout (and
+    // WAL/sqlite-vec setup) instead of a bare connection that fails fast under
+    // write contention (review item #10, step 4).
+    let conn = match crate::core::db::open(&db_path) {
         Ok(conn) => conn,
         Err(error) => {
             eprintln!(
@@ -103,26 +106,30 @@ pub(super) fn run_extraction_worker(db_path: String, stop: Arc<AtomicBool>, sess
 /// `configured_concurrency()` ready jobs in a single transaction,
 /// then processes them either inline (`:memory:` / single-claim) or
 /// in parallel on short-lived worker threads.
-pub fn drain_embedding_queue(conn: &Connection) -> Result<(), VaultSyncError> {
+pub fn drain_embedding_queue(conn: &Connection) -> Result<usize, VaultSyncError> {
     let claimed = claim_embedding_jobs(conn)?;
     if claimed.is_empty() {
-        return Ok(());
+        return Ok(0);
     }
 
     let db_path = database_path(conn).unwrap_or_default();
     if db_path.is_empty() || db_path == ":memory:" || claimed.len() == 1 {
+        let mut processed = 0usize;
         for job in claimed {
-            if let Err(error) = process_embedding_job_on_connection(conn, job.id, job.page_id) {
-                mark_embedding_job_failed(conn, job.id, &error)?;
-                if job.attempt_count >= 5 {
-                    eprintln!(
-                        "WARN: embedding_job_failed_permanently job_id={} page_id={} error={}",
-                        job.id, job.page_id, error
-                    );
+            match process_embedding_job_on_connection(conn, job.id, job.page_id) {
+                Ok(()) => processed += 1,
+                Err(error) => {
+                    mark_embedding_job_failed(conn, job.id, &error)?;
+                    if job.attempt_count >= 5 {
+                        eprintln!(
+                            "WARN: embedding_job_failed_permanently job_id={} page_id={} error={}",
+                            job.id, job.page_id, error
+                        );
+                    }
                 }
             }
         }
-        return Ok(());
+        return Ok(processed);
     }
 
     let mut handles = Vec::new();
@@ -142,9 +149,10 @@ pub fn drain_embedding_queue(conn: &Connection) -> Result<(), VaultSyncError> {
         }));
     }
 
+    let mut processed = 0usize;
     for handle in handles {
         match handle.join() {
-            Ok(Ok(_)) => {}
+            Ok(Ok(_)) => processed += 1,
             Ok(Err(error)) => {
                 eprintln!("WARN: embedding_job_failed error={error}");
             }
@@ -154,7 +162,7 @@ pub fn drain_embedding_queue(conn: &Connection) -> Result<(), VaultSyncError> {
         }
     }
 
-    Ok(())
+    Ok(processed)
 }
 
 #[derive(Debug, Clone)]

--- a/src/core/vault_sync/mod.rs
+++ b/src/core/vault_sync/mod.rs
@@ -97,6 +97,11 @@ const DEFAULT_MANIFEST_INCOMPLETE_ESCALATION_SECS: i64 = 1800;
 const QUARANTINE_SWEEP_INTERVAL_SECS: u64 = 24 * 60 * 60;
 const FULL_HASH_AUDIT_SWEEP_INTERVAL_SECS: u64 = 24 * 60 * 60;
 const RAW_IMPORT_TTL_SWEEP_INTERVAL_SECS: u64 = 24 * 60 * 60;
+/// Cadence for the orphaned-vector janitor sweep. vec0 rows are deleted inline
+/// on every page-delete path, so this is a slow backstop reclaiming vectors
+/// orphaned before the vec-aware paths existed or by a crash mid-delete
+/// (review item #10).
+const VEC_ORPHAN_SWEEP_INTERVAL_SECS: u64 = 24 * 60 * 60;
 const DEFAULT_FULL_HASH_AUDIT_DAYS: i64 = 7;
 #[cfg(unix)]
 const SELF_WRITE_DEDUP_TTL_SECS: u64 = 5;
@@ -2891,6 +2896,8 @@ fn run_supervisor_loop(
         Instant::now() - Duration::from_secs(FULL_HASH_AUDIT_SWEEP_INTERVAL_SECS);
     let mut last_raw_import_ttl_sweep =
         Instant::now() - Duration::from_secs(RAW_IMPORT_TTL_SWEEP_INTERVAL_SECS);
+    let mut last_vec_orphan_sweep =
+        Instant::now() - Duration::from_secs(VEC_ORPHAN_SWEEP_INTERVAL_SECS);
     let mut last_embedding_drain =
         Instant::now() - Duration::from_secs(embedding::drain_interval_secs());
     while !stop_signal.load(Ordering::SeqCst) {
@@ -3010,6 +3017,26 @@ fn run_supervisor_loop(
                     );
                 }
                 last_raw_import_ttl_sweep = Instant::now();
+            }
+            if last_vec_orphan_sweep.elapsed()
+                >= Duration::from_secs(VEC_ORPHAN_SWEEP_INTERVAL_SECS)
+            {
+                match crate::core::inference::sweep_orphaned_vec_rows(&conn) {
+                    Ok(removed) if removed > 0 => {
+                        eprintln!(
+                            "INFO: vec_orphan_sweep session_id_for_thread={} removed={}",
+                            session_id_for_thread, removed
+                        );
+                    }
+                    Ok(_) => {}
+                    Err(error) => {
+                        eprintln!(
+                            "WARN: vec_orphan_sweep_failed session_id_for_thread={} error={}",
+                            session_id_for_thread, error
+                        );
+                    }
+                }
+                last_vec_orphan_sweep = Instant::now();
             }
             let _ = run_rcrt_pass(&conn, &session_id_for_thread);
             let _ = sync_supervisor_handles(&conn, &session_id_for_thread);

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1243,7 +1243,9 @@ mod tests {
             })
             .unwrap();
 
-        let rows: Vec<serde_json::Value> = serde_json::from_str(&extract_text(&result)).unwrap();
+        // memory_query now returns a {results, pending_embedding_jobs?} envelope.
+        let envelope: serde_json::Value = serde_json::from_str(&extract_text(&result)).unwrap();
+        let rows = envelope["results"].as_array().cloned().unwrap_or_default();
         let gap_count: i64 = server
             .db
             .lock()

--- a/src/mcp/tools/search.rs
+++ b/src/mcp/tools/search.rs
@@ -8,17 +8,54 @@
 
 use rmcp::model::{CallToolResult, Content};
 use rmcp::tool;
+use rusqlite::Connection;
+use serde::Serialize;
 
 use crate::core::fts::{expand_numeric_fts_query, sanitize_fts_query, search_fts, FtsQuery};
 use crate::core::gaps;
 use crate::core::namespace;
 use crate::core::progressive::progressive_retrieve_with_namespace;
 use crate::core::search::{hybrid_search, HybridSearch};
+use crate::core::types::SearchResult;
 use crate::mcp::errors::{map_namespace_error, map_search_error, map_serialize_error};
 use crate::mcp::server::{
     resolve_memory_collection_filter_for_mcp, MemoryQueryInput, MemorySearchInput, QuaidServer,
 };
 use crate::mcp::validation::MAX_LIMIT;
+
+/// Read-side response envelope for `memory_query` / `memory_search`.
+///
+/// The `results` array is unconditionally present so existing consumers keep
+/// the familiar list shape. `pending_embedding_jobs` is a staleness hint
+/// (review item #10): when the embedding queue is non-empty — e.g. a CLI-only
+/// write happened with no daemon to drain it — semantic results may be stale,
+/// so the count is surfaced. It is omitted entirely when the queue is empty.
+#[derive(Serialize)]
+struct ReadResponse {
+    results: Vec<SearchResult>,
+    #[serde(skip_serializing_if = "is_zero")]
+    pending_embedding_jobs: i64,
+}
+
+#[expect(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "serde skip_serializing_if requires a `&T -> bool` predicate signature"
+)]
+fn is_zero(value: &i64) -> bool {
+    *value == 0
+}
+
+/// Counts queued (pending or failed-but-retryable) embedding jobs so the read
+/// tools can warn that semantic results may not yet reflect recent writes.
+fn pending_embedding_job_count(conn: &Connection) -> i64 {
+    conn.query_row(
+        "SELECT COUNT(*) FROM embedding_jobs \
+         WHERE job_state IN ('pending', 'failed', 'running')",
+        [],
+        |row| row.get(0),
+    )
+    .unwrap_or(0)
+}
 
 impl QuaidServer {
     /// `memory_query` MCP tool: run hybrid semantic + FTS5 retrieval with
@@ -93,7 +130,11 @@ impl QuaidServer {
             _ => results,
         };
 
-        let json = serde_json::to_string_pretty(&results).map_err(map_serialize_error)?;
+        let response = ReadResponse {
+            pending_embedding_jobs: pending_embedding_job_count(&db),
+            results,
+        };
+        let json = serde_json::to_string_pretty(&response).map_err(map_serialize_error)?;
         Ok(CallToolResult::success(vec![Content::text(json)]))
     }
 
@@ -132,7 +173,11 @@ impl QuaidServer {
         )
         .map_err(map_search_error)?;
 
-        let json = serde_json::to_string_pretty(&results).map_err(map_serialize_error)?;
+        let response = ReadResponse {
+            pending_embedding_jobs: pending_embedding_job_count(&db),
+            results,
+        };
+        let json = serde_json::to_string_pretty(&response).map_err(map_serialize_error)?;
         Ok(CallToolResult::success(vec![Content::text(json)]))
     }
 }

--- a/tests/cli_collection_platform_gates.rs
+++ b/tests/cli_collection_platform_gates.rs
@@ -56,6 +56,7 @@ fn sync_refuses_windows_platform() {
             remap_root: None,
             finalize_pending: false,
             online: false,
+            no_embed: false,
         }),
         true,
     )

--- a/tests/cli_collection_sync.rs
+++ b/tests/cli_collection_sync.rs
@@ -51,6 +51,7 @@ fn sync_finalize_pending_uses_external_finalize_path() {
             remap_root: None,
             finalize_pending: true,
             online: false,
+            no_embed: false,
         }),
         true,
     )
@@ -149,6 +150,7 @@ fn sync_without_flags_requires_active_root_collection() {
             remap_root: None,
             finalize_pending: false,
             online: false,
+            no_embed: false,
         }),
         true,
     )
@@ -178,6 +180,7 @@ fn sync_without_flags_refuses_restore_in_progress_state() {
             remap_root: None,
             finalize_pending: false,
             online: false,
+            no_embed: false,
         }),
         true,
     )
@@ -221,6 +224,7 @@ fn sync_without_flags_does_not_finalize_pending_restore_state() {
             remap_root: None,
             finalize_pending: false,
             online: false,
+            no_embed: false,
         }),
         true,
     )
@@ -262,6 +266,7 @@ fn sync_without_flags_refuses_restore_integrity_blocked_state() {
             remap_root: None,
             finalize_pending: false,
             online: false,
+            no_embed: false,
         }),
         true,
     )
@@ -302,6 +307,7 @@ fn sync_without_flags_does_not_clear_integrity_or_reconcile_halt_markers() {
             remap_root: None,
             finalize_pending: false,
             online: false,
+            no_embed: false,
         }),
         true,
     )

--- a/tests/cli_sync_inline_embed.rs
+++ b/tests/cli_sync_inline_embed.rs
@@ -1,0 +1,143 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::print_stdout,
+    reason = "integration tests panic on setup failure and print diagnostics"
+)]
+
+//! CLI write-path inline embedding drain (review item #10, step 3 — the DAB
+//! #220 "footgun"): a CLI-only `collection sync` (no running serve daemon) must
+//! leave the just-reconciled pages semantically searchable, and `--no-embed`
+//! must opt out and leave the queue pending.
+
+#![cfg(unix)]
+
+use std::fs;
+
+use quaid::commands::collection::{run, CollectionAction, CollectionAddArgs, CollectionSyncArgs};
+use quaid::core::db;
+use quaid::core::inference::search_vec;
+use rusqlite::Connection;
+
+fn open_test_db() -> (tempfile::TempDir, Connection) {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("memory.db");
+    let conn = db::open(db_path.to_str().unwrap()).unwrap();
+    (dir, conn)
+}
+
+fn pending_jobs(conn: &Connection) -> i64 {
+    conn.query_row(
+        "SELECT COUNT(*) FROM embedding_jobs WHERE job_state IN ('pending', 'failed', 'running')",
+        [],
+        |row| row.get(0),
+    )
+    .unwrap()
+}
+
+fn attach_with_page(conn: &Connection, vault: &std::path::Path, body: &str) {
+    fs::create_dir_all(vault.join("notes")).unwrap();
+    fs::write(
+        vault.join("notes").join("topic.md"),
+        format!("---\ntitle: Topic\ntype: concept\n---\n## State\n{body}\n"),
+    )
+    .unwrap();
+    run(
+        conn,
+        CollectionAction::Add(CollectionAddArgs {
+            name: "work".to_owned(),
+            path: vault.to_path_buf(),
+            read_only: false,
+            writable: true,
+            write_quaid_id: false,
+            namespace: None,
+        }),
+        true,
+    )
+    .unwrap();
+}
+
+#[test]
+fn cli_sync_without_daemon_embeds_new_pages() {
+    let (_db_dir, conn) = open_test_db();
+    let vault = tempfile::TempDir::new().unwrap();
+    attach_with_page(
+        &conn,
+        vault.path(),
+        "distributed consensus and quorum replication",
+    );
+
+    // Attach reconciled the file and enqueued an embedding job, but nothing has
+    // drained it yet (no daemon).
+    assert!(
+        pending_jobs(&conn) >= 1,
+        "attach must enqueue an embedding job that is not yet drained"
+    );
+    assert!(
+        search_vec("consensus replication", 5, None, None, &conn)
+            .unwrap()
+            .is_empty(),
+        "semantic search must be empty before any drain (the footgun)"
+    );
+
+    // A plain CLI sync (no daemon) drains the queue inline.
+    run(
+        &conn,
+        CollectionAction::Sync(CollectionSyncArgs {
+            name: "work".to_owned(),
+            remap_root: None,
+            finalize_pending: false,
+            online: false,
+            no_embed: false,
+        }),
+        true,
+    )
+    .unwrap();
+
+    assert_eq!(
+        pending_jobs(&conn),
+        0,
+        "sync must drain the embedding queue inline"
+    );
+    let results = search_vec("consensus replication", 5, None, None, &conn).unwrap();
+    assert!(
+        results.iter().any(|r| r.slug == "notes/topic"),
+        "sync without a daemon must make the new page semantically searchable: {results:?}"
+    );
+}
+
+#[test]
+fn cli_sync_no_embed_leaves_queue_pending() {
+    let (_db_dir, conn) = open_test_db();
+    let vault = tempfile::TempDir::new().unwrap();
+    attach_with_page(&conn, vault.path(), "supply chain logistics optimization");
+
+    let before = pending_jobs(&conn);
+    assert!(before >= 1);
+
+    run(
+        &conn,
+        CollectionAction::Sync(CollectionSyncArgs {
+            name: "work".to_owned(),
+            remap_root: None,
+            finalize_pending: false,
+            online: false,
+            no_embed: true,
+        }),
+        true,
+    )
+    .unwrap();
+
+    assert_eq!(
+        pending_jobs(&conn),
+        before,
+        "--no-embed must leave the embedding queue pending"
+    );
+    assert!(
+        search_vec("logistics optimization", 5, None, None, &conn)
+            .unwrap()
+            .is_empty(),
+        "--no-embed must not produce semantic results"
+    );
+}

--- a/tests/common/mcp_harness.rs
+++ b/tests/common/mcp_harness.rs
@@ -110,3 +110,15 @@ pub fn extract_text(result: &CallToolResult) -> String {
         .collect::<Vec<_>>()
         .join("")
 }
+
+/// Extracts the `results` array from a `memory_query` / `memory_search`
+/// response envelope (which also carries the optional `pending_embedding_jobs`
+/// staleness hint). Use this instead of parsing the payload as a bare array.
+pub fn extract_query_results(result: &CallToolResult) -> Vec<serde_json::Value> {
+    let value: serde_json::Value = serde_json::from_str(&extract_text(result)).unwrap();
+    value
+        .get("results")
+        .and_then(|results| results.as_array())
+        .cloned()
+        .unwrap_or_default()
+}

--- a/tests/extraction_end_to_end_smoke.rs
+++ b/tests/extraction_end_to_end_smoke.rs
@@ -210,7 +210,8 @@ fn turn_capture_close_extract_fact_and_search_smoke() {
             include_superseded: Some(false),
         })
         .unwrap();
-    let rows: Vec<serde_json::Value> = serde_json::from_str(&extract_text(&search)).unwrap();
+    let search_envelope: serde_json::Value = serde_json::from_str(&extract_text(&search)).unwrap();
+    let rows = search_envelope["results"].as_array().cloned().unwrap();
     assert!(
         rows.iter().any(|row| {
             row["summary"]

--- a/tests/file_edit_supersede.rs
+++ b/tests/file_edit_supersede.rs
@@ -36,6 +36,14 @@ fn extract_text(result: &rmcp::model::CallToolResult) -> String {
         .join("")
 }
 
+/// Extracts the `results` array from a `memory_query` / `memory_search`
+/// response envelope (the envelope also carries a `pending_embedding_jobs`
+/// staleness hint).
+fn search_results(result: &rmcp::model::CallToolResult) -> Vec<Value> {
+    let envelope: Value = serde_json::from_str(&extract_text(result)).unwrap();
+    envelope["results"].as_array().cloned().unwrap_or_default()
+}
+
 fn put_page(server: &QuaidServer, slug: &str, content: &str) {
     server
         .memory_put(MemoryPutInput {
@@ -191,7 +199,7 @@ fn editing_chained_extracted_preference_preserves_one_linear_chain() {
     assert!(live_file.contains("corrected_via: file_edit"));
     assert!(live_file.contains(&format!("supersedes: {archived_slug}")));
 
-    let search_default: Vec<Value> = serde_json::from_str(&extract_text(
+    let search_default: Vec<Value> = search_results(
         &server
             .memory_search(MemorySearchInput {
                 query: "shared marker".to_string(),
@@ -202,14 +210,13 @@ fn editing_chained_extracted_preference_preserves_one_linear_chain() {
                 include_superseded: None,
             })
             .unwrap(),
-    ))
-    .unwrap();
+    );
     assert_eq!(
         slugs(&search_default),
         vec!["default::preferences/foo".to_string()]
     );
 
-    let search_history: Vec<Value> = serde_json::from_str(&extract_text(
+    let search_history: Vec<Value> = search_results(
         &server
             .memory_search(MemorySearchInput {
                 query: "shared marker".to_string(),
@@ -220,8 +227,7 @@ fn editing_chained_extracted_preference_preserves_one_linear_chain() {
                 include_superseded: Some(true),
             })
             .unwrap(),
-    ))
-    .unwrap();
+    );
     assert_eq!(
         slugs(&search_history),
         vec![

--- a/tests/mcp_server_query_search_list.rs
+++ b/tests/mcp_server_query_search_list.rs
@@ -15,8 +15,8 @@
 #[path = "common/mcp_harness.rs"]
 mod harness;
 use harness::{
-    create_page, create_page_in_collection, extract_text, insert_collection, open_test_db,
-    set_collection_state,
+    create_page, create_page_in_collection, extract_query_results, extract_text, insert_collection,
+    open_test_db, set_collection_state,
 };
 use quaid::core::conversation::turn_writer;
 use quaid::mcp::server::{
@@ -61,7 +61,7 @@ fn memory_query_auto_depth_expands_linked_results() {
         })
         .unwrap();
 
-    let rows: Vec<serde_json::Value> = serde_json::from_str(&extract_text(&result)).unwrap();
+    let rows = extract_query_results(&result);
     assert!(rows
         .iter()
         .any(|row| row["slug"] == "default::concepts/child"));
@@ -109,7 +109,7 @@ fn memory_query_auto_depth_does_not_expand_across_collections() {
         })
         .unwrap();
 
-    let rows: Vec<serde_json::Value> = serde_json::from_str(&extract_text(&result)).unwrap();
+    let rows = extract_query_results(&result);
     assert!(
         !rows
             .iter()
@@ -147,7 +147,7 @@ fn memory_query_explicit_collection_filter_returns_only_named_collection() {
         })
         .unwrap();
 
-    let rows: Vec<serde_json::Value> = serde_json::from_str(&extract_text(&result)).unwrap();
+    let rows = extract_query_results(&result);
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0]["slug"], "work::notes/work-hit");
 }
@@ -181,7 +181,7 @@ fn memory_query_defaults_to_write_target_when_multiple_collections_are_active() 
         })
         .unwrap();
 
-    let rows: Vec<serde_json::Value> = serde_json::from_str(&extract_text(&result)).unwrap();
+    let rows = extract_query_results(&result);
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0]["slug"], "default::notes/default-target");
 }
@@ -223,7 +223,7 @@ fn memory_query_defaults_to_memory_collection_when_dedicated_memory_location_is_
         })
         .unwrap();
 
-    let rows: Vec<serde_json::Value> = serde_json::from_str(&extract_text(&result)).unwrap();
+    let rows = extract_query_results(&result);
     assert_eq!(rows.len(), 1);
     assert_eq!(
         rows[0]["slug"],
@@ -252,8 +252,79 @@ fn memory_search_returns_matching_pages() {
         })
         .unwrap();
 
-    let rows: Vec<serde_json::Value> = serde_json::from_str(&extract_text(&result)).unwrap();
+    let rows = extract_query_results(&result);
     assert_eq!(rows[0]["slug"], "default::companies/acme");
+}
+
+#[test]
+fn read_responses_surface_pending_embedding_jobs_hint() {
+    let (_dir, conn) = open_test_db();
+    let server = QuaidServer::new(conn);
+    // A CLI-style write through the MCP put enqueues an embedding job that no
+    // daemon has drained, so the read tools must warn about the stale queue.
+    create_page(
+        &server,
+        "companies/acme",
+        "---\ntitle: Acme\ntype: company\n---\nAcme builds fundraising software.\n",
+    );
+
+    let search = server
+        .memory_search(MemorySearchInput {
+            query: "fundraising".to_string(),
+            collection: None,
+            namespace: None,
+            wing: None,
+            limit: None,
+            include_superseded: None,
+        })
+        .unwrap();
+    let envelope: serde_json::Value = serde_json::from_str(&extract_text(&search)).unwrap();
+    assert!(
+        envelope["pending_embedding_jobs"].as_i64().unwrap_or(0) >= 1,
+        "memory_search must surface the pending-embedding-jobs hint when the \
+         queue is non-empty: {envelope}"
+    );
+
+    let query = server
+        .memory_query(MemoryQueryInput {
+            query: "fundraising".to_string(),
+            collection: None,
+            namespace: None,
+            wing: None,
+            limit: None,
+            depth: None,
+            include_superseded: None,
+        })
+        .unwrap();
+    let query_envelope: serde_json::Value = serde_json::from_str(&extract_text(&query)).unwrap();
+    assert!(
+        query_envelope["pending_embedding_jobs"]
+            .as_i64()
+            .unwrap_or(0)
+            >= 1,
+        "memory_query must surface the pending-embedding-jobs hint: {query_envelope}"
+    );
+
+    // With an empty queue the hint is omitted entirely.
+    let empty_dir = tempfile::TempDir::new().unwrap();
+    let empty_conn =
+        quaid::core::db::open(empty_dir.path().join("memory.db").to_str().unwrap()).unwrap();
+    let empty_server = QuaidServer::new(empty_conn);
+    let empty = empty_server
+        .memory_search(MemorySearchInput {
+            query: "nothing".to_string(),
+            collection: None,
+            namespace: None,
+            wing: None,
+            limit: None,
+            include_superseded: None,
+        })
+        .unwrap();
+    let empty_envelope: serde_json::Value = serde_json::from_str(&extract_text(&empty)).unwrap();
+    assert!(
+        empty_envelope.get("pending_embedding_jobs").is_none(),
+        "the staleness hint must be omitted when the queue is empty: {empty_envelope}"
+    );
 }
 
 #[test]
@@ -291,7 +362,7 @@ fn memory_search_defaults_to_memory_collection_when_dedicated_memory_location_is
         })
         .unwrap();
 
-    let rows: Vec<serde_json::Value> = serde_json::from_str(&extract_text(&result)).unwrap();
+    let rows = extract_query_results(&result);
     assert_eq!(rows.len(), 1);
     assert_eq!(
         rows[0]["slug"],
@@ -318,13 +389,16 @@ fn memory_search_natural_language_question_mark_returns_valid_response() {
         result.is_ok(),
         "memory_search with '?' must not return an MCP error: {result:?}"
     );
-    // The response content must parse as a JSON array (empty or populated).
+    // The response content must parse as a JSON envelope whose `results` is an
+    // array (empty or populated).
     let text = extract_text(&result.unwrap());
     let parsed: serde_json::Value =
         serde_json::from_str(&text).expect("memory_search response must be valid JSON");
     assert!(
-        parsed.is_array(),
-        "memory_search response must be a JSON array"
+        parsed
+            .get("results")
+            .is_some_and(serde_json::Value::is_array),
+        "memory_search response must carry a `results` array"
     );
 }
 
@@ -356,7 +430,7 @@ fn memory_search_explicit_collection_filter_returns_only_named_collection() {
         })
         .unwrap();
 
-    let rows: Vec<serde_json::Value> = serde_json::from_str(&extract_text(&result)).unwrap();
+    let rows = extract_query_results(&result);
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0]["slug"], "work::notes/work-hit");
 }
@@ -385,7 +459,7 @@ fn memory_search_defaults_to_single_active_collection() {
         })
         .unwrap();
 
-    let rows: Vec<serde_json::Value> = serde_json::from_str(&extract_text(&result)).unwrap();
+    let rows = extract_query_results(&result);
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0]["slug"], "work::notes/only-active");
 }

--- a/tests/search_hardening.rs
+++ b/tests/search_hardening.rs
@@ -249,8 +249,10 @@ fn call_memory_search_question_query_returns_json_array() {
 
     let parsed = parse_stdout_json(&output);
     assert!(
-        parsed.is_array(),
-        "memory_search call must emit a JSON array"
+        parsed
+            .get("results")
+            .is_some_and(serde_json::Value::is_array),
+        "memory_search call must emit a `results` array: {parsed:?}"
     );
 }
 
@@ -439,8 +441,10 @@ fn memory_search_compound_query_returns_valid_json_array() {
 
     let parsed = parse_stdout_json(&output);
     assert!(
-        parsed.is_array(),
-        "memory_search must always emit a JSON array (may be empty for compound-term AND miss)"
+        parsed
+            .get("results")
+            .is_some_and(serde_json::Value::is_array),
+        "memory_search must always emit a `results` array (may be empty for compound-term AND miss): {parsed:?}"
     );
 }
 
@@ -508,7 +512,9 @@ fn memory_search_numeric_query_matches_abbreviated_number_forms() {
     );
 
     let parsed = parse_stdout_json(&output);
-    let results = parsed.as_array().expect("output must be a JSON array");
+    let results = parsed["results"]
+        .as_array()
+        .expect("output must carry a `results` array");
     assert!(
         result_slugs(results).contains("default::journal/2026-04-15"),
         "memory_search numeric alias expansion should match $75K content: {results:?}"
@@ -579,7 +585,9 @@ fn memory_search_numeric_query_matches_grouped_number_forms() {
     );
 
     let parsed = parse_stdout_json(&output);
-    let results = parsed.as_array().expect("output must be a JSON array");
+    let results = parsed["results"]
+        .as_array()
+        .expect("output must carry a `results` array");
     assert!(
         result_slugs(results).contains("default::journal/2026-04-16"),
         "memory_search numeric alias expansion should match 75,000 content: {results:?}"

--- a/tests/supersede_chain.rs
+++ b/tests/supersede_chain.rs
@@ -60,6 +60,14 @@ fn extract_text(result: &rmcp::model::CallToolResult) -> String {
         .join("")
 }
 
+/// Extracts the `results` array from a `memory_query` / `memory_search`
+/// response envelope (the envelope also carries a `pending_embedding_jobs`
+/// staleness hint).
+fn search_results(result: &rmcp::model::CallToolResult) -> Vec<Value> {
+    let envelope: Value = serde_json::from_str(&extract_text(result)).unwrap();
+    envelope["results"].as_array().cloned().unwrap_or_default()
+}
+
 fn put_page(server: &QuaidServer, slug: &str, content: &str, expected_version: Option<i64>) {
     server
         .memory_put(MemoryPutInput {
@@ -219,7 +227,7 @@ fn retrieval_defaults_to_heads_and_include_superseded_restores_history() {
         None,
     );
 
-    let default_search: Vec<Value> = serde_json::from_str(&extract_text(
+    let default_search: Vec<Value> = search_results(
         &server
             .memory_search(MemorySearchInput {
                 query: "shared retrieval marker".to_string(),
@@ -230,9 +238,8 @@ fn retrieval_defaults_to_heads_and_include_superseded_restores_history() {
                 include_superseded: None,
             })
             .unwrap(),
-    ))
-    .unwrap();
-    let historical_search: Vec<Value> = serde_json::from_str(&extract_text(
+    );
+    let historical_search: Vec<Value> = search_results(
         &server
             .memory_search(MemorySearchInput {
                 query: "shared retrieval marker".to_string(),
@@ -243,8 +250,7 @@ fn retrieval_defaults_to_heads_and_include_superseded_restores_history() {
                 include_superseded: Some(true),
             })
             .unwrap(),
-    ))
-    .unwrap();
+    );
     assert_eq!(slugs(&default_search), vec!["default::facts/c".to_string()]);
     assert_eq!(
         slugs(&historical_search),
@@ -255,7 +261,7 @@ fn retrieval_defaults_to_heads_and_include_superseded_restores_history() {
         ]
     );
 
-    let default_query: Vec<Value> = serde_json::from_str(&extract_text(
+    let default_query: Vec<Value> = search_results(
         &server
             .memory_query(MemoryQueryInput {
                 query: "shared retrieval marker".to_string(),
@@ -267,9 +273,8 @@ fn retrieval_defaults_to_heads_and_include_superseded_restores_history() {
                 include_superseded: None,
             })
             .unwrap(),
-    ))
-    .unwrap();
-    let historical_query: Vec<Value> = serde_json::from_str(&extract_text(
+    );
+    let historical_query: Vec<Value> = search_results(
         &server
             .memory_query(MemoryQueryInput {
                 query: "shared retrieval marker".to_string(),
@@ -281,8 +286,7 @@ fn retrieval_defaults_to_heads_and_include_superseded_restores_history() {
                 include_superseded: Some(true),
             })
             .unwrap(),
-    ))
-    .unwrap();
+    );
     assert_eq!(slugs(&default_query), vec!["default::facts/c".to_string()]);
     assert_eq!(
         slugs(&historical_query),

--- a/tests/validate_vec_orphans.rs
+++ b/tests/validate_vec_orphans.rs
@@ -1,0 +1,82 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    reason = "integration tests panic on setup failure"
+)]
+
+//! `quaid validate` must detect orphaned vec rows (vec0 entries whose backing
+//! `page_embeddings` join row is gone) in addition to the pre-existing
+//! `stale_vec_rowid` (pe → vec) staleness check — review item #10.
+
+use quaid::commands::embed::run_with_batch;
+use quaid::commands::validate::{execute_validate, CheckFlags};
+use quaid::core::db;
+use rusqlite::Connection;
+use uuid::Uuid;
+
+fn open_test_db() -> Connection {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("memory.db");
+    let conn = db::open(db_path.to_str().unwrap()).unwrap();
+    std::mem::forget(dir);
+    conn
+}
+
+fn insert_page(conn: &Connection, slug: &str) {
+    conn.execute(
+        "INSERT INTO pages
+             (slug, uuid, type, title, summary, compiled_truth, timeline, frontmatter, wing, room, version)
+         VALUES (?1, ?2, 'concept', ?1, '', ?3, '', '{}', '', '', 1)",
+        rusqlite::params![
+            slug,
+            Uuid::now_v7().to_string(),
+            format!("## State\n{slug} has enough content to embed.")
+        ],
+    )
+    .unwrap();
+}
+
+fn embeddings_only_flags() -> CheckFlags {
+    CheckFlags {
+        links: false,
+        assertions: false,
+        embeddings: true,
+    }
+}
+
+#[test]
+fn validate_detects_orphaned_vec_rows() {
+    let conn = open_test_db();
+    insert_page(&conn, "notes/orphan-source");
+    run_with_batch(&conn, None, true, false, Some(8)).unwrap();
+
+    // A clean store has no orphans.
+    let clean = execute_validate(&conn, &embeddings_only_flags()).unwrap();
+    assert!(
+        !clean
+            .violations
+            .iter()
+            .any(|v| v.violation_type == "vec_orphans"),
+        "freshly embedded store must not report vec orphans: {:?}",
+        clean.violations
+    );
+
+    // Simulate a legacy delete path that dropped the page_embeddings join row
+    // but left the vec0 row behind, orphaning the vector.
+    conn.execute("DELETE FROM page_embeddings", []).unwrap();
+
+    let report = execute_validate(&conn, &embeddings_only_flags()).unwrap();
+    let orphan = report
+        .violations
+        .iter()
+        .find(|v| v.violation_type == "vec_orphans")
+        .expect("validate must report vec_orphans for a dangling vec row");
+    assert_eq!(orphan.check, "embeddings");
+    assert!(
+        orphan.details["orphan_count"].as_i64().unwrap() >= 1,
+        "orphan_count must be reported: {:?}",
+        orphan.details
+    );
+    assert!(!report.passed, "report with orphans must not pass");
+}

--- a/tests/vector_knn_scalability.rs
+++ b/tests/vector_knn_scalability.rs
@@ -1,0 +1,413 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::print_stdout,
+    reason = "integration tests panic on setup failure and print diagnostics"
+)]
+
+//! Integration coverage for review item #10 (vector index scalability):
+//!
+//! * two-phase KNN retrieval returns bit-for-bit the same ranked top-k and
+//!   scores as the brute-force full scan, under every business filter
+//!   (collection / namespace / wing / superseded / quarantine);
+//! * the larger-than-over-fetch corpus exercises the vec0 `MATCH ... k = ?`
+//!   heap path (not just the full-scan fallback);
+//! * bulk page-delete paths (`destroy_namespace`, collection purge) drop the
+//!   backing vec0 rows so the vec table count returns to zero;
+//! * `validate` surfaces orphaned vec rows (vec → page_embeddings dangling).
+
+use quaid::commands::collection::{self, CollectionAction};
+use quaid::commands::embed::run_with_batch;
+use quaid::core::db;
+use quaid::core::inference::search_vec_with_namespace_filtered;
+use quaid::core::namespace;
+use rusqlite::Connection;
+use uuid::Uuid;
+
+fn open_test_db() -> Connection {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("memory.db");
+    let conn = db::open(db_path.to_str().unwrap()).unwrap();
+    // Keep the temp dir alive for the life of the connection.
+    std::mem::forget(dir);
+    conn
+}
+
+#[allow(clippy::too_many_arguments)]
+fn insert_page(
+    conn: &Connection,
+    slug: &str,
+    wing: &str,
+    namespace: &str,
+    collection_id: i64,
+    body: &str,
+) {
+    conn.execute(
+        "INSERT INTO pages
+             (slug, uuid, namespace, collection_id, type, title, summary,
+              compiled_truth, timeline, frontmatter, wing, room, version)
+         VALUES (?1, ?2, ?3, ?4, 'concept', ?1, '', ?5, '', '{}', ?6, '', 1)",
+        rusqlite::params![
+            slug,
+            Uuid::now_v7().to_string(),
+            namespace,
+            collection_id,
+            format!("## State\n{body}"),
+            wing,
+        ],
+    )
+    .unwrap();
+}
+
+/// `(label, wing, collection, namespace, include_superseded)` for one parity
+/// case in [`knn_matches_brute_force_under_every_filter`].
+type FilterCase = (
+    &'static str,
+    Option<&'static str>,
+    Option<i64>,
+    Option<&'static str>,
+    bool,
+);
+
+fn vec_row_count(conn: &Connection) -> i64 {
+    conn.query_row("SELECT COUNT(*) FROM page_embeddings_vec_384", [], |row| {
+        row.get(0)
+    })
+    .unwrap()
+}
+
+/// The pre-KNN brute-force query, kept verbatim in the test as the parity
+/// oracle. Mirrors `search_vec_internal`'s old full-scan SQL: every chunk is
+/// scored with `1.0 - vec_distance_cosine`, then grouped per page.
+fn brute_force(
+    conn: &Connection,
+    query: &str,
+    k: usize,
+    wing: Option<&str>,
+    collection: Option<i64>,
+    namespace_filter: Option<&str>,
+    include_superseded: bool,
+) -> Vec<(String, f64)> {
+    let query_blob =
+        quaid::core::inference::embedding_to_blob(&quaid::core::inference::embed(query).unwrap());
+    let model_name: String = conn
+        .query_row(
+            "SELECT name FROM embedding_models WHERE active = 1 LIMIT 1",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+
+    let mut sql = String::from(
+        "SELECT p.slug, \
+                MAX(1.0 - vec_distance_cosine(pev.embedding, ?1)) AS score \
+         FROM page_embeddings_vec_384 pev \
+         JOIN page_embeddings pe ON pev.rowid = pe.vec_rowid \
+         JOIN pages p ON p.id = pe.page_id \
+         WHERE pe.model = ?2 \
+           AND p.quarantined_at IS NULL",
+    );
+    let mut params: Vec<Box<dyn rusqlite::ToSql>> =
+        vec![Box::new(query_blob), Box::new(model_name)];
+    if let Some(wing) = wing {
+        sql.push_str(" AND p.wing = ?3");
+        params.push(Box::new(wing.to_owned()));
+    }
+    if let Some(collection) = collection {
+        sql.push_str(&format!(" AND p.collection_id = ?{}", params.len() + 1));
+        params.push(Box::new(collection));
+    }
+    if let Some(ns) = namespace_filter {
+        if ns.is_empty() {
+            sql.push_str(&format!(" AND p.namespace = ?{}", params.len() + 1));
+            params.push(Box::new(String::new()));
+        } else {
+            sql.push_str(&format!(
+                " AND (p.namespace = ?{} OR p.namespace = '')",
+                params.len() + 1
+            ));
+            params.push(Box::new(ns.to_owned()));
+        }
+    }
+    if !include_superseded {
+        sql.push_str(" AND p.superseded_by IS NULL");
+    }
+    sql.push_str(&format!(
+        " GROUP BY p.id ORDER BY score DESC LIMIT ?{}",
+        params.len() + 1
+    ));
+    params.push(Box::new(k as i64));
+
+    let refs: Vec<&dyn rusqlite::ToSql> = params.iter().map(|p| p.as_ref()).collect();
+    let mut stmt = conn.prepare(&sql).unwrap();
+    let rows = stmt
+        .query_map(refs.as_slice(), |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, f64>(1)?))
+        })
+        .unwrap();
+    rows.map(|r| r.unwrap()).collect()
+}
+
+fn knn(
+    conn: &Connection,
+    query: &str,
+    k: usize,
+    wing: Option<&str>,
+    collection: Option<i64>,
+    namespace_filter: Option<&str>,
+    include_superseded: bool,
+) -> Vec<(String, f64)> {
+    search_vec_with_namespace_filtered(
+        query,
+        k,
+        wing,
+        collection,
+        namespace_filter,
+        include_superseded,
+        conn,
+    )
+    .unwrap()
+    .into_iter()
+    .map(|r| (r.slug, r.score))
+    .collect()
+}
+
+fn assert_parity(actual: &[(String, f64)], expected: &[(String, f64)], context: &str) {
+    assert_eq!(
+        actual.len(),
+        expected.len(),
+        "{context}: result count differs\n  knn={actual:?}\n  brute={expected:?}"
+    );
+    for (i, ((a_slug, a_score), (e_slug, e_score))) in
+        actual.iter().zip(expected.iter()).enumerate()
+    {
+        assert_eq!(
+            a_slug, e_slug,
+            "{context}: rank {i} slug differs\n  knn={actual:?}\n  brute={expected:?}"
+        );
+        assert!(
+            (a_score - e_score).abs() < 1e-6,
+            "{context}: rank {i} score differs ({a_score} vs {e_score})"
+        );
+    }
+}
+
+#[test]
+fn knn_matches_brute_force_under_every_filter() {
+    let conn = open_test_db();
+    // Two collections so the collection filter has something to discriminate.
+    conn.execute(
+        "INSERT INTO collections (id, name, root_path, writable, is_write_target, state)
+         VALUES (2, 'work', '/tmp/work-knn-parity', 1, 0, 'active')",
+        [],
+    )
+    .unwrap();
+
+    let topics = [
+        ("neural networks and deep learning architectures", "tech"),
+        ("distributed databases and consensus protocols", "tech"),
+        ("the history of renaissance oil painting", "art"),
+        ("baroque chamber music and counterpoint", "art"),
+        ("supply chain logistics optimization", "ops"),
+        ("kubernetes scheduling and autoscaling", "ops"),
+        ("photosynthesis in marine phytoplankton", "science"),
+        ("quantum error correction codes", "science"),
+    ];
+    for (index, (body, wing)) in topics.iter().enumerate() {
+        let collection_id = if index % 2 == 0 { 1 } else { 2 };
+        let namespace = if index % 3 == 0 { "alpha" } else { "" };
+        insert_page(
+            &conn,
+            &format!("notes/topic-{index:02}"),
+            wing,
+            namespace,
+            collection_id,
+            body,
+        );
+    }
+    // Mark one page superseded and one quarantined to exercise those filters.
+    conn.execute(
+        "UPDATE pages SET quarantined_at = '2026-01-01T00:00:00Z' WHERE slug = 'notes/topic-03'",
+        [],
+    )
+    .unwrap();
+    run_with_batch(&conn, None, true, false, Some(8)).unwrap();
+    // Supersede after embedding so the chunk still exists in the vec table.
+    conn.execute(
+        "UPDATE pages SET superseded_by = (SELECT id FROM pages WHERE slug='notes/topic-00')
+         WHERE slug = 'notes/topic-05'",
+        [],
+    )
+    .unwrap();
+
+    let query = "machine learning systems";
+    let cases: Vec<FilterCase> = vec![
+        ("no filters", None, None, None, false),
+        ("wing=tech", Some("tech"), None, None, false),
+        ("collection=2", None, Some(2), None, false),
+        ("namespace=alpha", None, None, Some("alpha"), false),
+        ("namespace=empty", None, None, Some(""), false),
+        ("include_superseded", None, None, None, true),
+        ("wing+collection", Some("science"), Some(1), None, false),
+    ];
+    for (label, wing, collection, ns, superseded) in cases {
+        for k in [1usize, 3, 8] {
+            let actual = knn(&conn, query, k, wing, collection, ns, superseded);
+            let expected = brute_force(&conn, query, k, wing, collection, ns, superseded);
+            assert_parity(&actual, &expected, &format!("{label} k={k}"));
+        }
+    }
+}
+
+#[test]
+fn knn_heap_path_matches_brute_force_above_overfetch_threshold() {
+    // The KNN branch only runs when the over-fetch (max(k*8, 256)) is smaller
+    // than the corpus, so seed > 256 chunks to exercise the vec0 heap rather
+    // than the full-scan fallback.
+    let conn = open_test_db();
+    let topics = [
+        "alpha vector retrieval",
+        "beta semantic ranking",
+        "gamma nearest neighbor",
+        "delta embedding similarity",
+    ];
+    for index in 0..300 {
+        let body = format!("{} variant {index}", topics[index % topics.len()]);
+        insert_page(
+            &conn,
+            &format!("notes/bulk-{index:03}"),
+            "notes",
+            "",
+            1,
+            &body,
+        );
+    }
+    run_with_batch(&conn, None, true, false, Some(64)).unwrap();
+    assert!(
+        vec_row_count(&conn) > 256,
+        "corpus must exceed the over-fetch floor to hit the KNN heap path"
+    );
+
+    let query = "nearest neighbor vector similarity";
+    for k in [1usize, 5, 10] {
+        let actual = knn(&conn, query, k, None, None, None, false);
+        let expected = brute_force(&conn, query, k, None, None, None, false);
+        assert_parity(&actual, &expected, &format!("heap-path k={k}"));
+    }
+}
+
+#[test]
+fn destroy_namespace_drops_backing_vec_rows() {
+    let conn = open_test_db();
+    insert_page(&conn, "notes/keep", "notes", "", 1, "page that survives");
+    insert_page(
+        &conn,
+        "notes/doomed",
+        "notes",
+        "q0001",
+        1,
+        "page in doomed ns",
+    );
+    run_with_batch(&conn, None, true, false, Some(8)).unwrap();
+    let before = vec_row_count(&conn);
+    assert!(before >= 2);
+
+    let deleted = namespace::destroy_namespace(&conn, "q0001").unwrap();
+    assert_eq!(deleted, 1);
+
+    let remaining = vec_row_count(&conn);
+    assert_eq!(
+        remaining,
+        before - 1,
+        "destroying the namespace must drop exactly its page's vec rows"
+    );
+
+    // No orphans left behind: every surviving vec row still joins to a page_embeddings row.
+    let orphans: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM page_embeddings_vec_384 v \
+             WHERE NOT EXISTS (SELECT 1 FROM page_embeddings pe WHERE pe.vec_rowid = v.rowid)",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(orphans, 0, "namespace destroy must not orphan vec rows");
+}
+
+#[test]
+fn collection_purge_zeroes_the_vec_table() {
+    let conn = open_test_db();
+    let root = tempfile::TempDir::new().unwrap();
+    conn.execute(
+        "INSERT INTO collections (id, name, root_path, writable, is_write_target, state)
+         VALUES (2, 'work', ?1, 1, 0, 'detached')",
+        [root.path().to_str().unwrap()],
+    )
+    .unwrap();
+    insert_page(&conn, "notes/work-a", "notes", "", 2, "first work page");
+    insert_page(&conn, "notes/work-b", "notes", "", 2, "second work page");
+    insert_page(
+        &conn,
+        "notes/keep",
+        "notes",
+        "",
+        1,
+        "page in default collection",
+    );
+    run_with_batch(&conn, None, true, false, Some(8)).unwrap();
+    let before = vec_row_count(&conn);
+    assert!(before >= 3);
+
+    collection::run(
+        &conn,
+        CollectionAction::Remove {
+            name: "work".to_owned(),
+            purge: true,
+            confirm: true,
+        },
+        true,
+    )
+    .unwrap();
+
+    // The two work-collection vectors are gone; the default page's vector stays.
+    assert_eq!(
+        vec_row_count(&conn),
+        before - 2,
+        "collection purge must drop exactly the purged collection's vec rows"
+    );
+    let default_pages: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM pages WHERE collection_id = 1",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(default_pages, 1);
+    let orphans: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM page_embeddings_vec_384 v \
+             WHERE NOT EXISTS (SELECT 1 FROM page_embeddings pe WHERE pe.vec_rowid = v.rowid)",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(orphans, 0, "collection purge must not orphan vec rows");
+}
+
+#[test]
+fn destroy_namespace_purging_all_pages_zeroes_the_vec_table() {
+    let conn = open_test_db();
+    insert_page(&conn, "notes/a", "notes", "q0001", 1, "first doomed page");
+    insert_page(&conn, "notes/b", "notes", "q0001", 1, "second doomed page");
+    run_with_batch(&conn, None, true, false, Some(8)).unwrap();
+    assert!(vec_row_count(&conn) >= 2);
+
+    namespace::destroy_namespace(&conn, "q0001").unwrap();
+
+    assert_eq!(
+        vec_row_count(&conn),
+        0,
+        "purging every page in the namespace must empty the vec table"
+    );
+}


### PR DESCRIPTION
Implements **Area 10 — vector index scalability & embedding job infrastructure** (steps 1–3 + the busy-timeout half of step 4). The single biggest lever for the #134 10K-page target.

## Changes
1. **Two-phase KNN** (`search_vec_internal`): phase 1 `SELECT rowid, distance FROM {vec_table} WHERE embedding MATCH ?1 AND k = ?2` with over-fetch `max(k*8, 256)`; phase 2 joins candidate rowids back to `page_embeddings`/`pages`, applies all existing filters (wing/collection/namespace/quarantine/superseded), and recomputes cosine on the merge layer's scale for exact parity. Escalates k ×4 to a 65536 cap, then full-scan fallback when filters under-fill. Replaces the ~50K-scalar-invocation full table scan per query with sqlite-vec's SIMD top-k heap.
2. **Vector cleanup**: `delete_page_vec_rows` wired before *every* bulk page delete (namespace destroy, collection purge, reconciler hard-delete, quarantine discard + TTL sweep — previously orphaned vec0 rows accumulated forever); a daily orphan-sweep in the supervisor janitor; a new `vec_orphans` check in `quaid validate` (vec→pe dangling, complementing the existing pe→vec staleness check).
3. **CLI queue drain**: `drain_embedding_queue` now drains inline at the end of CLI `put` (local-write path) and `collection sync` (gated by a new `--no-embed`), printing a drained count — fixes the DAB "footgun" where CLI-only users got FTS hits but silently empty semantic results. A serde-skip-when-0 `pending_embedding_jobs` staleness hint added to `memory_query`/`memory_search`.
4. Extraction worker connection now uses `db::open` (5s busy_timeout). The #73 jobs-table generalization is correctly out of scope.

## Validation
fmt/clippy/rustdoc gates clean. New: vector_knn_scalability (5 — **KNN-vs-brute-force parity under every filter**, k=1/3/8, identical top-k + scores within 1e-6, incl. a 300-chunk corpus exercising the heap path; destroy/purge zero the vec rows), validate_vec_orphans, cli_sync_inline_embed (sync-without-daemon makes pages findable; --no-embed leaves queue pending). Regression green across search/supersede/quarantine/namespace/validate/reconciler.

## ⚠️ Wire-contract change (merge sequencing)
`memory_query`/`memory_search` responses change from a bare JSON array to `{"results": [...], "pending_embedding_jobs": N}` (field skipped when 0). All in-repo MCP parse sites updated + an `extract_query_results` test helper added. **This overlaps #228 (rerank, also touches search.rs response) and the Wave 4 redaction PR (hooks search.rs serialization)** — these three need careful sequencing; whichever merges later rebases onto the envelope. Native CLI `quaid search`/`query` still emit bare arrays (unchanged).

## Notes
- The 300-page parity test embeds with the real BGE model (~130–290s on CPU). Left active as the load-bearing KNN parity check; could be `#[ignore]`-gated if CI time matters.
- `CollectionSyncArgs` gained `no_embed: bool` (7 src + 7 test sites updated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)