### PR TITLE
fix: heartbeat extraction queue leases

### DIFF
--- a/src/core/conversation/extractor.rs
+++ b/src/core/conversation/extractor.rs
@@ -14,6 +14,7 @@
 
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
 
@@ -39,6 +40,7 @@ pub const DEFAULT_WORKER_POLL_INTERVAL: Duration = Duration::from_secs(1);
 
 const DEFAULT_WINDOW_TURNS: usize = 5;
 const DEFAULT_MODEL_ALIAS: &str = "phi-3.5-mini";
+const DEFAULT_LEASE_HEARTBEAT_MAX_INTERVAL: Duration = Duration::from_secs(60);
 const MAX_RECORDED_PARSE_OUTPUT: usize = 240;
 const EXTRACTION_SYSTEM_PROMPT: &str = concat!(
     "You extract durable facts from conversations. Output JSON only — no prose,\n",
@@ -146,6 +148,8 @@ pub struct Worker<'db, S = LazySlmRunner, W = ResolvingFactWriter> {
     window_turns: usize,
     poll_interval: Duration,
     max_tokens: usize,
+    lease_heartbeat_interval: Duration,
+    db_path: Option<PathBuf>,
 }
 
 /// Errors returned from the extraction worker's polling and processing loop.
@@ -195,6 +199,7 @@ where
                 },
             )?;
         let window_turns = parse_usize_config(db, "extraction.window_turns", DEFAULT_WINDOW_TURNS)?;
+        let lease_expiry_seconds = queue::lease_expiry_seconds(db)?;
 
         Ok(Self {
             db,
@@ -204,6 +209,8 @@ where
             window_turns,
             poll_interval: DEFAULT_WORKER_POLL_INTERVAL,
             max_tokens: DEFAULT_EXTRACTION_MAX_TOKENS,
+            lease_heartbeat_interval: lease_heartbeat_interval(lease_expiry_seconds),
+            db_path: database_path(db)?,
         })
     }
 
@@ -212,6 +219,13 @@ where
     pub fn with_limits(mut self, poll_interval: Duration, max_tokens: usize) -> Self {
         self.poll_interval = poll_interval;
         self.max_tokens = max_tokens;
+        self
+    }
+
+    /// Override the lease heartbeat interval; used by tests to prove
+    /// renewal without waiting on the production lease window.
+    pub fn with_lease_heartbeat_interval(mut self, interval: Duration) -> Self {
+        self.lease_heartbeat_interval = interval;
         self
     }
 
@@ -316,10 +330,7 @@ where
         window: &WindowedTurns,
     ) -> Result<ExtractionResponse, WorkerError> {
         let prompt = self.build_prompt(&job.session_id, window);
-        let raw = self
-            .slm
-            .infer(&self.model_alias, &prompt, self.max_tokens)
-            .map_err(WorkerError::from)?;
+        let raw = self.infer_with_lease_heartbeat(job, &prompt)?;
 
         match parse_response(&raw) {
             Ok(response) => Ok(response),
@@ -349,13 +360,23 @@ where
                 }
             };
 
-            if let Err(error) = self
-                ._vault_writer
-                .write_window(self.db, job, window, &response)
-            {
+            if let Err(error) = self.refresh_job_lease(job).and_then(|_| {
+                self._vault_writer
+                    .write_window(self.db, job, window, &response)
+            }) {
                 self.record_job_failure(job, &error)?;
                 return Err(error);
             }
+
+            if let Err(error) = self.refresh_job_lease(job) {
+                self.record_job_failure(job, &error)?;
+                return Err(error);
+            }
+        }
+
+        if let Err(error) = self.refresh_job_lease(job) {
+            self.record_job_failure(job, &error)?;
+            return Err(error);
         }
 
         if !windows.is_empty() {
@@ -368,8 +389,45 @@ where
             )?;
         }
 
-        self._vault_writer.before_mark_done(self.db, job)?;
+        if let Err(error) = self.refresh_job_lease(job) {
+            self.record_job_failure(job, &error)?;
+            return Err(error);
+        }
+
+        if let Err(error) = self._vault_writer.before_mark_done(self.db, job) {
+            self.record_job_failure(job, &error)?;
+            return Err(error);
+        }
+
+        if let Err(error) = self.refresh_job_lease(job) {
+            self.record_job_failure(job, &error)?;
+            return Err(error);
+        }
+
         queue::mark_done(self.db, job.id, job.attempts).map_err(WorkerError::from)
+    }
+
+    fn infer_with_lease_heartbeat(
+        &self,
+        job: &ExtractionJob,
+        prompt: &str,
+    ) -> Result<String, WorkerError> {
+        let heartbeat = LeaseHeartbeat::start(
+            self.db_path.clone(),
+            job.id,
+            job.attempts,
+            self.lease_heartbeat_interval,
+        );
+        let result = self
+            .slm
+            .infer(&self.model_alias, prompt, self.max_tokens)
+            .map_err(WorkerError::from);
+        heartbeat.stop();
+        result
+    }
+
+    fn refresh_job_lease(&self, job: &ExtractionJob) -> Result<(), WorkerError> {
+        queue::refresh_lease(self.db, job.id, job.attempts).map_err(WorkerError::from)
     }
 
     /// Persist a truncated copy of the offending raw SLM output to the
@@ -411,6 +469,83 @@ where
         Ok(memory_root
             .root_path
             .join(slash_path_to_platform(conversation_path)))
+    }
+}
+
+struct LeaseHeartbeat {
+    stop_tx: Option<mpsc::Sender<()>>,
+    handle: Option<thread::JoinHandle<()>>,
+}
+
+impl LeaseHeartbeat {
+    fn start(db_path: Option<PathBuf>, job_id: i64, attempts: i64, interval: Duration) -> Self {
+        let Some(db_path) = db_path else {
+            return Self {
+                stop_tx: None,
+                handle: None,
+            };
+        };
+        if interval.is_zero() {
+            return Self {
+                stop_tx: None,
+                handle: None,
+            };
+        }
+
+        let (stop_tx, stop_rx) = mpsc::channel();
+        let handle = thread::spawn(move || loop {
+            match stop_rx.recv_timeout(interval) {
+                Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => break,
+                Err(mpsc::RecvTimeoutError::Timeout) => {
+                    let Some(db_path) = db_path.to_str() else {
+                        break;
+                    };
+                    let Ok(conn) = db::open(db_path) else {
+                        continue;
+                    };
+                    if queue::refresh_lease(&conn, job_id, attempts).is_err() {
+                        break;
+                    }
+                }
+            }
+        });
+
+        Self {
+            stop_tx: Some(stop_tx),
+            handle: Some(handle),
+        }
+    }
+
+    fn stop(mut self) {
+        if let Some(stop_tx) = self.stop_tx.take() {
+            let _ = stop_tx.send(());
+        }
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+fn lease_heartbeat_interval(lease_expiry_seconds: i64) -> Duration {
+    let expiry = Duration::from_secs(lease_expiry_seconds.max(1) as u64);
+    let third = expiry / 3;
+    if third.is_zero() {
+        Duration::from_secs(1)
+    } else {
+        std::cmp::min(third, DEFAULT_LEASE_HEARTBEAT_MAX_INTERVAL)
+    }
+}
+
+fn database_path(conn: &Connection) -> Result<Option<PathBuf>, WorkerError> {
+    let path = conn
+        .query_row("PRAGMA database_list", [], |row| row.get::<_, String>(2))
+        .map_err(|error| WorkerError::Config {
+            message: error.to_string(),
+        })?;
+    if path.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(PathBuf::from(path)))
     }
 }
 

--- a/src/core/conversation/queue.rs
+++ b/src/core/conversation/queue.rs
@@ -25,6 +25,8 @@ pub const DEFAULT_EXTRACTION_MAX_RETRIES: i64 = 3;
 /// Default lease window for a `running` job; once this many seconds
 /// elapse without a status update, [`dequeue`] reclaims the row.
 pub const DEFAULT_LEASE_EXPIRY_SECONDS: i64 = 300;
+/// Config key used to override the extraction lease expiry window.
+pub const LEASE_EXPIRY_CONFIG_KEY: &str = "extraction.lease_expiry_seconds";
 
 /// Errors surfaced by the extraction-queue API.
 #[derive(Debug, Error)]
@@ -238,7 +240,7 @@ pub fn pending_queue_position(
 /// when retries are exhausted).
 pub fn dequeue(conn: &Connection) -> Result<Option<ExtractionJob>, ExtractionQueueError> {
     recover_expired_leases(conn)?;
-    let now = current_timestamp(conn)?;
+    let now = current_lease_timestamp(conn)?;
     let mut stmt = conn.prepare(
         "UPDATE extraction_queue
          SET status = 'running',
@@ -309,8 +311,30 @@ pub fn mark_failed(
     Ok(())
 }
 
+/// Renew a running job's lease by stamping `scheduled_for` to the
+/// current SQLite timestamp. Returns [`ExtractionQueueError::StaleLease`]
+/// if the row has already been reclaimed or completed.
+pub fn refresh_lease(
+    conn: &Connection,
+    job_id: i64,
+    attempts: i64,
+) -> Result<(), ExtractionQueueError> {
+    let now = current_lease_timestamp(conn)?;
+    let updated = conn.execute(
+        "UPDATE extraction_queue
+         SET scheduled_for = ?3
+         WHERE id = ?1 AND status = 'running' AND attempts = ?2",
+        params![job_id, attempts, now],
+    )?;
+    if updated == 0 {
+        return Err(ExtractionQueueError::StaleLease { job_id, attempts });
+    }
+    Ok(())
+}
+
 fn recover_expired_leases(conn: &Connection) -> Result<(), ExtractionQueueError> {
     let max_retries = max_retries(conn)?;
+    let lease_expiry_seconds = lease_expiry_seconds(conn)?;
     conn.execute(
         "UPDATE extraction_queue
          SET attempts = attempts + 1,
@@ -321,7 +345,7 @@ fn recover_expired_leases(conn: &Connection) -> Result<(), ExtractionQueueError>
              last_error = COALESCE(last_error, 'lease expired')
          WHERE status = 'running'
            AND julianday('now') >= julianday(scheduled_for) + (?2 / 86400.0)",
-        params![max_retries, DEFAULT_LEASE_EXPIRY_SECONDS],
+        params![max_retries, lease_expiry_seconds],
     )?;
     Ok(())
 }
@@ -375,10 +399,41 @@ fn max_retries(conn: &Connection) -> Result<i64, ExtractionQueueError> {
         })
 }
 
+/// Read the configured extraction lease expiry in seconds.
+pub fn lease_expiry_seconds(conn: &Connection) -> Result<i64, ExtractionQueueError> {
+    let raw = db::read_config_value_or(
+        conn,
+        LEASE_EXPIRY_CONFIG_KEY,
+        &DEFAULT_LEASE_EXPIRY_SECONDS.to_string(),
+    )
+    .map_err(|error| ExtractionQueueError::Config {
+        message: error.to_string(),
+    })?;
+
+    let parsed = raw
+        .parse::<i64>()
+        .map_err(|_| ExtractionQueueError::Config {
+            message: format!("invalid {LEASE_EXPIRY_CONFIG_KEY} value: {raw}"),
+        })?;
+    if parsed <= 0 {
+        return Err(ExtractionQueueError::Config {
+            message: format!("{LEASE_EXPIRY_CONFIG_KEY} must be positive: {raw}"),
+        });
+    }
+    Ok(parsed)
+}
+
 /// Read SQLite's current UTC timestamp in canonical
 /// `YYYY-MM-DDTHH:MM:SSZ` form for use in queue-row timestamps.
 pub fn current_timestamp(conn: &Connection) -> Result<String, ExtractionQueueError> {
     conn.query_row("SELECT strftime('%Y-%m-%dT%H:%M:%SZ', 'now')", [], |row| {
+        row.get(0)
+    })
+    .map_err(ExtractionQueueError::from)
+}
+
+fn current_lease_timestamp(conn: &Connection) -> Result<String, ExtractionQueueError> {
+    conn.query_row("SELECT strftime('%Y-%m-%dT%H:%M:%fZ', 'now')", [], |row| {
         row.get(0)
     })
     .map_err(ExtractionQueueError::from)

--- a/tests/extraction_queue.rs
+++ b/tests/extraction_queue.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 use std::sync::{Arc, Barrier};
 use std::thread;
 
-use quaid::core::conversation::queue::{dequeue, enqueue, mark_done, mark_failed};
+use quaid::core::conversation::queue::{dequeue, enqueue, mark_done, mark_failed, refresh_lease};
 use quaid::core::db;
 use quaid::core::types::{ExtractionJobStatus, ExtractionTriggerKind};
 use rusqlite::Connection;
@@ -280,4 +280,41 @@ fn stale_worker_cannot_finish_released_job_after_lease_expiry() {
         )
         .unwrap();
     assert_eq!(status, ExtractionJobStatus::Done.as_str());
+}
+
+#[test]
+fn refresh_lease_keeps_running_job_from_expiring() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("memory.db");
+    let conn = open_queue_db(&db_path);
+    conn.execute(
+        "INSERT OR REPLACE INTO config (key, value)
+         VALUES ('extraction.lease_expiry_seconds', '1')",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO extraction_queue
+             (session_id, conversation_path, trigger_kind, enqueued_at, scheduled_for, attempts, last_error, status)
+         VALUES
+             ('running', 'conversations/2026-05-03/running.md', 'manual', '2000-01-01T00:00:00Z', strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), 0, NULL, 'running'),
+             ('pending', 'conversations/2026-05-03/pending.md', 'manual', '2000-01-01T00:00:00Z', '2000-01-01T00:00:00Z', 0, NULL, 'pending')",
+        [],
+    )
+    .unwrap();
+    std::thread::sleep(std::time::Duration::from_millis(1100));
+
+    refresh_lease(&conn, 1, 0).unwrap();
+    let claimed = dequeue(&conn).unwrap().unwrap();
+
+    assert_eq!(claimed.session_id, "pending");
+    let row: (i64, String) = conn
+        .query_row(
+            "SELECT attempts, status FROM extraction_queue WHERE id = 1",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(row.0, 0);
+    assert_eq!(row.1, ExtractionJobStatus::Running.as_str());
 }

--- a/tests/extraction_worker.rs
+++ b/tests/extraction_worker.rs
@@ -770,11 +770,57 @@ fn claim_next_job_returns_none_when_runtime_is_disabled() {
     assert_eq!(worker.claim_next_job().unwrap(), None);
 }
 
+#[test]
+fn slow_inference_heartbeats_running_lease() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("memory.db");
+    let conn = open_worker_db_at(&db_path);
+    conn.execute(
+        "INSERT OR REPLACE INTO config (key, value)
+         VALUES ('extraction.lease_expiry_seconds', '1')",
+        [],
+    )
+    .unwrap();
+
+    let conversation_path =
+        seed_conversation_file(dir.path(), "s1", conversation_with_cursor("s1", 0, 2));
+    queue::enqueue(
+        &conn,
+        "s1",
+        &conversation_path,
+        ExtractionTriggerKind::Manual,
+        "2000-01-01T00:00:00Z",
+    )
+    .unwrap();
+
+    let slm = StubSlm::with_results([Ok("{\"facts\":[]}")]).with_delay(Duration::from_millis(1500));
+    let worker =
+        worker_with_stub(&conn, slm).with_lease_heartbeat_interval(Duration::from_millis(100));
+    let claimed = worker.claim_next_job().unwrap().unwrap();
+
+    let competing_db_path = db_path.clone();
+    let competing = std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(1200));
+        let competing_conn = open_worker_db_at(&competing_db_path);
+        queue::dequeue(&competing_conn).unwrap()
+    });
+
+    worker.process_job(&claimed).unwrap();
+    let stolen = competing.join().unwrap();
+
+    assert_eq!(stolen, None);
+    assert_eq!(
+        job_status(&conn, claimed.id),
+        ExtractionJobStatus::Done.as_str()
+    );
+}
+
 #[derive(Debug, Clone)]
 struct StubSlm {
     results: Arc<Mutex<VecDeque<Result<String, SlmError>>>>,
     calls: Arc<Mutex<Vec<InferCall>>>,
     runtime_disabled: bool,
+    delay: Duration,
 }
 
 impl StubSlm {
@@ -783,6 +829,7 @@ impl StubSlm {
             results: Arc::new(Mutex::new(VecDeque::new())),
             calls: Arc::new(Mutex::new(Vec::new())),
             runtime_disabled: false,
+            delay: Duration::ZERO,
         }
     }
 
@@ -796,7 +843,13 @@ impl StubSlm {
             )),
             calls: Arc::new(Mutex::new(Vec::new())),
             runtime_disabled: false,
+            delay: Duration::ZERO,
         }
+    }
+
+    fn with_delay(mut self, delay: Duration) -> Self {
+        self.delay = delay;
+        self
     }
 
     fn runtime_disabled() -> Self {
@@ -818,6 +871,9 @@ impl SlmClient for StubSlm {
             prompt: prompt.to_string(),
             max_tokens,
         });
+        if !self.delay.is_zero() {
+            std::thread::sleep(self.delay);
+        }
         self.results
             .lock()
             .unwrap()


### PR DESCRIPTION
## Summary
- add a configurable extraction queue lease expiry and a `refresh_lease` API
- heartbeat running extraction jobs from the worker while SLM inference is blocking
- refresh leases around fact writes/cursor updates before final `mark_done`
- add regression coverage for stale lease prevention during slow inference

## Why
`quaid-evals` reruns against v0.23.0 online showed the fixed benchmark harness is no longer the scary part:
- DAB passed: run `27762583946`, final `Total: 213/215 (99%)`
- LoCoMo smoke passed: run `27762588640`, extraction drained to `done=2 failed=0`, score `0.200`
- LongMemEval still hit real extraction throughput/lease symptoms in the 50-question run before cancellation, with repeated queue states like `pending=53 running=1 done=0 failed=0`

This patch keeps long-running SLM calls from losing their queue lease while the model is still working.

## Verification
- `PATH="$HOME/.cargo/bin:$PATH" cargo fmt --check`
- `PATH="$HOME/.cargo/bin:$PATH" cargo test --test extraction_queue -- --nocapture`
- `PATH="$HOME/.cargo/bin:$PATH" cargo test --test extraction_worker -- --nocapture`
- `PATH="$HOME/.cargo/bin:$PATH" cargo test --lib core::conversation::queue -- --nocapture`
- `PATH="$HOME/.cargo/bin:$PATH" cargo test --test cli_extract -- --nocapture`
- `PATH="$HOME/.cargo/bin:$PATH" cargo check`

## Notes
- A separate 5-question LME smoke run (`27764528789`) failed during `quaid extraction enable` because HuggingFace dropped `model-00002-of-00002.safetensors` before extraction started. That is CI download reliability, not this queue path.
- `tests/extraction_end_to_end_smoke.rs` currently fails before this lease path at `queued close job`; I did not include that unrelated fix here.
- Local worktree still has pre-existing unstaged version bump files: `Cargo.toml`, `Cargo.lock`.
