### PR TITLE
feat(privacy): outbound secret-scrubbing layer at the MCP chokepoint + memory_rehydrate (area 24, #159)

### DIFF
--- a/src/commands/call.rs
+++ b/src/commands/call.rs
@@ -150,6 +150,13 @@ pub fn dispatch_tool(server: &QuaidServer, tool: &str, params: Value) -> Result<
                 serde_json::from_value(params).map_err(|e| format!("invalid params: {e}"))?;
             server.memory_raw(input).map_err(|e| e.message.to_string())
         }
+        "memory_rehydrate" => {
+            let input: MemoryRehydrateInput =
+                serde_json::from_value(params).map_err(|e| format!("invalid params: {e}"))?;
+            server
+                .memory_rehydrate(input)
+                .map_err(|e| e.message.to_string())
+        }
         _ => return Err(format!("unknown tool: {tool}")),
     };
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -60,6 +60,9 @@ pub mod quarantine;
 pub mod raw_imports;
 /// Reconciliation of competing pages and revisions.
 pub mod reconciler;
+/// Outbound secret scrubbing for the MCP read surface (deterministic,
+/// pattern-based, opt-in via `mcp.redact_outbound`).
+pub mod redaction;
 /// Hybrid search composition that fuses FTS5, vector, and palace filters.
 pub mod search;
 /// Superseding-page semantics: redirect chains and freshness ordering.

--- a/src/core/redaction.rs
+++ b/src/core/redaction.rs
@@ -1,0 +1,327 @@
+//! Outbound secret scrubbing for the MCP read surface.
+//!
+//! This module implements phase 1 of issue #159: a deterministic,
+//! pattern-based scrub that runs at the MCP serialization choke point
+//! (`crate::mcp::tools::{pages,search,conversation}`) just before page
+//! content is handed to a (frequently cloud-hosted) LLM client. It is
+//! deliberately *outbound only*: FTS5 and embeddings always index the
+//! original text, so retrieval quality is unaffected and the scrub only
+//! changes what crosses the wire.
+//!
+//! What this is NOT: this is **secret scrubbing**, not full PII / NER
+//! redaction. It catches high-confidence machine-shaped secrets (emails,
+//! phone numbers, API-key shapes, account / card numbers) plus a
+//! user-supplied blocklist. Names and other free-text PII are explicitly
+//! deferred to a later phase (#159 notes `crate::core::entities` patterns
+//! can feed a future NER pass).
+//!
+//! Determinism: within a single [`crate::core::redaction::RedactionSession`]
+//! the same original value always maps to the same token (`<EMAIL_1>`,
+//! `<SECRET_2>`, ...), preserving coreference so an LLM can still reason
+//! about "the same key" appearing twice. The session also retains the
+//! reverse mapping so the `memory_rehydrate` MCP tool can turn tokens back
+//! into the originals locally, without ever sending them over the wire.
+
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+/// Outbound redaction mode, parsed from the `mcp.redact_outbound` config key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RedactMode {
+    /// No scrubbing — output is byte-identical to the unredacted payload.
+    Off,
+    /// Deterministic pattern + blocklist scrubbing (phase 1).
+    Patterns,
+}
+
+impl RedactMode {
+    /// Parse the `mcp.redact_outbound` config value. Unknown values fall
+    /// back to [`RedactMode::Off`] so a malformed config never silently
+    /// turns scrubbing on (or, worse, errors out a read tool).
+    pub fn from_config_value(value: &str) -> Self {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "patterns" => RedactMode::Patterns,
+            _ => RedactMode::Off,
+        }
+    }
+
+    /// Whether this mode performs any scrubbing.
+    pub fn is_active(self) -> bool {
+        matches!(self, RedactMode::Patterns)
+    }
+}
+
+/// A single secret class. The ordering of [`PATTERN_CLASSES`] is the match
+/// priority: more specific shapes (keys, cards) are scrubbed before the
+/// broad token shape so an API key is never mislabelled `<TOKEN_1>`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SecretClass {
+    Email,
+    Phone,
+    ApiKey,
+    AccountNumber,
+    Token,
+}
+
+impl SecretClass {
+    /// Token prefix used in the placeholder, e.g. `EMAIL` -> `<EMAIL_1>`.
+    fn token_prefix(self) -> &'static str {
+        match self {
+            SecretClass::Email => "EMAIL",
+            SecretClass::Phone => "PHONE",
+            SecretClass::ApiKey => "SECRET",
+            SecretClass::AccountNumber => "ACCOUNT",
+            SecretClass::Token => "TOKEN",
+        }
+    }
+}
+
+struct PatternClass {
+    class: SecretClass,
+    regex: Regex,
+}
+
+/// Compiled secret-shape regexes, ordered by match priority. Built once per
+/// process via [`LazyLock`]. Patterns are intentionally conservative — the
+/// feature is opt-in, so false positives that mangle context are the bigger
+/// risk than a missed secret (#159 risk note).
+static PATTERN_CLASSES: LazyLock<Vec<PatternClass>> = LazyLock::new(|| {
+    // reason: these literals are authored and tested constants; a panic here
+    // would fire at first use in every build and is caught by unit tests.
+    #[allow(clippy::expect_used)]
+    fn compile(pattern: &str) -> Regex {
+        Regex::new(pattern).expect("redaction pattern must compile")
+    }
+
+    vec![
+        // Emails: local-part@domain.tld. Kept first so an address is never
+        // shredded into account/token fragments.
+        PatternClass {
+            class: SecretClass::Email,
+            regex: compile(r"(?i)\b[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}\b"),
+        },
+        // Provider API-key shapes: OpenAI-style `sk-...`/`sk-proj-...`,
+        // AWS access keys `AKIA...`, GitHub tokens `ghp_`/`gho_`/`ghs_`.
+        PatternClass {
+            class: SecretClass::ApiKey,
+            regex: compile(
+                r"(?x)
+                \b(?:
+                    sk-(?:proj-)?[A-Za-z0-9_\-]{16,}
+                  | (?:AKIA|ASIA)[A-Z0-9]{16}
+                  | gh[posru]_[A-Za-z0-9]{20,}
+                  | xox[baprs]-[A-Za-z0-9\-]{10,}
+                )\b",
+            ),
+        },
+        // Payment-card / account numbers: 13-19 digits, optionally grouped
+        // by spaces or dashes in 4s. Checked before the bare token shape so
+        // a card number is labelled `<ACCOUNT_n>` not `<TOKEN_n>`.
+        PatternClass {
+            class: SecretClass::AccountNumber,
+            regex: compile(r"\b(?:\d[ \-]?){12,18}\d\b"),
+        },
+        // Phone numbers: optional +country code, separators, grouped digits.
+        // The `regex` crate has no look-around, so we anchor on a word
+        // boundary plus an optional leading `+` and require at least two
+        // separated digit groups to avoid swallowing bare integers.
+        PatternClass {
+            class: SecretClass::Phone,
+            regex: compile(
+                r"(?x)
+                \+?\d{1,3}[\s.\-](?:\(\d{1,4}\)[\s.\-]?)?\d{2,4}(?:[\s.\-]\d{2,4}){1,3}
+                \b",
+            ),
+        },
+        // Long opaque tokens: 32+ chars of base64/hex-ish alphabet. Catches
+        // bearer tokens and hex secrets the named shapes above miss.
+        //
+        // The alphabet deliberately excludes `-` so hyphenated UUIDs
+        // (`xxxxxxxx-xxxx-...`, a common structural identifier such as a
+        // page `quaid_id`) split at their hyphens into sub-32 segments and
+        // are NOT masked. `sk-…`/`AKIA…`-style hyphenated keys are already
+        // caught by the higher-priority API-key class above.
+        PatternClass {
+            class: SecretClass::Token,
+            regex: compile(r"\b[A-Za-z0-9+/_]{32,}={0,2}\b"),
+        },
+    ]
+});
+
+/// Per-connection redaction state: deterministic forward (original -> token)
+/// and reverse (token -> original) maps plus per-class counters.
+///
+/// One of these lives behind a `Mutex` on `crate::mcp::server::QuaidServer`,
+/// which is per-connection (each stdio session / SSE connection gets a fresh
+/// `QuaidServer`), so token numbering is stable for the life of a connection
+/// and never leaks across clients.
+#[derive(Debug, Default)]
+pub struct RedactionSession {
+    /// original secret -> assigned token
+    forward: HashMap<String, String>,
+    /// token -> original secret
+    reverse: HashMap<String, String>,
+    /// next index per token prefix (e.g. "EMAIL" -> 3)
+    counters: HashMap<&'static str, usize>,
+    /// user-defined literal blocklist (longest-first for greedy matching)
+    blocklist: Vec<String>,
+}
+
+impl RedactionSession {
+    /// Build a session with an optional user-defined blocklist. Blocklist
+    /// entries are matched as plain (case-insensitive) substrings and are
+    /// scrubbed before the regex classes, so a custom secret always wins
+    /// over a generic shape.
+    pub fn new(blocklist: Vec<String>) -> Self {
+        let mut blocklist: Vec<String> = blocklist
+            .into_iter()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        // Longest-first so overlapping entries scrub the larger secret.
+        blocklist.sort_by(|a, b| b.len().cmp(&a.len()).then_with(|| a.cmp(b)));
+        blocklist.dedup();
+        Self {
+            blocklist,
+            ..Self::default()
+        }
+    }
+
+    /// Number of distinct secrets masked so far in this session.
+    pub fn masked_count(&self) -> usize {
+        self.forward.len()
+    }
+
+    /// Assign (or reuse) a deterministic token for one original value under
+    /// the given class prefix.
+    fn token_for(&mut self, prefix: &'static str, original: &str) -> String {
+        if let Some(existing) = self.forward.get(original) {
+            return existing.clone();
+        }
+        let counter = self.counters.entry(prefix).or_insert(0);
+        *counter += 1;
+        let token = format!("<{prefix}_{counter}>");
+        self.forward.insert(original.to_string(), token.clone());
+        self.reverse.insert(token.clone(), original.to_string());
+        token
+    }
+
+    /// Scrub `text`, replacing every recognised secret with a deterministic
+    /// token and recording the mapping. Returns the scrubbed string. When
+    /// nothing matches, the returned string equals the input.
+    pub fn scrub(&mut self, text: &str) -> String {
+        // Blocklist first (case-insensitive literal substrings), then the
+        // ordered regex classes. Each pass operates on the output of the
+        // previous so a token emitted by one pass is never re-scrubbed by a
+        // later one (tokens contain `<`/`>`, outside every pattern alphabet).
+        let mut out = self.scrub_blocklist(text);
+        for pattern in PATTERN_CLASSES.iter() {
+            out = self.scrub_with(&pattern.regex, pattern.class.token_prefix(), &out);
+        }
+        out
+    }
+
+    fn scrub_blocklist(&mut self, text: &str) -> String {
+        if self.blocklist.is_empty() {
+            return text.to_string();
+        }
+        let mut out = text.to_string();
+        // Clone the entries to avoid borrowing `self` while we mutate the maps.
+        let entries = self.blocklist.clone();
+        for entry in entries {
+            // Case-insensitive find loop preserving the matched original case.
+            let mut search_from = 0usize;
+            let lower_entry = entry.to_ascii_lowercase();
+            loop {
+                let haystack = out[search_from..].to_ascii_lowercase();
+                let Some(rel) = haystack.find(&lower_entry) else {
+                    break;
+                };
+                let start = search_from + rel;
+                let end = start + entry.len();
+                let matched = out[start..end].to_string();
+                let token = self.token_for(SecretClass::ApiKey.token_prefix(), &matched);
+                out.replace_range(start..end, &token);
+                search_from = start + token.len();
+            }
+        }
+        out
+    }
+
+    fn scrub_with(&mut self, regex: &Regex, prefix: &'static str, text: &str) -> String {
+        // Collect match spans first (immutable borrow of `text`).
+        let spans: Vec<(usize, usize, String)> = regex
+            .find_iter(text)
+            .map(|m| (m.start(), m.end(), m.as_str().to_string()))
+            .collect();
+        if spans.is_empty() {
+            return text.to_string();
+        }
+        // Assign tokens in document order so numbering reads left-to-right,
+        // then rewrite right-to-left so byte offsets stay valid as we splice.
+        let tokens: Vec<(usize, usize, String)> = spans
+            .into_iter()
+            .map(|(start, end, matched)| (start, end, self.token_for(prefix, &matched)))
+            .collect();
+        let mut out = text.to_string();
+        for (start, end, token) in tokens.into_iter().rev() {
+            out.replace_range(start..end, &token);
+        }
+        out
+    }
+
+    /// Reverse the session mapping: replace every known token in `text` with
+    /// its original value. Unknown tokens are left untouched. This is the
+    /// inverse of [`RedactionSession::scrub`] for the same session.
+    pub fn rehydrate(&self, text: &str) -> String {
+        if self.reverse.is_empty() {
+            return text.to_string();
+        }
+        // Token shape is `<PREFIX_n>`; match it generically and look each up.
+        static TOKEN_RE: LazyLock<Regex> = LazyLock::new(|| {
+            #[allow(clippy::expect_used)]
+            Regex::new(r"<[A-Z]+_\d+>").expect("token regex must compile")
+        });
+        let spans: Vec<(usize, usize, String)> = TOKEN_RE
+            .find_iter(text)
+            .filter_map(|m| {
+                self.reverse
+                    .get(m.as_str())
+                    .map(|orig| (m.start(), m.end(), orig.clone()))
+            })
+            .collect();
+        if spans.is_empty() {
+            return text.to_string();
+        }
+        let mut out = text.to_string();
+        for (start, end, original) in spans.into_iter().rev() {
+            out.replace_range(start..end, &original);
+        }
+        out
+    }
+}
+
+/// Read the configured outbound-redaction mode from the `config` table.
+pub fn redact_mode_from_config(value: Option<&str>) -> RedactMode {
+    value
+        .map(RedactMode::from_config_value)
+        .unwrap_or(RedactMode::Off)
+}
+
+/// Parse the user-defined blocklist config value (`mcp.redact_blocklist`).
+///
+/// The value is a comma- or newline-separated list of literal secrets to
+/// always scrub (e.g. an internal project codename). Empty / whitespace
+/// entries are dropped.
+pub fn parse_blocklist(value: Option<&str>) -> Vec<String> {
+    value
+        .map(|raw| {
+            raw.split(['\n', ','])
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect()
+        })
+        .unwrap_or_default()
+}

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -41,6 +41,7 @@ use crate::mcp::validation::{
 
 pub(crate) type DbRef = Arc<Mutex<Connection>>;
 pub(crate) type SlmRef = Arc<dyn SlmClient + Send + Sync>;
+pub(crate) type RedactionRef = Arc<Mutex<crate::core::redaction::RedactionSession>>;
 
 pub(crate) fn canonical_slug(collection_name: &str, slug: &str) -> String {
     format!("{collection_name}::{slug}")
@@ -187,6 +188,11 @@ pub(crate) fn extraction_debounce_ms(db: &Connection) -> Result<i64, rmcp::Error
 pub struct QuaidServer {
     pub(crate) db: DbRef,
     pub(crate) slm: SlmRef,
+    /// Per-connection outbound-redaction state. The token map is lazily
+    /// initialised from `mcp.redact_*` config on first scrub and lives for
+    /// the life of the connection, so tokens are stable per session and
+    /// never leak across clients. See [`crate::core::redaction`].
+    pub(crate) redaction: RedactionRef,
 }
 
 impl QuaidServer {
@@ -206,9 +212,21 @@ impl QuaidServer {
     where
         S: SlmClient + Send + Sync + 'static,
     {
+        // Seed the per-connection redaction session with the user-defined
+        // blocklist now; the mode itself is re-read per call so a live
+        // `config.set mcp.redact_outbound patterns` takes effect immediately.
+        let blocklist = crate::core::redaction::parse_blocklist(
+            db::read_config_value(&conn, "mcp.redact_blocklist")
+                .ok()
+                .flatten()
+                .as_deref(),
+        );
         Self {
             db: Arc::new(Mutex::new(conn)),
             slm,
+            redaction: Arc::new(Mutex::new(crate::core::redaction::RedactionSession::new(
+                blocklist,
+            ))),
         }
     }
 
@@ -224,6 +242,51 @@ impl QuaidServer {
     pub(crate) fn slm(&self) -> &SlmRef {
         &self.slm
     }
+
+    /// Borrow the per-connection redaction session. Used by the
+    /// `memory_rehydrate` tool to reverse the session token map.
+    pub(crate) fn redaction(&self) -> &RedactionRef {
+        &self.redaction
+    }
+
+    /// Resolve the effective outbound-redaction mode for a read tool call.
+    ///
+    /// Precedence: an explicit per-call `redact` flag wins over the
+    /// `mcp.redact_outbound` config default. A `redact: false` override can
+    /// force plaintext even when the config defaults to scrubbing.
+    pub(crate) fn resolve_redact_mode(
+        &self,
+        db: &Connection,
+        per_call: Option<bool>,
+    ) -> crate::core::redaction::RedactMode {
+        use crate::core::redaction::RedactMode;
+        match per_call {
+            Some(true) => RedactMode::Patterns,
+            Some(false) => RedactMode::Off,
+            None => crate::core::redaction::redact_mode_from_config(
+                db::read_config_value(db, "mcp.redact_outbound")
+                    .ok()
+                    .flatten()
+                    .as_deref(),
+            ),
+        }
+    }
+
+    /// Scrub an already-serialized outbound payload according to `mode`,
+    /// recording the token map on the per-connection session. When `mode`
+    /// is [`crate::core::redaction::RedactMode::Off`] the input is returned
+    /// unchanged (byte-identical), so non-redacting callers pay nothing.
+    pub(crate) fn apply_redaction(
+        &self,
+        mode: crate::core::redaction::RedactMode,
+        payload: String,
+    ) -> String {
+        if !mode.is_active() {
+            return payload;
+        }
+        let mut session = self.redaction.lock().unwrap_or_else(|e| e.into_inner());
+        session.scrub(&payload)
+    }
 }
 
 /// Input schema for the `memory_get` MCP tool.
@@ -231,6 +294,9 @@ impl QuaidServer {
 pub struct MemoryGetInput {
     /// Page slug to retrieve
     pub slug: String,
+    /// Scrub machine-shaped secrets from the outbound payload. Omitted
+    /// falls back to the `mcp.redact_outbound` config default.
+    pub redact: Option<bool>,
 }
 
 /// Input schema for the `memory_put` MCP tool.
@@ -320,6 +386,9 @@ pub struct MemoryQueryInput {
     pub depth: Option<String>,
     /// Include superseded historical pages in results
     pub include_superseded: Option<bool>,
+    /// Scrub machine-shaped secrets from the outbound payload. Omitted
+    /// falls back to the `mcp.redact_outbound` config default.
+    pub redact: Option<bool>,
 }
 
 /// Input schema for the `memory_search` MCP tool.
@@ -337,6 +406,9 @@ pub struct MemorySearchInput {
     pub limit: Option<u32>,
     /// Include superseded historical pages in results
     pub include_superseded: Option<bool>,
+    /// Scrub machine-shaped secrets from the outbound payload. Omitted
+    /// falls back to the `mcp.redact_outbound` config default.
+    pub redact: Option<bool>,
 }
 
 /// Input schema for the `memory_list` MCP tool.
@@ -485,6 +557,14 @@ pub struct MemoryRawInput {
     pub overwrite: Option<bool>,
 }
 
+/// Input schema for the `memory_rehydrate` MCP tool.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct MemoryRehydrateInput {
+    /// Text containing redaction tokens (e.g. `<EMAIL_1>`) to reverse back
+    /// to their original values using this connection's session map.
+    pub text: String,
+}
+
 // Central registry: every `#[tool]` method exposed by `QuaidServer`,
 // regardless of which file in `crate::mcp::tools::*` defines it, must be
 // listed here. The `rmcp::tool_box!` macro generates the static `ToolBox`
@@ -501,6 +581,8 @@ impl QuaidServer {
         // search
         memory_query,
         memory_search,
+        // redaction
+        memory_rehydrate,
         // links
         memory_link,
         memory_link_close,
@@ -585,7 +667,7 @@ mod tests {
     /// test catches it before the post-split MCP wire surface diverges from
     /// the pre-split baseline.
     #[test]
-    fn tool_registry_lists_all_24_tools() {
+    fn tool_registry_lists_all_25_tools() {
         let names: std::collections::BTreeSet<String> = QuaidServer::tool_box()
             .list()
             .into_iter()
@@ -598,6 +680,7 @@ mod tests {
             "memory_raw",
             "memory_query",
             "memory_search",
+            "memory_rehydrate",
             "memory_link",
             "memory_link_close",
             "memory_backlinks",
@@ -621,7 +704,7 @@ mod tests {
         .map(|s| (*s).to_string())
         .collect();
         assert_eq!(names, expected, "tool registry drift");
-        assert_eq!(names.len(), 24, "expected 24 tools, got {}", names.len());
+        assert_eq!(names.len(), 25, "expected 25 tools, got {}", names.len());
     }
 
     #[test]
@@ -1240,6 +1323,7 @@ mod tests {
                 limit: None,
                 depth: None,
                 include_superseded: None,
+                redact: None,
             })
             .unwrap();
 

--- a/src/mcp/tools/pages.rs
+++ b/src/mcp/tools/pages.rs
@@ -22,7 +22,7 @@ use crate::mcp::errors::{
 use crate::mcp::server::{
     canonical_slug, canonicalize_page_for_mcp, page_id_for_resolved,
     resolve_memory_collection_filter_for_mcp, resolve_slug_for_mcp, MemoryGetInput,
-    MemoryListInput, MemoryPutInput, MemoryRawInput, QuaidServer,
+    MemoryListInput, MemoryPutInput, MemoryRawInput, MemoryRehydrateInput, QuaidServer,
 };
 use crate::mcp::validation::{validate_content, validate_slug, MAX_LIMIT, MAX_RAW_DATA_LEN};
 
@@ -40,6 +40,7 @@ impl QuaidServer {
     ) -> Result<CallToolResult, rmcp::Error> {
         validate_slug(&input.slug)?;
         let db = self.db().lock().unwrap_or_else(|e| e.into_inner());
+        let redact_mode = self.resolve_redact_mode(&db, input.redact);
         let resolved = resolve_slug_for_mcp(&db, &input.slug, OpKind::Read)?;
         let page = vault_sync::get_page_by_input(&db, &input.slug).map_err(map_vault_sync_error)?;
         let canonical_page = canonicalize_page_for_mcp(&page, &resolved);
@@ -71,6 +72,10 @@ impl QuaidServer {
             "superseded_by": successor_slug,
         }))
         .map_err(map_serialize_error)?;
+        // Outbound-only scrub: FTS5 and embeddings still index the originals;
+        // only this serialized payload (the bytes crossing the MCP wire) is
+        // masked. When the mode is Off the payload is returned byte-identical.
+        let json = self.apply_redaction(redact_mode, json);
         Ok(CallToolResult::success(vec![Content::text(json)]))
     }
 
@@ -313,6 +318,29 @@ impl QuaidServer {
 
         let row_id = db.last_insert_rowid();
         let result = serde_json::json!({ "id": row_id });
+        Ok(CallToolResult::success(vec![Content::text(
+            serialize_response(&result)?,
+        )]))
+    }
+
+    /// `memory_rehydrate` MCP tool: reverse this connection's outbound
+    /// redaction map, replacing `<EMAIL_1>`-style tokens with the original
+    /// values that were scrubbed earlier in the same session. The reversal
+    /// happens entirely locally — originals never leave the machine until
+    /// the agent chooses to act on the rehydrated text — so an agent can
+    /// round-trip a redacted read without losing the underlying secret.
+    /// Unknown tokens are passed through untouched.
+    #[tool(description = "Reverse outbound redaction tokens back to originals for this session")]
+    /// `memory_rehydrate` MCP tool: reverse this connection's outbound
+    /// redaction map, replacing `<EMAIL_1>`-style tokens with the original
+    /// values that were scrubbed earlier in the same session.
+    pub fn memory_rehydrate(
+        &self,
+        #[tool(aggr)] input: MemoryRehydrateInput,
+    ) -> Result<CallToolResult, rmcp::Error> {
+        let session = self.redaction().lock().unwrap_or_else(|e| e.into_inner());
+        let restored = session.rehydrate(&input.text);
+        let result = serde_json::json!({ "text": restored });
         Ok(CallToolResult::success(vec![Content::text(
             serialize_response(&result)?,
         )]))

--- a/src/mcp/tools/search.rs
+++ b/src/mcp/tools/search.rs
@@ -35,6 +35,7 @@ impl QuaidServer {
         let db = self.db().lock().unwrap_or_else(|e| e.into_inner());
         namespace::validate_optional_namespace(input.namespace.as_deref())
             .map_err(map_namespace_error)?;
+        let redact_mode = self.resolve_redact_mode(&db, input.redact);
         let namespace_filter = input.namespace.as_deref().or(Some(""));
         let collection_filter =
             resolve_memory_collection_filter_for_mcp(&db, input.collection.as_deref())?;
@@ -94,6 +95,9 @@ impl QuaidServer {
         };
 
         let json = serde_json::to_string_pretty(&results).map_err(map_serialize_error)?;
+        // Outbound-only scrub: the hybrid index used the originals; only the
+        // serialized result payload is masked. Off => byte-identical output.
+        let json = self.apply_redaction(redact_mode, json);
         Ok(CallToolResult::success(vec![Content::text(json)]))
     }
 
@@ -111,6 +115,7 @@ impl QuaidServer {
         let db = self.db().lock().unwrap_or_else(|e| e.into_inner());
         namespace::validate_optional_namespace(input.namespace.as_deref())
             .map_err(map_namespace_error)?;
+        let redact_mode = self.resolve_redact_mode(&db, input.redact);
         let namespace_filter = input.namespace.as_deref().or(Some(""));
         let collection_filter =
             resolve_memory_collection_filter_for_mcp(&db, input.collection.as_deref())?;
@@ -133,6 +138,8 @@ impl QuaidServer {
         .map_err(map_search_error)?;
 
         let json = serde_json::to_string_pretty(&results).map_err(map_serialize_error)?;
+        // Outbound-only scrub; Off => byte-identical output.
+        let json = self.apply_redaction(redact_mode, json);
         Ok(CallToolResult::success(vec![Content::text(json)]))
     }
 }

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -462,7 +462,15 @@ INSERT OR IGNORE INTO config (key, value) VALUES
     ('graph_expansion_max',          '50'),
     ('edge_weight_frontmatter',      '1.0'),
     ('edge_weight_entity_pattern',   '0.7'),
-    ('edge_weight_wikilink',         '0.5');
+    ('edge_weight_wikilink',         '0.5'),
+    -- Outbound secret scrubbing for the MCP read surface (issue #159 phase 1).
+    -- 'off' (default) => read payloads cross the wire byte-identical to today;
+    -- 'patterns' => deterministic regex/blocklist scrub at the serialization
+    -- chokepoint. FTS5/embeddings always index originals (outbound-only).
+    ('mcp.redact_outbound',          'off'),
+    -- Comma/newline-separated literal secrets to always scrub (e.g. an
+    -- internal codename). Empty by default.
+    ('mcp.redact_blocklist',         '');
 
 -- ============================================================
 -- contradictions: detected inconsistencies

--- a/tests/entity_extraction.rs
+++ b/tests/entity_extraction.rs
@@ -75,6 +75,32 @@ fn count_entity_pattern_links(conn: &Connection) -> i64 {
     .unwrap()
 }
 
+/// `entities::run_for_page` with a generous extraction deadline.
+///
+/// The production 5 ms budget is load-sensitive: on a saturated CI runner the
+/// first pattern can already blow it, skipping extraction and flaking any
+/// assertion-count expectation. Routing tests pin a deterministic deadline via
+/// the explicit seam; budget behaviour itself is covered by the
+/// `extract_entities` over-budget test.
+fn run_for_page_generous(
+    conn: &Connection,
+    page_id: i64,
+    collection_id: i64,
+    page_slug: &str,
+    compiled_truth: &str,
+    patterns: &[EntityPattern],
+) -> Result<entities::RoutingSummary, entities::EntityError> {
+    entities::run_for_page_with_deadline(
+        conn,
+        page_id,
+        collection_id,
+        page_slug,
+        compiled_truth,
+        patterns,
+        Duration::from_secs(30),
+    )
+}
+
 // ── 6.x: pattern config and validation ────────────────────────
 
 #[test]
@@ -305,7 +331,7 @@ fn budget_overrun_logs_knowledge_gap() {
     assert!(outcome.over_budget);
 
     // Force the wired gap-logging via the helper for budget overrun.
-    let summary = entities::run_for_page(&conn, page_id, 1, "people/alice", "", &[]).unwrap();
+    let summary = run_for_page_generous(&conn, page_id, 1, "people/alice", "", &[]).unwrap();
     assert_eq!(summary.matches_seen, 0);
     let gap_count: i64 = conn
         .query_row("SELECT COUNT(*) FROM knowledge_gaps", [], |row| row.get(0))
@@ -323,7 +349,7 @@ fn match_with_both_resolved_inserts_assertion_no_link() {
     insert_page(&conn, "companies/brex", "Brex", "body");
 
     let patterns = entities::load_patterns_from(None, &conn).unwrap();
-    let summary = entities::run_for_page(
+    let summary = run_for_page_generous(
         &conn,
         source,
         1,
@@ -360,7 +386,7 @@ fn unresolved_match_still_inserts_assertion_no_link() {
     insert_page(&conn, "people/alice", "Alice", "body");
 
     let patterns = entities::load_patterns_from(None, &conn).unwrap();
-    let summary = entities::run_for_page(
+    let summary = run_for_page_generous(
         &conn,
         source,
         1,
@@ -387,7 +413,7 @@ fn unresolved_evidence_does_not_include_raw_capture_text() {
     insert_page(&conn, "people/alice", "Alice", "body");
 
     let patterns = entities::load_patterns_from(None, &conn).unwrap();
-    entities::run_for_page(
+    run_for_page_generous(
         &conn,
         source,
         1,
@@ -450,7 +476,7 @@ fn idempotent_reingest_does_not_duplicate_assertions() {
     let patterns = entities::load_patterns_from(None, &conn).unwrap();
 
     for _ in 0..3 {
-        entities::run_for_page(
+        run_for_page_generous(
             &conn,
             source,
             1,
@@ -475,7 +501,7 @@ fn reingest_removes_entity_assertions_no_longer_in_page_text() {
     insert_page(&conn, "companies/stripe", "Stripe", "body");
     let patterns = entities::load_patterns_from(None, &conn).unwrap();
 
-    entities::run_for_page(
+    run_for_page_generous(
         &conn,
         source,
         1,
@@ -484,7 +510,7 @@ fn reingest_removes_entity_assertions_no_longer_in_page_text() {
         &patterns,
     )
     .unwrap();
-    entities::run_for_page(
+    run_for_page_generous(
         &conn,
         source,
         1,
@@ -574,7 +600,7 @@ fn over_budget_run_for_page_logs_gap_and_preserves_existing_entity_assertions() 
     insert_page(&conn, "companies/brex", "Brex", "body");
     let patterns = entities::load_patterns_from(None, &conn).unwrap();
 
-    entities::run_for_page(
+    run_for_page_generous(
         &conn,
         source,
         1,

--- a/tests/extraction_end_to_end_smoke.rs
+++ b/tests/extraction_end_to_end_smoke.rs
@@ -208,6 +208,7 @@ fn turn_capture_close_extract_fact_and_search_smoke() {
             wing: None,
             limit: Some(5),
             include_superseded: Some(false),
+            redact: None,
         })
         .unwrap();
     let rows: Vec<serde_json::Value> = serde_json::from_str(&extract_text(&search)).unwrap();

--- a/tests/file_edit_supersede.rs
+++ b/tests/file_edit_supersede.rs
@@ -200,6 +200,7 @@ fn editing_chained_extracted_preference_preserves_one_linear_chain() {
                 wing: None,
                 limit: None,
                 include_superseded: None,
+                redact: None,
             })
             .unwrap(),
     ))
@@ -218,6 +219,7 @@ fn editing_chained_extracted_preference_preserves_one_linear_chain() {
                 wing: None,
                 limit: None,
                 include_superseded: Some(true),
+                redact: None,
             })
             .unwrap(),
     ))

--- a/tests/mcp_redaction.rs
+++ b/tests/mcp_redaction.rs
@@ -1,0 +1,266 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "integration test fixtures favour direct unwraps for readable failure output"
+)]
+
+//! Public-API integration tests for the MCP outbound-redaction surface
+//! (issue #159 phase 1). Seeds a page containing an email + API key and
+//! asserts:
+//!   * `memory_get` / `memory_query` / `memory_search` mask secrets when
+//!     `mcp.redact_outbound = patterns` (or per-call `redact: true`);
+//!   * FTS5 still indexes the ORIGINALS (redaction is outbound-only);
+//!   * `memory_rehydrate` reverses the session token map;
+//!   * output is byte-identical to the unredacted payload when `off`.
+
+#[path = "common/mcp_harness.rs"]
+mod harness;
+
+use harness::{create_page, extract_text, open_test_db};
+use quaid::mcp::server::{
+    MemoryGetInput, MemoryQueryInput, MemoryRehydrateInput, MemorySearchInput, QuaidServer,
+};
+use rusqlite::Connection;
+
+const EMAIL: &str = "alice@example.com";
+const API_KEY: &str = "sk-AbCdEf0123456789ZyXwVuTs";
+
+/// Body whose first paragraph (and thus the derived summary) carries the
+/// secrets, so they surface through both `compiled_truth` (memory_get) and
+/// `summary` (memory_query / memory_search).
+fn secret_page_body() -> String {
+    format!(
+        "---\ntitle: Alice\ntype: person\n---\nContact alice at {EMAIL} using key {API_KEY} for access.\n"
+    )
+}
+
+fn set_config(conn: &Connection, key: &str, value: &str) {
+    conn.execute(
+        "INSERT OR REPLACE INTO config(key, value) VALUES (?1, ?2)",
+        rusqlite::params![key, value],
+    )
+    .unwrap();
+}
+
+#[test]
+fn memory_get_masks_secrets_when_redaction_enabled() {
+    let (_dir, conn) = open_test_db();
+    set_config(&conn, "mcp.redact_outbound", "patterns");
+    let server = QuaidServer::new(conn);
+    create_page(&server, "people/alice", &secret_page_body());
+
+    let result = server
+        .memory_get(MemoryGetInput {
+            slug: "people/alice".to_string(),
+            redact: None, // falls back to config default = patterns
+        })
+        .unwrap();
+    let text = extract_text(&result);
+
+    assert!(
+        !text.contains(EMAIL),
+        "email leaked through memory_get: {text}"
+    );
+    assert!(
+        !text.contains(API_KEY),
+        "api key leaked through memory_get: {text}"
+    );
+    assert!(text.contains("<EMAIL_1>"), "email token missing: {text}");
+    assert!(text.contains("<SECRET_1>"), "secret token missing: {text}");
+}
+
+#[test]
+fn memory_get_off_is_byte_identical_to_unredacted() {
+    // Two servers over equivalent DBs: one with redaction off (default),
+    // one explicitly forced off per-call. Both must equal the raw payload.
+    let (_dir, conn) = open_test_db();
+    let server = QuaidServer::new(conn);
+    create_page(&server, "people/alice", &secret_page_body());
+
+    let default_off = extract_text(
+        &server
+            .memory_get(MemoryGetInput {
+                slug: "people/alice".to_string(),
+                redact: None,
+            })
+            .unwrap(),
+    );
+    let forced_off = extract_text(
+        &server
+            .memory_get(MemoryGetInput {
+                slug: "people/alice".to_string(),
+                redact: Some(false),
+            })
+            .unwrap(),
+    );
+
+    assert_eq!(
+        default_off, forced_off,
+        "config-off and per-call-off diverge"
+    );
+    assert!(
+        default_off.contains(EMAIL),
+        "off mode must pass secrets through"
+    );
+    assert!(
+        default_off.contains(API_KEY),
+        "off mode must pass secrets through"
+    );
+}
+
+#[test]
+fn per_call_redact_true_overrides_config_off() {
+    let (_dir, conn) = open_test_db();
+    // config default off
+    let server = QuaidServer::new(conn);
+    create_page(&server, "people/alice", &secret_page_body());
+
+    let masked = extract_text(
+        &server
+            .memory_get(MemoryGetInput {
+                slug: "people/alice".to_string(),
+                redact: Some(true),
+            })
+            .unwrap(),
+    );
+    assert!(!masked.contains(EMAIL), "per-call redact ignored: {masked}");
+    assert!(masked.contains("<EMAIL_1>"));
+}
+
+#[test]
+fn memory_search_masks_summary_but_fts_indexes_originals() {
+    let (_dir, conn) = open_test_db();
+    set_config(&conn, "mcp.redact_outbound", "patterns");
+    let server = QuaidServer::new(conn);
+    create_page(&server, "people/alice", &secret_page_body());
+
+    // FTS proof: search a fragment that exists ONLY inside the email. If the
+    // index held the original, the page is found even though the returned
+    // summary is masked.
+    let result = server
+        .memory_search(MemorySearchInput {
+            query: "example.com".to_string(),
+            collection: None,
+            namespace: None,
+            wing: None,
+            limit: Some(10),
+            include_superseded: None,
+            redact: None,
+        })
+        .unwrap();
+    let text = extract_text(&result);
+
+    assert!(
+        text.contains("people/alice"),
+        "FTS did not index original email: {text}"
+    );
+    assert!(
+        !text.contains(EMAIL),
+        "email leaked through search summary: {text}"
+    );
+    assert!(
+        text.contains("<EMAIL_1>"),
+        "summary email token missing: {text}"
+    );
+}
+
+#[test]
+fn memory_query_masks_summary_when_enabled() {
+    let (_dir, conn) = open_test_db();
+    set_config(&conn, "mcp.redact_outbound", "patterns");
+    let server = QuaidServer::new(conn);
+    create_page(&server, "people/alice", &secret_page_body());
+
+    let result = server
+        .memory_query(MemoryQueryInput {
+            query: "alice contact access".to_string(),
+            collection: None,
+            namespace: None,
+            wing: None,
+            limit: Some(10),
+            depth: None,
+            include_superseded: None,
+            redact: None,
+        })
+        .unwrap();
+    let text = extract_text(&result);
+
+    assert!(
+        text.contains("people/alice"),
+        "query missed the seeded page: {text}"
+    );
+    assert!(
+        !text.contains(EMAIL),
+        "email leaked through query summary: {text}"
+    );
+    assert!(
+        !text.contains(API_KEY),
+        "api key leaked through query summary: {text}"
+    );
+}
+
+#[test]
+fn rehydrate_reverses_session_tokens() {
+    let (_dir, conn) = open_test_db();
+    set_config(&conn, "mcp.redact_outbound", "patterns");
+    let server = QuaidServer::new(conn);
+    create_page(&server, "people/alice", &secret_page_body());
+
+    // Populate the session token map via a redacted read.
+    let masked = extract_text(
+        &server
+            .memory_get(MemoryGetInput {
+                slug: "people/alice".to_string(),
+                redact: None,
+            })
+            .unwrap(),
+    );
+    assert!(masked.contains("<EMAIL_1>"));
+
+    let restored = extract_text(
+        &server
+            .memory_rehydrate(MemoryRehydrateInput { text: masked })
+            .unwrap(),
+    );
+    let restored_json: serde_json::Value = serde_json::from_str(&restored).unwrap();
+    let inner = restored_json
+        .get("text")
+        .and_then(serde_json::Value::as_str)
+        .unwrap();
+
+    assert!(inner.contains(EMAIL), "email not rehydrated: {inner}");
+    assert!(inner.contains(API_KEY), "api key not rehydrated: {inner}");
+}
+
+#[test]
+fn rehydrate_partial_token_string_round_trips() {
+    let (_dir, conn) = open_test_db();
+    set_config(&conn, "mcp.redact_outbound", "patterns");
+    let server = QuaidServer::new(conn);
+    create_page(&server, "people/alice", &secret_page_body());
+
+    // Establish the map.
+    let _ = server
+        .memory_get(MemoryGetInput {
+            slug: "people/alice".to_string(),
+            redact: None,
+        })
+        .unwrap();
+
+    // Rehydrate a hand-written snippet that mixes a known token with prose.
+    let restored = extract_text(
+        &server
+            .memory_rehydrate(MemoryRehydrateInput {
+                text: "the address is <EMAIL_1> per the record".to_string(),
+            })
+            .unwrap(),
+    );
+    let inner: serde_json::Value = serde_json::from_str(&restored).unwrap();
+    assert_eq!(
+        inner
+            .get("text")
+            .and_then(serde_json::Value::as_str)
+            .unwrap(),
+        format!("the address is {EMAIL} per the record")
+    );
+}

--- a/tests/mcp_server_get_put.rs
+++ b/tests/mcp_server_get_put.rs
@@ -30,6 +30,7 @@ fn memory_get_returns_not_found_error_code_for_missing_slug() {
     let error = server
         .memory_get(MemoryGetInput {
             slug: "definitely-does-not-exist".to_string(),
+            redact: None,
         })
         .unwrap_err();
 
@@ -44,6 +45,7 @@ fn memory_get_rejects_invalid_slug() {
     let error = server
         .memory_get(MemoryGetInput {
             slug: "Invalid/SLUG!".to_string(),
+            redact: None,
         })
         .unwrap_err();
 
@@ -70,6 +72,7 @@ fn memory_get_returns_structured_ambiguity_payload_for_colliding_bare_slug() {
     let error = server
         .memory_get(MemoryGetInput {
             slug: "people/alice".to_string(),
+            redact: None,
         })
         .unwrap_err();
 
@@ -112,6 +115,7 @@ fn memory_get_explicit_collection_slug_reads_resolved_page_when_slug_collides() 
     let result = server
         .memory_get(MemoryGetInput {
             slug: "memory::people/alice".to_string(),
+            redact: None,
         })
         .unwrap();
 
@@ -145,6 +149,7 @@ fn memory_get_renders_persisted_memory_id_after_update_omits_frontmatter_uuid() 
     let result = server
         .memory_get(MemoryGetInput {
             slug: "notes/uuid".to_string(),
+            redact: None,
         })
         .unwrap();
     let payload: serde_json::Value = serde_json::from_str(&extract_text(&result)).unwrap();

--- a/tests/mcp_server_query_search_list.rs
+++ b/tests/mcp_server_query_search_list.rs
@@ -58,6 +58,7 @@ fn memory_query_auto_depth_expands_linked_results() {
             limit: Some(1),
             depth: Some("auto".to_string()),
             include_superseded: None,
+            redact: None,
         })
         .unwrap();
 
@@ -106,6 +107,7 @@ fn memory_query_auto_depth_does_not_expand_across_collections() {
             limit: Some(5),
             depth: Some("auto".to_string()),
             include_superseded: None,
+            redact: None,
         })
         .unwrap();
 
@@ -144,6 +146,7 @@ fn memory_query_explicit_collection_filter_returns_only_named_collection() {
             limit: None,
             depth: None,
             include_superseded: None,
+            redact: None,
         })
         .unwrap();
 
@@ -178,6 +181,7 @@ fn memory_query_defaults_to_write_target_when_multiple_collections_are_active() 
             limit: None,
             depth: None,
             include_superseded: None,
+            redact: None,
         })
         .unwrap();
 
@@ -220,6 +224,7 @@ fn memory_query_defaults_to_memory_collection_when_dedicated_memory_location_is_
             limit: None,
             depth: None,
             include_superseded: None,
+            redact: None,
         })
         .unwrap();
 
@@ -249,6 +254,7 @@ fn memory_search_returns_matching_pages() {
             wing: None,
             limit: None,
             include_superseded: None,
+            redact: None,
         })
         .unwrap();
 
@@ -288,6 +294,7 @@ fn memory_search_defaults_to_memory_collection_when_dedicated_memory_location_is
             wing: None,
             limit: None,
             include_superseded: None,
+            redact: None,
         })
         .unwrap();
 
@@ -312,6 +319,7 @@ fn memory_search_natural_language_question_mark_returns_valid_response() {
         wing: None,
         limit: None,
         include_superseded: None,
+        redact: None,
     });
 
     assert!(
@@ -353,6 +361,7 @@ fn memory_search_explicit_collection_filter_returns_only_named_collection() {
             wing: None,
             limit: None,
             include_superseded: None,
+            redact: None,
         })
         .unwrap();
 
@@ -382,6 +391,7 @@ fn memory_search_defaults_to_single_active_collection() {
             wing: None,
             limit: None,
             include_superseded: None,
+            redact: None,
         })
         .unwrap();
 
@@ -541,6 +551,7 @@ fn read_tools_unknown_collection_filter_errors_clearly() {
             limit: None,
             depth: None,
             include_superseded: None,
+            redact: None,
         })
         .unwrap_err();
     assert_eq!(query_error.code, ErrorCode(-32001));
@@ -556,6 +567,7 @@ fn read_tools_unknown_collection_filter_errors_clearly() {
             wing: None,
             limit: None,
             include_superseded: None,
+            redact: None,
         })
         .unwrap_err();
     assert_eq!(search_error.code, ErrorCode(-32001));

--- a/tests/memory_correct.rs
+++ b/tests/memory_correct.rs
@@ -88,6 +88,7 @@ impl Harness {
             .server
             .memory_get(MemoryGetInput {
                 slug: slug.to_string(),
+                redact: None,
             })
             .unwrap();
         serde_json::from_str(&extract_text(&result)).unwrap()

--- a/tests/redaction_patterns.rs
+++ b/tests/redaction_patterns.rs
@@ -1,0 +1,168 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test assertions favour direct unwraps for readable failure output"
+)]
+
+//! Public-API unit tests for `quaid::core::redaction`: one test per secret
+//! class plus blocklist, determinism, and the rehydrate round-trip. These
+//! exercise the scrub engine in isolation; the MCP-surface integration
+//! lives in `tests/mcp_redaction.rs`.
+
+use quaid::core::redaction::{
+    parse_blocklist, redact_mode_from_config, RedactMode, RedactionSession,
+};
+
+fn session() -> RedactionSession {
+    RedactionSession::new(Vec::new())
+}
+
+#[test]
+fn email_is_masked() {
+    let mut s = session();
+    let out = s.scrub("reach me at alice.smith+work@example.co.uk anytime");
+    assert!(out.contains("<EMAIL_1>"), "got: {out}");
+    assert!(!out.contains("alice.smith"), "email leaked: {out}");
+}
+
+#[test]
+fn phone_is_masked() {
+    let mut s = session();
+    let out = s.scrub("call +1 (415) 555-0142 or 020 7946 0958");
+    assert!(out.contains("<PHONE_1>"), "got: {out}");
+    assert!(out.contains("<PHONE_2>"), "second phone not masked: {out}");
+    assert!(!out.contains("555"), "phone digits leaked: {out}");
+}
+
+#[test]
+fn openai_key_is_masked_as_secret() {
+    let mut s = session();
+    let out = s.scrub("key sk-proj-AbCdEf0123456789ZyXwVuTs in env");
+    assert!(out.contains("<SECRET_1>"), "got: {out}");
+    assert!(!out.contains("sk-proj-"), "key leaked: {out}");
+}
+
+#[test]
+fn aws_access_key_is_masked_as_secret() {
+    let mut s = session();
+    let out = s.scrub("AKIAIOSFODNN7EXAMPLE is the access key id");
+    assert!(out.contains("<SECRET_1>"), "got: {out}");
+    assert!(!out.contains("AKIA"), "aws key leaked: {out}");
+}
+
+#[test]
+fn github_token_is_masked_as_secret() {
+    let mut s = session();
+    let out = s.scrub("token ghp_1234567890abcdefghijABCDEFGHIJ0987 here");
+    assert!(out.contains("<SECRET_1>"), "got: {out}");
+    assert!(!out.contains("ghp_"), "gh token leaked: {out}");
+}
+
+#[test]
+fn card_number_is_masked_as_account() {
+    let mut s = session();
+    let out = s.scrub("card 4111 1111 1111 1111 expires soon");
+    assert!(out.contains("<ACCOUNT_1>"), "got: {out}");
+    assert!(!out.contains("4111"), "card leaked: {out}");
+}
+
+#[test]
+fn long_opaque_token_is_masked() {
+    let mut s = session();
+    // 40 hex chars — not an email/phone/card, caught by the token class.
+    let out = s.scrub("digest a1b2c3d4e5f60718293a4b5c6d7e8f9012345678 committed");
+    assert!(out.contains("<TOKEN_1>"), "got: {out}");
+    assert!(!out.contains("a1b2c3d4"), "token leaked: {out}");
+}
+
+#[test]
+fn blocklist_literal_is_masked() {
+    let mut s = RedactionSession::new(vec!["ProjectBluebird".to_string()]);
+    let out = s.scrub("we shipped ProjectBluebird and projectbluebird again");
+    assert!(
+        !out.to_lowercase().contains("projectbluebird"),
+        "blocklist leaked: {out}"
+    );
+    // Same token reused for both case variants (stable per original casing
+    // is not required; both distinct casings each get a stable token).
+    assert!(out.contains("<SECRET_"), "blocklist not tokenised: {out}");
+}
+
+#[test]
+fn hyphenated_uuid_is_not_masked() {
+    let mut s = session();
+    // Page `quaid_id` shape — a structural identifier, not a secret. The
+    // hyphens split it below the 32-char token threshold.
+    let uuid = "0190a1b2-c3d4-7e5f-8a9b-0c1d2e3f4a5b";
+    let out = s.scrub(&format!("quaid_id: {uuid} stays"));
+    assert!(out.contains(uuid), "uuid was wrongly masked: {out}");
+    assert_eq!(s.masked_count(), 0);
+}
+
+#[test]
+fn deterministic_tokens_within_session() {
+    let mut s = session();
+    let out = s.scrub("a@x.com then a@x.com then b@x.com");
+    // Same email -> same token; different email -> different token.
+    assert_eq!(out.matches("<EMAIL_1>").count(), 2, "got: {out}");
+    assert!(
+        out.contains("<EMAIL_2>"),
+        "second distinct email missing: {out}"
+    );
+    assert_eq!(s.masked_count(), 2);
+}
+
+#[test]
+fn no_match_returns_input_unchanged() {
+    let mut s = session();
+    let input = "just some ordinary prose with no secrets in it at all.";
+    assert_eq!(s.scrub(input), input);
+    assert_eq!(s.masked_count(), 0);
+}
+
+#[test]
+fn rehydrate_round_trips_scrubbed_text() {
+    let mut s = session();
+    let original = "email alice@example.com and key sk-AbCdEf0123456789ZyXwVuTs done";
+    let scrubbed = s.scrub(original);
+    assert_ne!(scrubbed, original);
+    let restored = s.rehydrate(&scrubbed);
+    assert_eq!(restored, original, "round-trip mismatch");
+}
+
+#[test]
+fn rehydrate_leaves_unknown_tokens_untouched() {
+    let s = session();
+    // No mapping recorded -> nothing to reverse.
+    let text = "this mentions <EMAIL_9> which was never assigned";
+    assert_eq!(s.rehydrate(text), text);
+}
+
+#[test]
+fn redact_mode_parsing() {
+    assert_eq!(
+        RedactMode::from_config_value("patterns"),
+        RedactMode::Patterns
+    );
+    assert_eq!(
+        RedactMode::from_config_value("PATTERNS"),
+        RedactMode::Patterns
+    );
+    assert_eq!(RedactMode::from_config_value("off"), RedactMode::Off);
+    assert_eq!(RedactMode::from_config_value("garbage"), RedactMode::Off);
+    assert_eq!(redact_mode_from_config(None), RedactMode::Off);
+    assert_eq!(
+        redact_mode_from_config(Some("patterns")),
+        RedactMode::Patterns
+    );
+    assert!(RedactMode::Patterns.is_active());
+    assert!(!RedactMode::Off.is_active());
+}
+
+#[test]
+fn blocklist_parsing_splits_and_trims() {
+    let parsed = parse_blocklist(Some("alpha, beta\n  gamma  ,,"));
+    assert_eq!(parsed, vec!["alpha", "beta", "gamma"]);
+    assert!(parse_blocklist(None).is_empty());
+    assert!(parse_blocklist(Some("   ")).is_empty());
+}

--- a/tests/supersede_chain.rs
+++ b/tests/supersede_chain.rs
@@ -169,6 +169,7 @@ fn supersede_chain_write_rejects_non_head_and_memory_get_returns_successor_point
         &server
             .memory_get(MemoryGetInput {
                 slug: "facts/a".to_string(),
+                redact: None,
             })
             .unwrap(),
     ))
@@ -177,6 +178,7 @@ fn supersede_chain_write_rejects_non_head_and_memory_get_returns_successor_point
         &server
             .memory_get(MemoryGetInput {
                 slug: "facts/c".to_string(),
+                redact: None,
             })
             .unwrap(),
     ))
@@ -228,6 +230,7 @@ fn retrieval_defaults_to_heads_and_include_superseded_restores_history() {
                 wing: None,
                 limit: None,
                 include_superseded: None,
+                redact: None,
             })
             .unwrap(),
     ))
@@ -241,6 +244,7 @@ fn retrieval_defaults_to_heads_and_include_superseded_restores_history() {
                 wing: None,
                 limit: None,
                 include_superseded: Some(true),
+                redact: None,
             })
             .unwrap(),
     ))
@@ -265,6 +269,7 @@ fn retrieval_defaults_to_heads_and_include_superseded_restores_history() {
                 limit: Some(10),
                 depth: None,
                 include_superseded: None,
+                redact: None,
             })
             .unwrap(),
     ))
@@ -279,6 +284,7 @@ fn retrieval_defaults_to_heads_and_include_superseded_restores_history() {
                 limit: Some(10),
                 depth: None,
                 include_superseded: Some(true),
+                redact: None,
             })
             .unwrap(),
     ))

--- a/website/src/content/docs/explanation/privacy.mdx
+++ b/website/src/content/docs/explanation/privacy.mdx
@@ -1,12 +1,14 @@
 ---
 title: Privacy and data sovereignty
-description: What leaves your machine (nothing, unless you ask) and how the gap-tracking system enforces consent before storing query text.
+description: What runs locally, the real egress map (including MCP reads into a cloud LLM's context), the opt-in secret scrubbing layer, and how the gap-tracking system enforces consent before storing query text.
 guide:
   eyebrow: Explanation
   accentBar: true
 ---
 
-Quaid is local-first by construction. This page makes the privacy posture explicit: what runs locally, what (rarely) goes over the wire, and how the knowledge-gap system handles the one place where consent matters.
+Quaid is local-first by construction. This page makes the privacy posture explicit: what runs locally, the real ways content can leave your machine, the opt-in secret-scrubbing layer that masks machine-shaped secrets on outbound reads, and how the knowledge-gap system handles the one place where consent matters.
+
+**The dominant egress path is the MCP client, not the network.** `quaid` itself contacts almost nothing. But the whole point of the MCP server is that a *client* reads your memory — and the common clients are cloud-hosted LLMs (Claude Code, Cursor, etc.). When such a client calls `memory_get`/`memory_query`/`memory_search`, the returned page content enters that client's context window and is sent to the model provider. "Nothing leaves your machine" describes the binary; it does **not** describe what your agent does with what it reads. See the egress map below.
 
 ## What runs locally
 
@@ -22,9 +24,18 @@ Everything that touches your notes runs on your machine:
 
 No API keys are required. No third-party service is contacted by `quaid` during normal use.
 
-## What can go over the wire
+## The real egress map
 
-Three narrow exceptions, all opt-in:
+There are two categories of egress, and the dangerous one is easy to miss.
+
+**Content `quaid` reads out to a client.** This is the high-volume path. The MCP read tools return page content into the calling client's context. If that client is a cloud LLM, the content is sent to the provider as part of the model request.
+
+| Path | When | What is sent |
+| ---- | ---- | ------------ |
+| MCP reads (`memory_get`, `memory_query`, `memory_search`) | Every read your agent makes | Full page content (`compiled_truth` + `timeline` for `memory_get`; summaries, and full chunks under `depth:"auto"`, for query/search) into the client's context — i.e. to the model provider when the client is cloud-hosted. |
+| Skill research (`research`) | If a skill calls an external search/LLM API (e.g. Exa) | The query the skill sends. Its "redacted" mode is prompt-enforced by the agent today, not code-enforced. |
+
+**Network calls `quaid` itself can make.** Three narrow exceptions, all opt-in:
 
 | Path | When | What is sent |
 | ---- | ---- | ------------ |
@@ -32,7 +43,32 @@ Three narrow exceptions, all opt-in:
 | Skill enrichment (`enrich`) | If you authorize an external API call from a skill | Whatever the skill's `memory_raw` payload is — under your control. |
 | Knowledge gap escalation | If you approve a gap for `external` sensitivity | Only after explicit approval — see below. |
 
-The airgapped build can refuse all of these by construction. The online build lets you participate in the first; the other two require you to wire and authorize them.
+The airgapped build can refuse the second category by construction. It cannot stop the first: once a client is connected, what the agent reads is by definition headed into that client. That is what the secret-scrubbing layer below is for.
+
+## Outbound secret scrubbing (opt-in)
+
+To reduce what crosses the MCP wire, Quaid can scrub machine-shaped secrets out of read-tool responses **before they are serialized to the client**. It is off by default and deterministic.
+
+**This is secret scrubbing, not full PII redaction.** It is a phase-1, regex-based pass: it catches high-confidence machine-shaped secrets — email addresses, phone numbers, API-key shapes (`sk-…`, `AKIA…`, GitHub/Slack tokens), long opaque hex/base64 tokens, and account/card-number shapes — plus a user-defined blocklist. It does **not** recognise names or other free-text PII; that (NER) is deliberately deferred to a later phase. Do not treat a scrubbed payload as anonymised.
+
+### Turning it on
+
+```bash
+# Mask secrets on every read for this brain:
+quaid config set mcp.redact_outbound patterns   # default: off
+
+# Optional: always scrub these literal strings (comma- or newline-separated):
+quaid config set mcp.redact_blocklist "Project Bluebird, internal-codename"
+```
+
+Each read tool also accepts a per-call `redact` boolean that overrides the config default — `redact: true` forces scrubbing even when the config is `off`; `redact: false` forces plaintext even when the config is `patterns`.
+
+### How it behaves
+
+- **Outbound only.** FTS5 and the embeddings index always store the *originals*, so retrieval quality is unchanged — only the bytes returned to the client are masked. A search for a term that lives inside a secret still finds the page; the returned preview is what gets tokenised.
+- **Deterministic, stable tokens.** Each distinct secret is replaced with a stable token like `<EMAIL_1>` or `<SECRET_2>`. The same value maps to the same token for the life of the connection, so an LLM can still reason about "the same key" appearing twice (coreference is preserved).
+- **Byte-identical when off.** With `mcp.redact_outbound = off` (and no per-call `redact: true`), read output is byte-for-byte what it was before this feature existed.
+- **Locally reversible.** The token map lives in memory on the per-connection server, never on disk and never on the wire. The `memory_rehydrate` MCP tool reverses the map (`<EMAIL_1>` → the original) locally, so an agent that needs the real value can round-trip without the original ever being sent to the provider.
 
 ## The knowledge gap problem
 
@@ -97,9 +133,10 @@ If you redirect stderr to a file or a SIEM, audit what gets captured before you 
 
 The same MCP surface that humans use is exposed to agents. An agent connected over MCP can read every page in your memory and call every tool. That's a feature: agents need access to do useful work.
 
-It's also a responsibility. Two practical implications:
+It's also a responsibility. Three practical implications:
 
-1. **Trust your client.** Anything that connects via `quaid serve` can read everything. Don't run unknown MCP clients against a memory that contains sensitive material.
-2. **Use sensitivity tiers.** If an agent escalates a gap, the sensitivity contract is what keeps the raw query out of any outbound payload by default.
+1. **Trust your client.** Anything that connects via `quaid serve` can read everything, and a cloud client forwards what it reads to its model provider. Don't run unknown MCP clients against a memory that contains sensitive material.
+2. **Scrub outbound reads when the client is cloud-hosted.** Turn on `mcp.redact_outbound = patterns` to mask machine-shaped secrets before they reach the client's context (see [Outbound secret scrubbing](#outbound-secret-scrubbing-opt-in)). Remember it is secret scrubbing, not full PII redaction.
+3. **Use sensitivity tiers.** If an agent escalates a gap, the sensitivity contract is what keeps the raw query out of any outbound payload by default.
 
 Local-first doesn't make those concerns disappear. It just means the trust boundary is at your machine instead of a SaaS dashboard.


### PR DESCRIPTION
Implements **Area 24 — outbound redaction** (#159 phase 1: deterministic pattern scrub at the MCP serialization chokepoint).

## Changes
- **`core/redaction.rs`**: compiled regexes for emails, phone numbers, API-key shapes (sk-…, AKIA…, long hex/base64), card/account numbers + a user config blocklist; deterministic per-session tokens (`<EMAIL_1>`, `<SECRET_1>`) stable within a session.
- **Config `mcp.redact_outbound = off|patterns`** (default `off`, seeded) + optional `redact` bool on `memory_get`/`memory_query`/`memory_search` inputs.
- **Hooked before `Content::text`** in `mcp/tools/{pages,search}.rs`; session map stored on the per-connection `QuaidServer`. When `off`, output is byte-identical to today (regression-tested).
- **`memory_rehydrate`** MCP tool reverses the mapping locally (registry now 25 tools; `call.rs` dispatch arm added).
- **privacy.mdx** documents the real egress map (MCP reads into a cloud client, skills→Exa, HF download) + the opt-in scrub, labeled "secret scrubbing" not full PII redaction.

## Validation
fmt/clippy/rustdoc clean. `redaction_patterns` 15/15, `mcp_redaction` 7/7 (mask when enabled, **FTS/embeddings still index originals** — redaction is outbound-only, rehydrate round-trip, byte-identical when off), registry-25 test, call dispatch 25/25. Website build OK.

## Scope notes
- Conversation tools deliberately NOT scrubbed: they return structural data (turn IDs, paths, version stamps) not stored page content; scrubbing would corrupt identifiers. The content-egress reads the review names (get/query/search) are all covered.
- Phase 1 = secret scrubbing only; NER/name detection deferred per #159.
- ⚠️ Overlaps #239 (vector) + #228 (rerank) on the search.rs response shape — sequence at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)