### PR TITLE
fix(slm): Phi-3 chat template + EOS set, fence recovery, F16 weights + idle unload, reject non-phi3 aliases (area 15)

### DIFF
--- a/src/core/conversation/extractor.rs
+++ b/src/core/conversation/extractor.rs
@@ -36,6 +36,10 @@ use crate::core::types::{
 pub const DEFAULT_EXTRACTION_MAX_TOKENS: usize = 2048;
 /// Default sleep interval between worker polls when the queue is empty.
 pub const DEFAULT_WORKER_POLL_INTERVAL: Duration = Duration::from_secs(1);
+/// How long the loaded SLM may sit idle before the worker drops it to
+/// reclaim its multi-GB resident footprint; the next job transparently
+/// reloads it.
+pub const DEFAULT_SLM_IDLE_UNLOAD_TTL: Duration = Duration::from_secs(300);
 
 const DEFAULT_WINDOW_TURNS: usize = 5;
 const DEFAULT_MODEL_ALIAS: &str = "phi-3.5-mini";
@@ -77,6 +81,11 @@ pub trait SlmClient {
     fn is_runtime_disabled(&self) -> bool {
         false
     }
+
+    /// Hook invoked when the worker has been idle, giving a runtime that
+    /// caches a loaded model the chance to drop it after `idle_ttl`.
+    /// Defaults to a no-op for stub clients that hold no weights.
+    fn unload_if_idle(&self, _idle_ttl: Duration) {}
 }
 
 impl SlmClient for LazySlmRunner {
@@ -86,6 +95,10 @@ impl SlmClient for LazySlmRunner {
 
     fn is_runtime_disabled(&self) -> bool {
         LazySlmRunner::is_runtime_disabled(self)
+    }
+
+    fn unload_if_idle(&self, idle_ttl: Duration) {
+        LazySlmRunner::unload_if_idle(self, idle_ttl);
     }
 }
 
@@ -241,6 +254,10 @@ where
     pub fn run_once(&self) -> Result<bool, WorkerError> {
         let processed = self.poll_once()?;
         if !processed {
+            // Queue is quiet: give the SLM client a chance to drop a
+            // cold, cached model before parking, so an idle MCP server
+            // does not pin ~8 GB indefinitely.
+            self.slm.unload_if_idle(DEFAULT_SLM_IDLE_UNLOAD_TTL);
             self.sleep_until_next_poll();
         }
         Ok(processed)
@@ -482,13 +499,32 @@ pub fn compute_windows(
 /// Render the SLM prompt for one extraction window, framing the new
 /// turns as the extraction target and the lookback turns as
 /// reference-only context.
+///
+/// The prompt is emitted in Phi-3's chat template
+/// (`<|system|>…<|end|><|user|>…<|end|><|assistant|>`) so the
+/// instruct-tuned model receives the role markers and the trailing
+/// `<|assistant|>` generation cue it was fine-tuned on, instead of the
+/// plain `SYSTEM:/USER:` framing that made it behave base-like. The
+/// `<|system|>`, `<|user|>`, `<|end|>`, and `<|assistant|>` markers are
+/// recognized as special tokens by the Phi-3 tokenizer (see
+/// `crate::core::conversation::slm::SlmRunner::infer`, which encodes
+/// with `add_special_tokens` enabled).
 pub fn build_prompt(session_id: &str, window: &WindowedTurns) -> String {
-    format!(
-        "SYSTEM:\n{EXTRACTION_SYSTEM_PROMPT}\n\nUSER:\nSession: {session_id}\nNew turns to extract from ({}):\n{}\nLookback context (do not extract from these — for reference only):\n{}",
+    let user = format!(
+        "Session: {session_id}\nNew turns to extract from ({}):\n{}\nLookback context (do not extract from these — for reference only):\n{}",
         ordinal_range_label(&window.new_turns),
         render_prompt_turns(&window.new_turns),
         render_prompt_turns(&window.lookback_turns)
-    )
+    );
+    render_phi3_chat_prompt(EXTRACTION_SYSTEM_PROMPT, &user)
+}
+
+/// Wrap a system+user message pair in the Phi-3 chat template the
+/// instruct model was trained on. Kept separate from
+/// [`build_prompt`] so the exact rendered string is covered by a
+/// golden-prompt snapshot test.
+pub fn render_phi3_chat_prompt(system: &str, user: &str) -> String {
+    format!("<|system|>\n{system}<|end|>\n<|user|>\n{user}<|end|>\n<|assistant|>\n")
 }
 
 fn ordinal_range_label(turns: &[Turn]) -> String {

--- a/src/core/conversation/model_lifecycle.rs
+++ b/src/core/conversation/model_lifecycle.rs
@@ -633,6 +633,18 @@ pub enum ModelLifecycleError {
         /// Human-readable explanation of the metadata problem.
         message: String,
     },
+
+    /// A curated alias resolves to a model architecture the extraction
+    /// runner cannot load, so downloading its (multi-GB) weights would
+    /// be wasted: the runner only wires `phi3`. Rejected before any
+    /// network I/O at `quaid model pull` time.
+    #[error("model `{alias}` is not supported by the extraction runner: {message}")]
+    UnsupportedByRunner {
+        /// Curated alias the caller requested.
+        alias: String,
+        /// Human-readable explanation and remediation.
+        message: String,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -775,6 +787,33 @@ pub fn resolve_model_alias(alias: &str) -> Result<ResolvedModelAlias, ModelLifec
         repo_id,
         revision,
     })
+}
+
+/// Curated aliases whose architecture the extraction runner
+/// (`crate::core::conversation::slm`) cannot load. The runner only
+/// wires Phi-3, so pulling these would download gigabytes the runner
+/// then refuses at load time, permanently disabling extraction. Kept
+/// here, next to the curated alias table, so the two stay in sync.
+const RUNNER_UNSUPPORTED_CURATED_ALIASES: &[&str] = &["gemma-3-1b", "gemma-3-4b"];
+
+/// Reject a curated alias the extraction runner cannot load before any
+/// download work begins. Raw `<org>/<model>` repo ids are intentionally
+/// left alone: callers may point Quaid at any compatible Phi-3 repo,
+/// and the runner's own `model_type` gate still fails closed at load
+/// time for anything it cannot build.
+fn ensure_alias_supported_by_runner(
+    resolved: &ResolvedModelAlias,
+) -> Result<(), ModelLifecycleError> {
+    let normalized = resolved.requested_alias.to_ascii_lowercase();
+    if RUNNER_UNSUPPORTED_CURATED_ALIASES.contains(&normalized.as_str()) {
+        return Err(ModelLifecycleError::UnsupportedByRunner {
+            alias: resolved.requested_alias.clone(),
+            message:
+                "the local extraction runner only loads Phi-3 models; use `phi-3.5-mini` instead"
+                    .to_owned(),
+        });
+    }
+    Ok(())
 }
 
 /// Compute the cache directory path for an alias without touching the
@@ -1468,6 +1507,12 @@ pub fn download_model(
     alias: &str,
     progress: &mut impl ProgressReporter,
 ) -> Result<PathBuf, ModelLifecycleError> {
+    // Reject curated aliases the runner cannot load before any network
+    // I/O so `quaid model pull gemma-3-1b` fails fast with a clear
+    // error instead of downloading gigabytes the runner then refuses.
+    let resolved = resolve_model_alias(alias)?;
+    ensure_alias_supported_by_runner(&resolved)?;
+
     #[cfg(feature = "online-model")]
     {
         download_model_online(alias, progress)
@@ -1475,7 +1520,6 @@ pub fn download_model(
 
     #[cfg(not(feature = "online-model"))]
     {
-        let _ = alias;
         let _ = progress;
         Err(ModelLifecycleError::DownloadsUnsupported)
     }

--- a/src/core/conversation/slm.rs
+++ b/src/core/conversation/slm.rs
@@ -67,7 +67,13 @@ pub struct SlmRunner {
     model: Phi3Model,
     device: Device,
     inference: SlmInferenceConfig,
-    eos_token_id: Option<u32>,
+    /// Every token id that should halt generation. Seeded from
+    /// `config.json`'s single `eos_token_id` and unioned with the full
+    /// stop-token list in `generation_config.json` (Phi-3.5 ships
+    /// `<|endoftext|>`, `<|end|>`, and `<|assistant|>` here), so
+    /// completions stop at the chat-template boundary instead of
+    /// burning the whole token budget.
+    eos_token_ids: std::collections::HashSet<u32>,
     #[expect(
         dead_code,
         reason = "model_dir is held for diagnostics/Debug logging of which weights backed this runner; not read from struct fields directly"
@@ -89,6 +95,10 @@ struct LazySlmState {
     runner: Option<SlmRunner>,
     runtime_disabled: bool,
     last_error: Option<String>,
+    /// When the loaded runner was last used for inference. Consulted by
+    /// [`LazySlmRunner::unload_if_idle`] to drop the multi-GB model
+    /// after an idle interval; `None` whenever no runner is loaded.
+    last_used: Option<std::time::Instant>,
 }
 
 /// Errors surfaced by SLM load, inference, and response parsing.
@@ -228,25 +238,38 @@ impl SlmRunner {
 
         let model_paths = safetensor_paths(&model_dir)?;
         let device = Device::Cpu;
+        // Load the Phi-3.5 weights in half precision rather than F32.
+        // The 3.8B-parameter checkpoint resides ~15 GB at F32 but only
+        // ~8 GB at half precision; candle's mmaped backend converts the
+        // on-disk tensors to the requested dtype, and the phi3 model
+        // adopts `VarBuilder::dtype()` for all of its internal math (the
+        // attention mask is built in F32 then cast to the model dtype).
+        // F16 (not BF16) is used because candle's CPU `matmul` only
+        // supports F16/F32/F64, and Phi-3 weights and activations sit
+        // well inside F16's dynamic range.
+        let weights_dtype = select_weights_dtype(&device);
         #[expect(
             unsafe_code,
             reason = "candle's VarBuilder::from_mmaped_safetensors mmaps the on-disk Phi-3 weights; safety holds because we treat the cached model files as immutable for the lifetime of the VarBuilder"
         )]
-        let vb = unsafe { VarBuilder::from_mmaped_safetensors(&model_paths, DType::F32, &device) }
-            .map_err(|error| SlmError::Weights {
-                cache_dir: model_dir.display().to_string(),
-                message: error.to_string(),
-            })?;
+        let vb =
+            unsafe { VarBuilder::from_mmaped_safetensors(&model_paths, weights_dtype, &device) }
+                .map_err(|error| SlmError::Weights {
+                    cache_dir: model_dir.display().to_string(),
+                    message: error.to_string(),
+                })?;
         let model = Phi3Model::new(&config, vb).map_err(|error| SlmError::Inference {
             message: format!("build phi3 model: {error}"),
         })?;
+
+        let eos_token_ids = collect_eos_token_ids(&model_dir, config.eos_token_id);
 
         Ok(Self {
             tokenizer,
             model,
             device,
             inference: SlmInferenceConfig::default(),
-            eos_token_id: config.eos_token_id,
+            eos_token_ids,
             model_dir,
         })
     }
@@ -276,9 +299,15 @@ impl SlmRunner {
             return Ok(String::new());
         }
 
+        // Encode with `add_special_tokens` so the Phi-3 chat-template
+        // markers (`<|system|>`, `<|user|>`, `<|end|>`, `<|assistant|>`)
+        // rendered by `super::extractor::render_phi3_chat_prompt` are
+        // tokenized as their dedicated special-token ids and the
+        // tokenizer's post-processor applies the model's BOS handling,
+        // rather than splitting the markers into ordinary subwords.
         let encoding =
             self.tokenizer
-                .encode(prompt, false)
+                .encode(prompt, true)
                 .map_err(|error| SlmError::Inference {
                     message: format!("tokenizer encode: {error}"),
                 })?;
@@ -317,7 +346,7 @@ impl SlmRunner {
                 .map_err(|error| SlmError::Inference {
                     message: format!("sample logits: {error}"),
                 })?;
-            if Some(next_token) == self.eos_token_id {
+            if self.eos_token_ids.contains(&next_token) {
                 break;
             }
             all_tokens.push(next_token);
@@ -349,6 +378,7 @@ impl SlmRunner {
 impl LazySlmState {
     fn disable_runtime(&mut self, error: &SlmError) {
         self.runner = None;
+        self.last_used = None;
         self.runtime_disabled = true;
         self.last_error = Some(error.to_string());
     }
@@ -397,8 +427,39 @@ impl LazySlmRunner {
             .infer(prompt, max_tokens);
         if let Err(error @ SlmError::Panic { .. }) = &result {
             state.disable_runtime(error);
+        } else {
+            // Record activity so a later `unload_if_idle` sweep can tell
+            // whether the multi-GB model has gone cold; a panic above
+            // already cleared the runner, so only touch this when the
+            // runner survives.
+            state.last_used = Some(std::time::Instant::now());
         }
         result
+    }
+
+    /// Drop the loaded model when it has been idle for at least
+    /// `idle_ttl`, freeing its multi-GB resident footprint until the
+    /// next [`infer`](Self::infer) transparently reloads it. Returns
+    /// `true` when a runner was unloaded. A disabled runtime or an
+    /// already-empty handle is left untouched and returns `false`.
+    pub fn unload_if_idle(&self, idle_ttl: std::time::Duration) -> bool {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if state.runner.is_none() {
+            return false;
+        }
+        let idle_for = state
+            .last_used
+            .map(|last| last.elapsed())
+            .unwrap_or(idle_ttl);
+        if idle_for < idle_ttl {
+            return false;
+        }
+        state.runner = None;
+        state.last_used = None;
+        true
     }
 
     /// Report whether a runner has been successfully loaded into the
@@ -425,6 +486,69 @@ fn parse_phi3_config(config_text: &str) -> serde_json::Result<Phi3Config> {
     let mut config_value: JsonValue = serde_json::from_str(config_text)?;
     normalize_phi3_rope_scaling(&mut config_value);
     serde_json::from_value(config_value)
+}
+
+/// Pick the dtype the Phi-3 weights load under. Half precision roughly
+/// halves resident memory versus F32. On the CPU backend candle's
+/// `matmul` only implements F16/F32/F64 — BF16 is rejected at runtime —
+/// so F16 is the half-precision choice here. The device is taken as
+/// input so a future accelerated backend (where BF16 matmul is
+/// available and numerically preferable) can override the choice.
+fn select_weights_dtype(device: &Device) -> DType {
+    match device {
+        Device::Cpu => DType::F16,
+        // GPU/Metal backends support BF16 matmul and prefer its wider
+        // exponent range; today the runner only builds CPU models, but
+        // keep the mapping explicit for when that changes.
+        _ => DType::BF16,
+    }
+}
+
+/// Build the set of token ids that halt generation. The single
+/// `eos_token_id` from `config.json` is always included; when a
+/// sibling `generation_config.json` is present its `eos_token_id`
+/// field (a scalar or an array — Phi-3.5 ships `[32007, 32001,
+/// 32000]`) is unioned in so the runner stops at the chat-template
+/// boundary instead of running to the token budget. A missing or
+/// malformed `generation_config.json` is non-fatal: the function falls
+/// back to whatever `config.json` provided.
+fn collect_eos_token_ids(
+    model_dir: &Path,
+    config_eos: Option<u32>,
+) -> std::collections::HashSet<u32> {
+    let mut ids = std::collections::HashSet::new();
+    ids.extend(config_eos);
+
+    let generation_config_path = model_dir.join("generation_config.json");
+    if let Ok(text) = fs::read_to_string(&generation_config_path) {
+        for id in parse_generation_config_eos_ids(&text) {
+            ids.insert(id);
+        }
+    }
+
+    ids
+}
+
+/// Extract every `eos_token_id` declared in a `generation_config.json`
+/// body, accepting both the scalar form (`"eos_token_id": 32000`) and
+/// the array form (`"eos_token_id": [32007, 32001, 32000]`). Values
+/// that are not non-negative integers in `u32` range are skipped.
+/// Unparseable JSON yields an empty list rather than an error.
+fn parse_generation_config_eos_ids(text: &str) -> Vec<u32> {
+    let Ok(value) = serde_json::from_str::<JsonValue>(text) else {
+        return Vec::new();
+    };
+    let Some(field) = value.get("eos_token_id") else {
+        return Vec::new();
+    };
+    match field {
+        JsonValue::Array(entries) => entries.iter().filter_map(json_value_as_u32).collect(),
+        scalar => json_value_as_u32(scalar).into_iter().collect(),
+    }
+}
+
+fn json_value_as_u32(value: &JsonValue) -> Option<u32> {
+    value.as_u64().and_then(|id| u32::try_from(id).ok())
 }
 
 fn normalize_phi3_rope_scaling(config: &mut JsonValue) {
@@ -542,6 +666,9 @@ fn recover_commentary_wrapped_object(raw: &str) -> Option<&str> {
     };
     let prefix = &raw[..candidate.0];
     let suffix = &raw[candidate.1..];
+    if let Some(object) = single_fenced_json_object(raw, prefix, suffix, *candidate) {
+        return Some(object);
+    }
     if !candidate_has_adjacent_container_chars(prefix, suffix)
         && !candidate_is_inside_container(prefix, suffix)
         && wrapper_is_plain_commentary(prefix)
@@ -551,6 +678,58 @@ fn recover_commentary_wrapped_object(raw: &str) -> Option<&str> {
     } else {
         None
     }
+}
+
+/// Accept exactly one JSON object wrapped in a single Markdown fence
+/// (```` ```json … ``` ```` or a bare ```` ``` … ``` ````). Returns the
+/// inner object span when the wrapper is *only* a fence — an optional
+/// `json`/`json5` info string before the object and the closing fence
+/// after it, with nothing but whitespace otherwise. Any extra prose,
+/// a missing closing fence, or a second object outside the fence falls
+/// through to the stricter plain-commentary path, which fails closed.
+fn single_fenced_json_object<'raw>(
+    raw: &'raw str,
+    prefix: &str,
+    suffix: &str,
+    candidate: (usize, usize),
+) -> Option<&'raw str> {
+    let opening = fence_opening_before(prefix)?;
+    if !fence_closing_after(suffix) {
+        return None;
+    }
+    // The text before the opening fence must be empty so we only ever
+    // unwrap a lone fenced envelope, never a fence buried in prose.
+    if !prefix[..opening].trim().is_empty() {
+        return None;
+    }
+    Some(&raw[candidate.0..candidate.1])
+}
+
+/// When `prefix` (everything before the JSON object) ends in an opening
+/// code fence — optionally carrying an info string like `json` — return
+/// the byte offset where that fence marker begins. The only content
+/// allowed between the fence's newline and the object is whitespace.
+fn fence_opening_before(prefix: &str) -> Option<usize> {
+    let trimmed_end = prefix.trim_end();
+    let last_line_start = trimmed_end.rfind('\n').map_or(0, |index| index + 1);
+    let last_line = trimmed_end[last_line_start..].trim();
+    let info = last_line
+        .strip_prefix("```")
+        .or_else(|| last_line.strip_prefix("~~~"))?;
+    // Reject fences that themselves contain non-info characters (e.g.
+    // the model put the object on the same line as the fence) so we
+    // keep matching only clean, single-object fences.
+    if info.contains('`') || info.contains('{') {
+        return None;
+    }
+    Some(last_line_start)
+}
+
+/// True when `suffix` (everything after the JSON object) is just
+/// whitespace followed by a closing code fence and nothing else.
+fn fence_closing_after(suffix: &str) -> bool {
+    let trimmed = suffix.trim();
+    matches!(trimmed.strip_prefix("```").or_else(|| trimmed.strip_prefix("~~~")), Some(rest) if rest.trim().is_empty())
 }
 
 fn candidate_has_adjacent_container_chars(prefix: &str, suffix: &str) -> bool {
@@ -930,9 +1109,12 @@ mod tests {
     use tokenizers::Tokenizer;
 
     #[test]
-    fn parse_response_rejects_json_code_fence() {
-        let error = parse_response("```json\n{\"facts\":[]}\n```").unwrap_err();
-        assert!(matches!(error, SlmError::Parse { .. }));
+    fn parse_response_accepts_single_json_code_fence() {
+        // A lone fenced JSON envelope is now unwrapped and parsed; the
+        // exhaustive fence-recovery matrix lives in
+        // tests/slm_parse_response.rs.
+        let parsed = parse_response("```json\n{\"facts\":[]}\n```").unwrap();
+        assert!(parsed.facts.is_empty());
     }
 
     #[test]

--- a/tests/cli_extraction.rs
+++ b/tests/cli_extraction.rs
@@ -577,3 +577,43 @@ fn model_pull_caches_model_without_flipping_extraction_flag() {
         .unwrap();
     assert_eq!(enabled, "false");
 }
+
+/// `quaid model pull gemma-3-1b` must fail fast with a clear
+/// "not supported by the extraction runner" message before any
+/// download work, because the runner only loads Phi-3. This holds on
+/// every build (the gate runs ahead of the online-model download path),
+/// so the test is not feature-gated.
+#[test]
+fn model_pull_rejects_unsupported_curated_gemma_alias() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("memory.db");
+    open_test_db(&db_path);
+
+    let cache_root = dir.path().join("model-cache");
+    let envs = vec![(
+        "QUAID_MODEL_CACHE_DIR".to_string(),
+        cache_root.display().to_string(),
+    )];
+    let output = run_quaid_with_env(&db_path, &["model", "pull", "gemma-3-1b"], &envs);
+
+    assert!(
+        !output.status.success(),
+        "pull of an unsupported curated alias must fail"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("not supported by the extraction runner"),
+        "expected runner-unsupported message, got stderr={stderr}"
+    );
+    assert!(
+        stderr.contains("phi-3.5-mini"),
+        "error should point at the supported alias, got stderr={stderr}"
+    );
+    let cache_empty = std::fs::read_dir(&cache_root)
+        .map(|mut entries| entries.next().is_none())
+        .unwrap_or(true);
+    assert!(
+        cache_empty,
+        "rejection must not create any download cache entries"
+    );
+}

--- a/tests/entity_extraction.rs
+++ b/tests/entity_extraction.rs
@@ -75,6 +75,32 @@ fn count_entity_pattern_links(conn: &Connection) -> i64 {
     .unwrap()
 }
 
+/// `entities::run_for_page` with a generous extraction deadline.
+///
+/// The production 5 ms budget is load-sensitive: on a saturated CI runner the
+/// first pattern can already blow it, skipping extraction and flaking any
+/// assertion-count expectation. Routing tests pin a deterministic deadline via
+/// the explicit seam; budget behaviour itself is covered by the
+/// `extract_entities` over-budget test.
+fn run_for_page_generous(
+    conn: &Connection,
+    page_id: i64,
+    collection_id: i64,
+    page_slug: &str,
+    compiled_truth: &str,
+    patterns: &[EntityPattern],
+) -> Result<entities::RoutingSummary, entities::EntityError> {
+    entities::run_for_page_with_deadline(
+        conn,
+        page_id,
+        collection_id,
+        page_slug,
+        compiled_truth,
+        patterns,
+        Duration::from_secs(30),
+    )
+}
+
 // ── 6.x: pattern config and validation ────────────────────────
 
 #[test]
@@ -305,7 +331,7 @@ fn budget_overrun_logs_knowledge_gap() {
     assert!(outcome.over_budget);
 
     // Force the wired gap-logging via the helper for budget overrun.
-    let summary = entities::run_for_page(&conn, page_id, 1, "people/alice", "", &[]).unwrap();
+    let summary = run_for_page_generous(&conn, page_id, 1, "people/alice", "", &[]).unwrap();
     assert_eq!(summary.matches_seen, 0);
     let gap_count: i64 = conn
         .query_row("SELECT COUNT(*) FROM knowledge_gaps", [], |row| row.get(0))
@@ -323,7 +349,7 @@ fn match_with_both_resolved_inserts_assertion_no_link() {
     insert_page(&conn, "companies/brex", "Brex", "body");
 
     let patterns = entities::load_patterns_from(None, &conn).unwrap();
-    let summary = entities::run_for_page(
+    let summary = run_for_page_generous(
         &conn,
         source,
         1,
@@ -360,7 +386,7 @@ fn unresolved_match_still_inserts_assertion_no_link() {
     insert_page(&conn, "people/alice", "Alice", "body");
 
     let patterns = entities::load_patterns_from(None, &conn).unwrap();
-    let summary = entities::run_for_page(
+    let summary = run_for_page_generous(
         &conn,
         source,
         1,
@@ -387,7 +413,7 @@ fn unresolved_evidence_does_not_include_raw_capture_text() {
     insert_page(&conn, "people/alice", "Alice", "body");
 
     let patterns = entities::load_patterns_from(None, &conn).unwrap();
-    entities::run_for_page(
+    run_for_page_generous(
         &conn,
         source,
         1,
@@ -450,7 +476,7 @@ fn idempotent_reingest_does_not_duplicate_assertions() {
     let patterns = entities::load_patterns_from(None, &conn).unwrap();
 
     for _ in 0..3 {
-        entities::run_for_page(
+        run_for_page_generous(
             &conn,
             source,
             1,
@@ -475,7 +501,7 @@ fn reingest_removes_entity_assertions_no_longer_in_page_text() {
     insert_page(&conn, "companies/stripe", "Stripe", "body");
     let patterns = entities::load_patterns_from(None, &conn).unwrap();
 
-    entities::run_for_page(
+    run_for_page_generous(
         &conn,
         source,
         1,
@@ -484,7 +510,7 @@ fn reingest_removes_entity_assertions_no_longer_in_page_text() {
         &patterns,
     )
     .unwrap();
-    entities::run_for_page(
+    run_for_page_generous(
         &conn,
         source,
         1,
@@ -574,7 +600,7 @@ fn over_budget_run_for_page_logs_gap_and_preserves_existing_entity_assertions() 
     insert_page(&conn, "companies/brex", "Brex", "body");
     let patterns = entities::load_patterns_from(None, &conn).unwrap();
 
-    entities::run_for_page(
+    run_for_page_generous(
         &conn,
         source,
         1,

--- a/tests/slm_parse_response.rs
+++ b/tests/slm_parse_response.rs
@@ -1,0 +1,419 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::print_stdout,
+    reason = "test fixtures legitimately panic on setup failure and print diagnostics; per-site #[expect] would generate noise across thousands of test sites"
+)]
+
+//! Fence-recovery matrix for `parse_response`, plus behavioral coverage
+//! of the SLM runner's EOS-union stop set, half-precision weight load,
+//! and the `LazySlmRunner` idle-unload-then-reload cycle. The
+//! cache-touching tests use the same tiny hand-built Phi-3 fixture the
+//! other SLM integration suites use, so no real multi-GB download is
+//! required.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, MutexGuard, OnceLock};
+use std::time::Duration;
+
+use quaid::core::conversation::model_lifecycle::{cache_dir_for_alias, resolve_model_alias};
+use quaid::core::conversation::slm::{parse_response, LazySlmRunner, SlmError, SlmRunner};
+use safetensors::tensor::{serialize_to_file, Dtype, TensorView};
+use sha2::{Digest, Sha256};
+use tokenizers::models::wordlevel::WordLevel;
+use tokenizers::pre_tokenizers::whitespace::Whitespace;
+use tokenizers::Tokenizer;
+
+// ---------------------------------------------------------------------------
+// Fence recovery: a single fenced JSON object is accepted; anything else
+// (multiple objects, missing close, garbage, fence buried in prose) fails
+// closed.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn accepts_single_json_fence_with_info_string() {
+    let parsed = parse_response("```json\n{\"facts\":[]}\n```").unwrap();
+    assert!(parsed.facts.is_empty());
+    assert!(parsed.validation_errors.is_empty());
+}
+
+#[test]
+fn accepts_bare_triple_backtick_fence() {
+    let parsed = parse_response("```\n{\"facts\":[]}\n```").unwrap();
+    assert!(parsed.facts.is_empty());
+}
+
+#[test]
+fn accepts_tilde_fence() {
+    let parsed = parse_response("~~~json\n{\"facts\":[]}\n~~~").unwrap();
+    assert!(parsed.facts.is_empty());
+}
+
+#[test]
+fn accepts_single_fence_with_nonempty_facts() {
+    let parsed = parse_response(concat!(
+        "```json\n",
+        "{\"facts\":[{\"kind\":\"fact\",\"about\":\"repo\",\"summary\":\"Quaid is local-first\"}]}\n",
+        "```"
+    ))
+    .unwrap();
+    assert_eq!(parsed.facts.len(), 1);
+    assert!(parsed.validation_errors.is_empty());
+}
+
+#[test]
+fn accepts_fence_with_surrounding_whitespace() {
+    let parsed = parse_response("\n  ```json\n{\"facts\":[]}\n```  \n").unwrap();
+    assert!(parsed.facts.is_empty());
+}
+
+#[test]
+fn rejects_two_fenced_objects() {
+    let error = parse_response(concat!(
+        "```json\n{\"facts\":[]}\n```\n",
+        "```json\n{\"facts\":[]}\n```"
+    ))
+    .unwrap_err();
+    assert!(matches!(error, SlmError::Parse { .. }));
+}
+
+#[test]
+fn rejects_fence_with_trailing_prose() {
+    // A closing fence followed by commentary is not a lone fenced
+    // envelope, so recovery falls through and fails closed.
+    let error = parse_response("```json\n{\"facts\":[]}\n```\nHope that helps!").unwrap_err();
+    assert!(matches!(error, SlmError::Parse { .. }));
+}
+
+#[test]
+fn rejects_fence_with_leading_prose() {
+    let error = parse_response("Here you go:\n```json\n{\"facts\":[]}\n```").unwrap_err();
+    assert!(matches!(error, SlmError::Parse { .. }));
+}
+
+#[test]
+fn rejects_unclosed_fence() {
+    let error = parse_response("```json\n{\"facts\":[]}").unwrap_err();
+    assert!(matches!(error, SlmError::Parse { .. }));
+}
+
+#[test]
+fn rejects_object_without_closing_fence_but_with_opening() {
+    let error = parse_response("```json\n{\"facts\":[]}\nstill talking").unwrap_err();
+    assert!(matches!(error, SlmError::Parse { .. }));
+}
+
+#[test]
+fn rejects_pure_garbage() {
+    let error = parse_response("not json at all, just prose").unwrap_err();
+    assert!(matches!(error, SlmError::Parse { .. }));
+}
+
+#[test]
+fn rejects_empty_input() {
+    let error = parse_response("   ").unwrap_err();
+    assert!(matches!(error, SlmError::Parse { .. }));
+}
+
+// ---------------------------------------------------------------------------
+// EOS stop set: ids from generation_config.json are unioned with config.json.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn generation_config_eos_id_halts_generation() {
+    let temp = tempfile::tempdir().unwrap();
+    let _guard = EnvGuard::set("QUAID_MODEL_CACHE_DIR", temp.path().display().to_string());
+    seed_tiny_phi3_cache("phi-3.5-mini");
+    // The tiny model greedily emits token 2 ("world") for input "hello".
+    // config.json's eos is token 3, so without the generation_config
+    // union the model would emit "world". Declaring token 2 as an eos
+    // in generation_config.json must halt generation immediately.
+    write_generation_config(
+        "phi-3.5-mini",
+        serde_json::json!({ "eos_token_id": [2, 99] }),
+    );
+
+    let mut runner = SlmRunner::load("phi-3.5-mini").expect("load tiny phi3 model");
+    let output = runner.infer("hello", 4).expect("run infer");
+
+    assert!(
+        output.is_empty(),
+        "generation should stop on the unioned eos id 2, got {output:?}"
+    );
+}
+
+#[test]
+fn scalar_generation_config_eos_id_halts_generation() {
+    let temp = tempfile::tempdir().unwrap();
+    let _guard = EnvGuard::set("QUAID_MODEL_CACHE_DIR", temp.path().display().to_string());
+    seed_tiny_phi3_cache("phi-3.5-mini");
+    write_generation_config("phi-3.5-mini", serde_json::json!({ "eos_token_id": 2 }));
+
+    let mut runner = SlmRunner::load("phi-3.5-mini").expect("load tiny phi3 model");
+    let output = runner.infer("hello", 4).expect("run infer");
+
+    assert!(output.is_empty(), "scalar eos union should stop on 2");
+}
+
+#[test]
+fn missing_generation_config_falls_back_to_config_eos() {
+    let temp = tempfile::tempdir().unwrap();
+    let _guard = EnvGuard::set("QUAID_MODEL_CACHE_DIR", temp.path().display().to_string());
+    seed_tiny_phi3_cache("phi-3.5-mini");
+    // No generation_config.json written: only config.json eos=3 applies,
+    // so the model still emits "world" (token 2).
+
+    let mut runner = SlmRunner::load("phi-3.5-mini").expect("load tiny phi3 model");
+    let output = runner.infer("hello", 1).expect("run infer");
+
+    assert_eq!(output, "world");
+}
+
+#[test]
+fn malformed_generation_config_is_non_fatal() {
+    let temp = tempfile::tempdir().unwrap();
+    let _guard = EnvGuard::set("QUAID_MODEL_CACHE_DIR", temp.path().display().to_string());
+    seed_tiny_phi3_cache("phi-3.5-mini");
+    let cache_dir = cache_dir_for_alias("phi-3.5-mini").unwrap();
+    std::fs::write(cache_dir.join("generation_config.json"), b"{ not json").unwrap();
+
+    let mut runner = SlmRunner::load("phi-3.5-mini").expect("load despite bad generation config");
+    let output = runner.infer("hello", 1).expect("run infer");
+
+    assert_eq!(output, "world");
+}
+
+// ---------------------------------------------------------------------------
+// Half-precision load: F16 weights (the CPU half-precision choice, since
+// candle's CPU matmul rejects BF16) still produce the expected argmax token.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn half_precision_weight_load_preserves_deterministic_argmax() {
+    let temp = tempfile::tempdir().unwrap();
+    let _guard = EnvGuard::set("QUAID_MODEL_CACHE_DIR", temp.path().display().to_string());
+    seed_tiny_phi3_cache("phi-3.5-mini");
+
+    // The runner now loads weights in half precision; the tiny fixture's
+    // exact values (10.0, 1.0) are representable in F16 so the greedy
+    // decode is unchanged. This guards that the dtype switch did not
+    // perturb the selected token.
+    let mut runner =
+        SlmRunner::load("phi-3.5-mini").expect("load tiny phi3 model in half precision");
+    let output = runner.infer("hello", 1).expect("run infer");
+
+    assert_eq!(output, "world");
+}
+
+// ---------------------------------------------------------------------------
+// Idle-unload: the lazy runner drops its model after the idle TTL and
+// transparently reloads on the next infer.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unload_if_idle_drops_then_reloads() {
+    let temp = tempfile::tempdir().unwrap();
+    let _guard = EnvGuard::set("QUAID_MODEL_CACHE_DIR", temp.path().display().to_string());
+    seed_tiny_phi3_cache("phi-3.5-mini");
+
+    let runtime = LazySlmRunner::new();
+    assert!(!runtime.is_loaded());
+
+    let first = runtime
+        .infer("phi-3.5-mini", "hello", 1)
+        .expect("first infer");
+    assert_eq!(first, "world");
+    assert!(runtime.is_loaded());
+
+    // A zero idle TTL means "any idle time counts": the model is dropped.
+    assert!(
+        runtime.unload_if_idle(Duration::from_secs(0)),
+        "idle model should unload"
+    );
+    assert!(
+        !runtime.is_loaded(),
+        "runner should be dropped after unload"
+    );
+
+    // Next infer reloads transparently and still works.
+    let second = runtime
+        .infer("phi-3.5-mini", "hello", 1)
+        .expect("reload after unload");
+    assert_eq!(second, "world");
+    assert!(runtime.is_loaded());
+    assert!(!runtime.is_runtime_disabled());
+}
+
+#[test]
+fn unload_if_idle_keeps_recently_used_model() {
+    let temp = tempfile::tempdir().unwrap();
+    let _guard = EnvGuard::set("QUAID_MODEL_CACHE_DIR", temp.path().display().to_string());
+    seed_tiny_phi3_cache("phi-3.5-mini");
+
+    let runtime = LazySlmRunner::new();
+    runtime.infer("phi-3.5-mini", "hello", 1).expect("infer");
+    assert!(runtime.is_loaded());
+
+    // A long TTL just after use must not drop the model.
+    assert!(
+        !runtime.unload_if_idle(Duration::from_secs(3600)),
+        "freshly used model must not be unloaded"
+    );
+    assert!(runtime.is_loaded());
+}
+
+#[test]
+fn unload_if_idle_on_empty_handle_is_noop() {
+    let runtime = LazySlmRunner::new();
+    assert!(!runtime.unload_if_idle(Duration::from_secs(0)));
+    assert!(!runtime.is_loaded());
+}
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+fn env_lock() -> &'static Mutex<()> {
+    ENV_LOCK.get_or_init(|| Mutex::new(()))
+}
+
+struct EnvGuard {
+    key: &'static str,
+    previous: Option<String>,
+    _lock: MutexGuard<'static, ()>,
+}
+
+impl EnvGuard {
+    fn set(key: &'static str, value: String) -> Self {
+        let lock = env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let previous = std::env::var(key).ok();
+        std::env::set_var(key, value);
+        Self {
+            key,
+            previous,
+            _lock: lock,
+        }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        if let Some(previous) = self.previous.take() {
+            std::env::set_var(self.key, previous);
+        } else {
+            std::env::remove_var(self.key);
+        }
+    }
+}
+
+fn write_generation_config(alias: &str, body: serde_json::Value) {
+    // Written after seeding and intentionally left out of the manifest;
+    // manifest validation only walks recorded files, so an extra sibling
+    // is tolerated and exercises the real load-time read path.
+    let cache_dir = cache_dir_for_alias(alias).unwrap();
+    std::fs::write(
+        cache_dir.join("generation_config.json"),
+        serde_json::to_vec_pretty(&body).unwrap(),
+    )
+    .unwrap();
+}
+
+fn seed_tiny_phi3_cache(alias: &str) {
+    let resolved = resolve_model_alias(alias).unwrap();
+    let cache_dir = cache_dir_for_alias(alias).unwrap();
+    std::fs::create_dir_all(&cache_dir).unwrap();
+
+    std::fs::write(
+        cache_dir.join("config.json"),
+        serde_json::to_vec_pretty(&serde_json::json!({
+            "model_type": "phi3",
+            "vocab_size": 4,
+            "hidden_act": "relu",
+            "hidden_size": 2,
+            "intermediate_size": 2,
+            "num_hidden_layers": 0,
+            "num_attention_heads": 1,
+            "num_key_value_heads": 1,
+            "rms_norm_eps": 1e-6,
+            "rope_theta": 10_000.0,
+            "bos_token_id": serde_json::Value::Null,
+            "eos_token_id": 3,
+            "rope_scaling": serde_json::Value::Null,
+            "max_position_embeddings": 16
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let mut tokenizer = Tokenizer::new(
+        WordLevel::builder()
+            .vocab(HashMap::from([
+                ("<unk>".to_string(), 0),
+                ("hello".to_string(), 1),
+                ("world".to_string(), 2),
+                ("<eos>".to_string(), 3),
+            ]))
+            .unk_token("<unk>".to_string())
+            .build()
+            .unwrap(),
+    );
+    tokenizer.with_pre_tokenizer(Some(Whitespace));
+    tokenizer
+        .save(cache_dir.join("tokenizer.json"), false)
+        .unwrap();
+
+    let embed = floats_to_bytes(&[0.0, 0.0, 10.0, 0.0, 0.0, 10.0, 0.0, 0.0]);
+    let norm = floats_to_bytes(&[1.0, 1.0]);
+    let lm_head = floats_to_bytes(&[0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0]);
+
+    let embed_view = TensorView::new(Dtype::F32, vec![4, 2], &embed).unwrap();
+    let norm_view = TensorView::new(Dtype::F32, vec![2], &norm).unwrap();
+    let lm_head_view = TensorView::new(Dtype::F32, vec![4, 2], &lm_head).unwrap();
+    serialize_to_file(
+        [
+            ("model.embed_tokens.weight", embed_view),
+            ("model.norm.weight", norm_view),
+            ("lm_head.weight", lm_head_view),
+        ],
+        &None,
+        &cache_dir.join("model.safetensors"),
+    )
+    .unwrap();
+
+    let manifest = serde_json::json!({
+        "requested_alias": resolved.requested_alias,
+        "repo_id": resolved.repo_id,
+        "revision": resolved.revision,
+        "files": [
+            manifest_entry("config.json", &cache_dir.join("config.json")),
+            manifest_entry("model.safetensors", &cache_dir.join("model.safetensors")),
+            manifest_entry("tokenizer.json", &cache_dir.join("tokenizer.json")),
+        ]
+    });
+    std::fs::write(
+        cache_dir.join("manifest.json"),
+        serde_json::to_vec_pretty(&manifest).unwrap(),
+    )
+    .unwrap();
+}
+
+fn manifest_entry(path: &str, full_path: &std::path::Path) -> serde_json::Value {
+    let bytes = std::fs::read(full_path).unwrap();
+    serde_json::json!({
+        "path": path,
+        "sha256": format!("{:x}", Sha256::digest(bytes)),
+        "verified_from_source": false
+    })
+}
+
+fn floats_to_bytes(values: &[f32]) -> Vec<u8> {
+    values
+        .iter()
+        .flat_map(|value| value.to_le_bytes())
+        .collect()
+}

--- a/tests/slm_prompt_parsing.rs
+++ b/tests/slm_prompt_parsing.rs
@@ -53,8 +53,13 @@ fn build_prompt_should_match_foundation_contract_for_sparse_window() {
 
     let prompt = worker.build_prompt("session-42", &window);
 
+    // Golden Phi-3 chat-template render: the system prompt is wrapped
+    // in `<|system|>…<|end|>`, the windowed turns in `<|user|>…<|end|>`,
+    // and the prompt ends with the bare `<|assistant|>\n` generation
+    // cue. This is the exact byte sequence the tokenizer encodes with
+    // special tokens before inference.
     let expected = concat!(
-        "SYSTEM:\n",
+        "<|system|>\n",
         "You extract durable facts from conversations. Output JSON only — no prose,\n",
         "no markdown fences. Each fact is one of four kinds:\n\n",
         "  decision     — a choice made between alternatives\n",
@@ -74,8 +79,9 @@ fn build_prompt_should_match_foundation_contract_for_sparse_window() {
         "Allowed outputs only:\n",
         "  {\"facts\":[]}\n",
         "  {\"facts\":[{\"kind\":\"preference\",\"about\":\"beverage\",\"strength\":\"high\",\"summary\":\"The user prefers coffee to tea.\"}]}\n",
-        "Return: {\"facts\": [...]}. Empty array if nothing durable.\n\n",
-        "USER:\n",
+        "Return: {\"facts\": [...]}. Empty array if nothing durable.",
+        "<|end|>\n",
+        "<|user|>\n",
         "Session: session-42\n",
         "New turns to extract from (turns 11..12):\n",
         "  [turn 11, user, 2026-05-03T10:00:11Z]\n",
@@ -88,7 +94,9 @@ fn build_prompt_should_match_foundation_contract_for_sparse_window() {
         "  [turn 9, assistant, 2026-05-03T10:00:09Z]\n",
         "    Rust would keep the CLI local-first.\n",
         "  [turn 10, user, 2026-05-03T10:00:10Z]\n",
-        "    I care most about stability."
+        "    I care most about stability.",
+        "<|end|>\n",
+        "<|assistant|>\n"
     );
 
     assert_eq!(prompt, expected);
@@ -192,10 +200,13 @@ fn parse_response_should_recover_json_after_bracketed_prose_only_line() {
 }
 
 #[test]
-fn parse_response_should_reject_fenced_wrapper() {
-    let error = parse_response("```json\n{\"facts\":[]}\n```").unwrap_err();
+fn parse_response_should_accept_single_json_fence() {
+    // A lone fenced JSON envelope is unwrapped and parsed; the full
+    // fence-recovery matrix lives in tests/slm_parse_response.rs.
+    let parsed = parse_response("```json\n{\"facts\":[]}\n```").unwrap();
 
-    assert!(matches!(error, SlmError::Parse { .. }));
+    assert!(parsed.facts.is_empty());
+    assert!(parsed.validation_errors.is_empty());
 }
 
 #[test]

--- a/tests/slm_runtime.rs
+++ b/tests/slm_runtime.rs
@@ -43,13 +43,24 @@ fn slm_runner_accepts_object_valued_rope_scaling_config() {
 }
 
 #[test]
-fn parse_response_rejects_fenced_response() {
-    let error = parse_response(
+fn parse_response_accepts_single_fenced_response() {
+    // A lone fenced JSON envelope is now unwrapped and parsed; only
+    // multi-object / non-JSON fences still fail closed (covered in
+    // tests/slm_parse_response.rs).
+    let parsed = parse_response(
         "```json\n{\"facts\":[{\"kind\":\"preference\",\"about\":\"language\",\"summary\":\"Rust is preferred\"}]}\n```",
     )
-    .expect_err("markdown fences must fail closed");
+    .expect("single fenced envelope should be recovered");
 
-    assert!(matches!(error, SlmError::Parse { .. }));
+    assert_eq!(
+        parsed.facts,
+        vec![RawFact::Preference {
+            about: "language".to_string(),
+            strength: None,
+            summary: "Rust is preferred".to_string(),
+        }]
+    );
+    assert!(parsed.validation_errors.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
Implements **Area 15 — SLM extraction quality & model lifecycle** (steps 2–5; step 1's DAB bisect can't run locally — flagged).

## Changes
- **Phi-3 chat template**: `build_prompt` now renders `<|system|>…<|end|>\n<|user|>…<|end|>\n<|assistant|>\n` (was plain `SYSTEM:/USER:` which made the instruct model behave base-like and necessitated ~300 lines of echo-recovery); encode with special tokens; stop on **all** EOS ids from `generation_config.json` (was only `config.json`'s single eos, so completions could burn the full 2048-token budget).
- **Fence recovery**: `recover_commentary_wrapped_object` now accepts exactly one ```json-fenced envelope (was rejecting it → window parse failure → dead-lettered job → facts permanently lost); still fails closed for multiple objects / non-JSON.
- **F16 weights + idle unload**: weights load half-precision instead of F32 (~15GB→~8GB resident); `LazySlmRunner` unloads after an idle TTL (300s). (BF16 requested, but candle 0.8 CPU matmul lacks BF16 → F16 on CPU; GPU→BF16 mapping kept for future backends.)
- **Reject non-phi3 curated aliases** (gemma-3-1b/4b) at `quaid model pull` time with a clear error, instead of downloading GBs the runner then refuses to load.

## Validation
fmt/clippy/rustdoc clean (incl. online-model channel). `tests/slm_parse_response.rs` 20/20 (fence matrix, scalar+array EOS-stop, half-precision load, idle-unload-then-reload), `slm_runtime` 7/7, golden Phi-3 prompt snapshot, `cli_extraction` gemma-rejection subprocess test, model_lifecycle under online-model channel.

## ⚠️ Post-merge requirement
The template change shifts SLM outputs — **DAB re-baselining is required post-merge**; gate via the existing mini-bench (per the review). `DEFAULT_SLM_IDLE_UNLOAD_TTL` is a fixed 300s constant, not yet config-driven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)