### PR TITLE
fix: make extraction lease expiry configurable

### DIFF
--- a/openspec/specs/extraction-queue/spec.md
+++ b/openspec/specs/extraction-queue/spec.md
@@ -64,15 +64,19 @@ The worker SHALL transition a claimed job to `status = 'done'` on success or to 
 - **THEN** the stale transition is rejected and the newer lease remains authoritative
 
 ### Requirement: Queue persistence survives daemon restart
-The system SHALL persist `extraction_queue` rows durably (SQLite WAL, the project's existing durability mode). On `quaid serve` restart, `pending` rows SHALL remain in `pending` and SHALL be dequeued in normal order; `running` rows that were claimed by a worker that did not complete SHALL be re-eligible for dequeue after the shipped fixed 300-second lease-expiry interval so that a crashed worker does not orphan a row indefinitely.
+The system SHALL persist `extraction_queue` rows durably (SQLite WAL, the project's existing durability mode). On `quaid serve` restart, `pending` rows SHALL remain in `pending` and SHALL be dequeued in normal order; `running` rows that were claimed by a worker that did not complete SHALL be re-eligible for dequeue after the configured `extraction.lease_expiry_seconds` interval, defaulting to 300 seconds, so that a crashed worker does not orphan a row indefinitely while slow extraction runtimes can extend the crash-recovery window.
 
 #### Scenario: Pending rows survive a daemon restart
 - **WHEN** `quaid serve` is killed while pending rows exist and is then restarted
 - **THEN** the previously pending rows are still present with `status = 'pending'` and are dequeued in normal `scheduled_for` order
 
 #### Scenario: Stale running rows recover after lease expiry
-- **WHEN** a `running` row's `scheduled_for + 300 seconds` has passed without a `done` or `failed` transition
+- **WHEN** a `running` row's `scheduled_for + extraction.lease_expiry_seconds` has passed without a `done` or `failed` transition
 - **THEN** the row is re-eligible for dequeue and the next claim transitions it back to `running` with `attempts += 1`
+
+#### Scenario: Configured lease expiry preserves a slow live job
+- **WHEN** `extraction.lease_expiry_seconds = 3600` and a `running` row was claimed 10 minutes ago
+- **THEN** dequeue does not reclaim that row as expired
 
 ### Requirement: A single in-process worker drains the queue inside `quaid serve`
 The system SHALL run a single extraction worker as a long-lived task inside `quaid serve` whenever extraction is enabled (and not runtime-disabled per `slm-runtime`). The worker SHALL claim pending jobs via the dequeue contract defined in proposal #1, process them serially, and report success or failure via the existing accounting paths. Concurrent multi-worker operation SHALL NOT be introduced in this proposal ΓÇö single-worker is the v1 model.
@@ -154,4 +158,3 @@ The system SHALL wrap multi-statement queue mutations (enqueue, dequeue, mark-do
 
 - **WHEN** a queue write closure returns an error
 - **THEN** the in-flight changes are rolled back, the connection is no longer inside a transaction, and a follow-up queue write on the same connection succeeds normally
-

--- a/src/core/conversation/queue.rs
+++ b/src/core/conversation/queue.rs
@@ -310,6 +310,7 @@ pub fn mark_failed(
 
 fn recover_expired_leases(conn: &Connection) -> Result<(), ExtractionQueueError> {
     let max_retries = max_retries(conn)?;
+    let lease_expiry_seconds = lease_expiry_seconds(conn)?;
     conn.execute(
         "UPDATE extraction_queue
          SET attempts = attempts + 1,
@@ -320,7 +321,7 @@ fn recover_expired_leases(conn: &Connection) -> Result<(), ExtractionQueueError>
              last_error = COALESCE(last_error, 'lease expired')
          WHERE status = 'running'
            AND julianday('now') >= julianday(scheduled_for) + (?2 / 86400.0)",
-        params![max_retries, DEFAULT_LEASE_EXPIRY_SECONDS],
+        params![max_retries, lease_expiry_seconds],
     )?;
     Ok(())
 }
@@ -372,6 +373,29 @@ fn max_retries(conn: &Connection) -> Result<i64, ExtractionQueueError> {
         .map_err(|_| ExtractionQueueError::Config {
             message: format!("invalid extraction.max_retries value: {raw}"),
         })
+}
+
+fn lease_expiry_seconds(conn: &Connection) -> Result<i64, ExtractionQueueError> {
+    let raw = db::read_config_value_or(
+        conn,
+        "extraction.lease_expiry_seconds",
+        &DEFAULT_LEASE_EXPIRY_SECONDS.to_string(),
+    )
+    .map_err(|error| ExtractionQueueError::Config {
+        message: error.to_string(),
+    })?;
+
+    let parsed = raw
+        .parse::<i64>()
+        .map_err(|_| ExtractionQueueError::Config {
+            message: format!("invalid extraction.lease_expiry_seconds value: {raw}"),
+        })?;
+    if parsed <= 0 {
+        return Err(ExtractionQueueError::Config {
+            message: format!("invalid extraction.lease_expiry_seconds value: {raw}"),
+        });
+    }
+    Ok(parsed)
 }
 
 /// Read SQLite's current UTC timestamp in canonical

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -480,6 +480,7 @@ INSERT OR IGNORE INTO config (key, value) VALUES
     ('extraction.window_turns', '5'),
     ('extraction.debounce_ms', '5000'),
     ('extraction.idle_close_ms', '60000'),
+    ('extraction.lease_expiry_seconds', '300'),
     ('extraction.retention_days', '30'),
     ('fact_resolution.dedup_cosine_min', '0.92'),
     ('fact_resolution.supersede_cosine_min', '0.4'),

--- a/tests/db_schema_v10.rs
+++ b/tests/db_schema_v10.rs
@@ -112,6 +112,7 @@ fn fresh_v10_schema_includes_conversation_memory_artifacts_and_defaults() {
                  'extraction.window_turns',
                  'extraction.debounce_ms',
                  'extraction.idle_close_ms',
+                 'extraction.lease_expiry_seconds',
                  'extraction.retention_days',
                  'fact_resolution.dedup_cosine_min',
                  'fact_resolution.key_match_cosine_min',
@@ -134,6 +135,10 @@ fn fresh_v10_schema_includes_conversation_memory_artifacts_and_defaults() {
             ("extraction.debounce_ms".to_string(), "5000".to_string()),
             ("extraction.enabled".to_string(), "false".to_string()),
             ("extraction.idle_close_ms".to_string(), "60000".to_string()),
+            (
+                "extraction.lease_expiry_seconds".to_string(),
+                "300".to_string()
+            ),
             ("extraction.max_retries".to_string(), "3".to_string()),
             (
                 "extraction.model_alias".to_string(),

--- a/tests/extraction_queue.rs
+++ b/tests/extraction_queue.rs
@@ -265,6 +265,60 @@ fn lease_expiry_recovers_running_job_and_increments_attempts() {
 }
 
 #[test]
+fn configured_lease_expiry_keeps_slow_running_job_claimed() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("memory.db");
+    let conn = open_queue_db(&db_path);
+    conn.execute(
+        "INSERT OR REPLACE INTO config (key, value)
+         VALUES ('extraction.lease_expiry_seconds', '3600')",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO extraction_queue
+             (session_id, conversation_path, trigger_kind, enqueued_at, scheduled_for, attempts, last_error, status)
+         VALUES
+             ('slow', 'conversations/2026-05-03/slow.md', 'debounce', '2000-01-01T00:00:00Z', strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '-10 minutes'), 0, NULL, 'running'),
+             ('ready', 'conversations/2026-05-03/ready.md', 'debounce', '2000-01-01T00:00:00Z', '2000-01-01T00:00:00Z', 0, NULL, 'pending')",
+        [],
+    )
+    .unwrap();
+
+    let claimed = dequeue(&conn).unwrap().unwrap();
+    let slow_row: (i64, String) = conn
+        .query_row(
+            "SELECT attempts, status FROM extraction_queue WHERE session_id = 'slow'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+
+    assert_eq!(claimed.session_id, "ready");
+    assert_eq!(slow_row.0, 0);
+    assert_eq!(slow_row.1, "running");
+}
+
+#[test]
+fn invalid_lease_expiry_config_is_rejected() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("memory.db");
+    let conn = open_queue_db(&db_path);
+    conn.execute(
+        "INSERT OR REPLACE INTO config (key, value)
+         VALUES ('extraction.lease_expiry_seconds', '0')",
+        [],
+    )
+    .unwrap();
+
+    let error = dequeue(&conn).unwrap_err();
+
+    assert!(error
+        .to_string()
+        .contains("invalid extraction.lease_expiry_seconds"));
+}
+
+#[test]
 fn queue_rows_survive_reopen_and_done_rows_stop_dequeueing() {
     let dir = tempfile::TempDir::new().unwrap();
     let db_path = dir.path().join("memory.db");


### PR DESCRIPTION
## Summary
- adds  with the current 300 second default
- uses that config when recovering stale running extraction jobs
- documents the configurable lease window in the extraction queue spec

## Why
LoCoMo/LongMemEval CI can run local SLM extraction on slow GitHub CPUs. A fixed 300 second lease makes a slow live inference look like a crashed worker. Keeping the default preserves current behavior, while CI and constrained machines can raise the lease window explicitly.

## Tests
- ~/.cargo/bin/cargo fmt --all -- --check
- ~/.cargo/bin/cargo test --test extraction_queue
- ~/.cargo/bin/cargo test --test db_schema_v10
- git diff --check